### PR TITLE
Update df.history.xml

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -206,14 +206,22 @@
     </struct-type>
 
     <enum-type type-name='histfig_flags'>
-        <enum-item/>
-        <enum-item/>
+        <enum-item name='revealartwork'/>
+        <enum-item name='equipmentcreated/>
         <enum-item name='deity'/>
         <enum-item name='force'/>
-        <enum-item/>
-        <enum-item/>
-        <enum-item/>
+        <enum-item name='skeletaldeity'/>
+        <enum-item name='rottingdeity'/>
+        <enum-item name='worldgenacted'/>
         <enum-item name='ghost'/>
+        <enum-item name='skindestroyed'/>
+        <enum-item name='meatdestroyed'/>
+        <enum-item name='bonesdestroyed'/>
+        <enum-item name='bragonkill'/>
+        <enum-item name='killquest'/>
+        <enum-item name='chatworthy'/>
+        <enum-item name='flashes'/>
+        <enum-item name='nevercull'/>
     </enum-type>
 
     <enum-type type-name='histfig_relationship_type' base-type='int16_t'>


### PR DESCRIPTION
Per Toady: http://www.bay12forums.com/smf/index.php?topic=140544.msg6067817#msg6067817

"Yeah, the first one is for whether associated artwork should be revealed -- don't remember if/how that works anymore.  Second is whether or not its initial equipment has been created.  Five and six are whether it has "skeletal" or "rotting" for it's deity name (should probably be in a deity profile somewhere instead).  Seven is a temp world gen flag for "I've acted".  Nine, ten, eleven are whether skin/meat/bones have been destroyed in its death, for corpse generation in tombs etc.  Lots of exceptional cases there that don't work probably.  Twelve through fifteen are copies of the quest-type flags -- brag on kill, kill quest, chat worthy and flashes.  Sixteen being on means to never cull the hf."