### PR TITLE
Identifying world::unk_59e78 as a save version number.

### DIFF
--- a/df.world.xml
+++ b/df.world.xml
@@ -912,7 +912,7 @@
                     comment='buildings with nonempty getUsers'/>
 
         <df-flagarray name='cavein_flags' comment='flag 0 means process cave columns'/>
-        <int32_t name='unk_59e78'/>
+        <int32_t name='original_save_version' comment='DF version on which the world was first created'/>
 
         <compound name='worldgen'>
             <stl-string name='version'/>


### PR DESCRIPTION
This number is initialized from the global save_version on world creation, and does not seem to change when the game is saved, even when saved from a different version of Dwarf Fortress.
