### PR TITLE
Instrument research

### DIFF
--- a/df.item-raws.xml
+++ b/df.item-raws.xml
@@ -807,6 +807,16 @@
         <enum-item name='WOOD_MAT'/>
         <enum-item name='INVERTED_TILE'/>
         <enum-item name='FURNITURE'/>
+        <enum-item/>
+        <enum-item/>
+        <enum-item/>
+        <enum-item/>
+        <enum-item/>
+        <enum-item/>
+        <enum-item/>
+        <enum-item/>
+        <enum-item name='NO_DEFAULT_JOB'/>
+        <enum-item name='INCOMPLETE_ITEM'/>
     </enum-type>
 
     <enum-type type-name='tool_uses' base-type='int16_t'>
@@ -863,8 +873,8 @@
 
         <int32_t name="container_capacity"/>
 
-        <stl-string name="unk_v4201_1" comment='v0.42.01'/>
-        <stl-vector name="unk_v4201_2" comment='v0.42.01'/>
+        <stl-string name="description" comment='v0.42.01'/>
+        <stl-vector name="default_improvements" comment='v0.42.01'/>
     </class-type>
 
     <enum-type type-name='toy_flags'>

--- a/df.job-types.xml
+++ b/df.job-types.xml
@@ -685,14 +685,7 @@
             <item-attr name='skill_stone' value='STONECRAFT'/>
             <item-attr name='skill_metal' value='METALCRAFT'/>
         </enum-item>
-        <enum-item name='MakeInstrument'>
-            <item-attr name='caption' value='Make Instrument'/>
-            <item-attr name='type' value='Manufacture'/>
-            <item-attr name='item' value='INSTRUMENT'/>
-            <item-attr name='skill_wood' value='WOODCRAFT'/>
-            <item-attr name='skill_stone' value='STONECRAFT'/>
-            <item-attr name='skill_metal' value='METALCRAFT'/>
-        </enum-item>
+        <enum-item/> formerly MakeInstrument
         <enum-item name='MakeToy'>
             <item-attr name='caption' value='Make Toy'/>
             <item-attr name='type' value='Manufacture'/>


### PR DESCRIPTION
MakeInstrument is no longer a supported job type, and there are new tags allowed in raws for tools.
Depends on dfhack/dfhack#770 for plugin compilation.