### PR TITLE
identify some unit_personality fields 

### DIFF
--- a/df.syndrome.xml
+++ b/df.syndrome.xml
@@ -424,7 +424,7 @@
         <int32_t name='sev'/>
     </class-type>
 
-    <class-type type-name='creature_interaction_effect_change_personality'
+    <class-type type-name='creature_interaction_effect_change_personalityst'
                 inherits-from='creature_interaction_effect'>
         <static-array type-name='int16_t' name='facets' count='50' index-enum='personality_facet_type'/>
     </class-type>

--- a/df.units.xml
+++ b/df.units.xml
@@ -1704,20 +1704,25 @@
         <int32_t name='unk_v4019_1' comment='v0.40.17-19'/>
         <int32_t name='unk_v4019_2' comment='v0.40.17-19'/>
 
-        <stl-vector name="unk_v4201_1a" comment='v0.42.01'>
+        <stl-vector name="needs" comment='v0.42.01'>
             <pointer>
-                <int32_t name="unk_0"/>
-                <int32_t name="unk_4" init-value='-1'/>
-                <int32_t name="unk_8"/>
-                <int32_t name="unk_c"/>
+                <enum base-type='int32_t' name="id" type-name='need_type'/>
+                <int32_t name="deity_id" init-value='-1' comment='for pray need'/>
+                <int32_t name="focus_level" comment='goes to 400 when unit satisfies need'/>
+                <int32_t name="need_level" comment='how fast focus_level decreases when it below 0'/>
             </pointer>
         </stl-vector>
-        <int32_t name="unk_v4201_1" comment='v0.42.01'/>
-        <int32_t name="unk_v4201_2" comment='v0.42.01'/>
+        <bitfield name='flags' base-type='uint32_t' comment='v0.42.01'>
+            <flag-bit/>
+            <flag-bit name='has_unmet_needs' comment='focus_level is below -999 for at least one need'/>
+        </bitfield>
+        <pointer name='temporary_trait_changes' comment='summ of inebriation or so personality changing effects'>
+            <static-array type-name='int16_t' name='traits' count='50' index-enum='personality_facet_type'/>
+        </pointer>
         <int32_t name="unk_v4201_3" init-value='-1' comment='v0.42.01'/>
         <int32_t name="unk_v4201_4" init-value='-1' comment='v0.42.01'/>
-        <int32_t name="unk_v4201_5" comment='v0.42.01; uninitialized'/>
-        <int32_t name="unk_v4201_6" comment='v0.42.01; uninitialized'/>
+        <int32_t name="current_focus" comment='weighted sum of needs focus_level-s'/>
+        <int32_t name="undistracted_focus" comment='usually number of needs multiplied by 4'/>
     </struct-type>
 
     <enum-type type-name='unit_action_type'>


### PR DESCRIPTION
unk_v4201_1a - vector contains needs

    unk_0 need-type - seems to be already known (df.units.xml contains enum for it)
    unk_4 deity historical figure - only for pray need. -1 for all others needs
    unk_8 focus_level - less means more distracted(more time passed since last satisfyed)
    unk_c need_level - how fast distraction_level value decreases when it below 0

unk_v4201_1 - bitfield

    second byte is up when unit is unfocused or distracted on at least one need

unk_v4201_2 - pointer to trait array. Values are signed int16, same order in unit_personality.traits (personality_facet_type enum has base type uint16_t -works fine in lisp tool but not in gm-editor). Values represents temporary deltas(changes) in traits applied by syndromes(inebriation or so). You can see "he is currently more rude" and so text in the dwarf thoughts and preferences screens.

unk_v4201_5, unk_v4201_6 - calculated from distraction levels in unk_v4201_1a. Relation between these two values determines the focus level

distraction levels(adventurer z menu and fort dwarf thoughts and preferences screen):
-200000 seems to be negative limit
+400 positive. (It goes to +400 when unit satisfies its need)
interval - text - points (for focus calculation):

    [-200000 - -100000] red "Distracted!" - 2 points
    [-99999 - -10000] yellow "Distracted" - 2.66(6) points
    [-9999 - -1000] brown "Unfocused" - 3.33(3) points
    [-999 - +99] grey "Undistracted" - 4 points
    [+100 - +199] white "Untroubled" - 4.66(6) points
    [+200 - +299] green "Level-headed" - 5.33(3) points
    [+300 - +400] bright green "Unfettered" - 6 points

if at least one need is Unfocused, Distracted or Distracted! second flag in the unk_v4201_1 will be up

need_levels(you can see these text values when you creating new adventurer):

    1 - Slight Need
    2 - Moderate Need
    5 - Strong Need
    10 - Intense Need

if distraction_level is 0 or below - distraction_level decreases by this value every 70 dot clicks in fort mode and every 145 dot clicks in adv mode
if distraction_level greater then 0 - distraction_level decreases by 1, and this value is ignored.

undistracted focus is number of needs multiplied by 4.
current focus is calculated: 2 points for every "badly distracted" need, 2.66(6) for every "distracted", 3.33(3) for every "unfocused" etc. final value is being truncated to int.
If all needs are "Undistracted" - current_focus and average_focus will be set to 1.
final focus level = current_focus/average_focus
interval - adv text - fort thoughts and preferences text(Overall, [name] is [text] by unmet/satisfied needs)

    0.00 <= f < 0.61 -red "Distracted!" --red "badly distracted"
    0.61 <= f < 0.81 -yellow "Distracted" --yellow "distracted"
    0.81 <= f < 1.00 -no text --brown "unfocused"
    f == 1.00 -no text --grey "untroubled"
    1.00 < f < 1.20 -no text --white "somewhat focused"
    1.20 <= f < 1.39 -green "Focused" --green "quite focused"
    1.40 <= f -bright green "Focused!" --bright green "very focused"
