### PR TITLE
safe_landing and attack_velocity seem apt

### DIFF
--- a/df.projectile.xml
+++ b/df.projectile.xml
@@ -26,6 +26,7 @@
         <flag-bit name='unk9'/>
         <flag-bit name='unk10'/>
         <flag-bit name='no_collide'/>
+        <flag-bit name='safe_landing'/>
     </bitfield-type>
 
     <class-type type-name='projectile' original-name='projst' key-field='id'>

--- a/df.units.xml
+++ b/df.units.xml
@@ -1682,7 +1682,7 @@
                 <int32_t name='attack_id' comment='refers to weapon_attack or caste_attack'/>
                 <int32_t name='unk_28'/>
                 <int32_t name='unk_2c'/>
-                <int32_t name='unk_30'/>
+                <int32_t name='attack_velocity'/>
 <!--            <bitfield name='flags' base-type='int32_t'>
                     <flag-bit/>
                     <flag-bit/>


### PR DESCRIPTION
Toady confirmed that projectile flags 12 lets units land on their feet, hence safe_landing. Putnam found that the unit.actions.data.attack.unk_30 field is the actual velocity, hence attack_velocity. So here they are.