### PR TITLE
unit.body.unk_4b8 identified

### DIFF
--- a/df.units.xml
+++ b/df.units.xml
@@ -152,6 +152,45 @@
         <enum-item name='CAUTIOUSNESS'/>
     </enum-type>
 
+	<enum-type type-name='face_and_hair_appearance_trait_order' comment='NOT an index: traits might have duplicates or not exist depending on the creature, but they always happen in this order.'>
+		<enum-item name='eye_closeness' comment='lo is wide-set, hi is close-set' />
+		<enum-item name='eye_depth' comment='lo is bulging, large is sunken' />
+		<enum-item name='eye_wideness' comment='lo is slit eyes, hi is round eyes' />
+		<enum-item name='iris_size' comment='lo is small, hi is large' />
+		<enum-item name='lip_thickness' comment='lo is thin, hi is thick' />
+		<enum-item name='nose_thickness' comment='lo is thin, hi is thick' />
+		<enum-item name='nose_length' comment='lo is short, hi is long' />
+		<enum-item name='nose_tipped_up_ness' comment='lo is hooked, hi is upturned' />
+		<enum-item name='nose_bridge_concavity' comment='lo is concave, hi is convex' />
+		<enum-item name='ear_flatness' comment='lo is flattened, hi is splayed' />
+		<enum-item name='ear_lobe_freedom' comment='lo is attached, hi is swinging' />
+		<enum-item name='ear_broadness' comment='lo is narrow, hi is broad' />
+		<enum-item name='ear_tallness' comment='lo is short, hi is tall' />
+		<enum-item name='teeth_spacing' comment='lo is tangled, hi is wide' />
+		<enum-item name='teeth_length' comment='lo is short, hi is long' />
+		<enum-item name='cheekbone_height' comment='lo is low, hi is high' />
+		<enum-item name='chin_thickness' comment='lo is narrow, hi is broad' />
+		<enum-item name='chin_protrusion' comment='lo is recessed, hi is jutting' />
+		<enum-item name='chin_squareness' comment='lo is round, hi is square' />
+		<enum-item name='voice_deepness' comment='lo is high-pitched, hi is deep' />
+		<enum-item name='voice_raspiness' comment='lo is clear, hi is grating and raspy' />
+		<enum-item name='head_thickness' comment='lo is narrow, hi is broad' />
+		<enum-item name='head_height' comment='lo is short, hi is tall' />
+		<enum-item name='eyebrow_length' comment='lo is short, hi is long' />
+		<enum-item name='eyebrow_denseness' comment='lo is sparse, hi is dense' />
+		<enum-item name='eyebrow_height' comment='lo is low, hi is high' />
+		<enum-item name='sideburn_length' comment = 'lo is short, hi is long' />
+		<enum-item name='moustache_length' comment = 'lo is short, hi is long' />
+		<enum-item name='beard_length' comment = 'lo is short, hi is long' />
+		<enum-item name='hair_length' comment='lo is short, hi is long' />
+		<enum-item name='unknown_1' comment='not present in female dwarves'/>
+		<enum-item name='hair_curliness' comment='lo is straight, hi is curly' />
+		<enum-item name='hair_grease' comment='lo is crinkly, hi is greasy' />
+		<enum-item name='hair_density' comment='lo is sparse, hi is dense' />
+		<enum-item name='unknown_2' comment='not present in female dwarves'/>
+		<enum-item name='skin_wrinkles' comment='0 is very smooth, hi is wrinkled' />
+	</enum-type>
+
     <enum-type type-name='physical_attribute_type'>
         <enum-item name='STRENGTH'/>
         <enum-item name='AGILITY'/>
@@ -451,7 +490,7 @@
             </stl-vector>
 
             <stl-vector name='body_app_modifiers' type-name='uint32_t'/>
-            <stl-vector type-name='uint32_t' name='unk_4b8'/>
+            <stl-vector type-name='uint32_t' name='face_and_hair_appearance'/>
             <uint32_t name='unk_4c8'/>
         </compound>
 


### PR DESCRIPTION
I updated df.units.xml, changing unit.body.unk_4b8 to unit.body.face_and_hair_appearance, and adding an enum face_and_hair_appearance_trait_order with the order of the traits. The traits have different multiplicities in different creatures (and castes). 

I tested it with a female dwarf, a male dwarf, an elf, an ettin, and a hydra (although it was an empty vector for the hydra). 
