### PR TITLE
identify some perfomance-related fields

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -105,7 +105,7 @@
         <pointer name='secret' comment='v0.34.01'>
             <stl-vector name="interactions" pointer-type='interaction'/>
             <int32_t name="unk_10"/>
-            <stl-vector type-name='int32_t'/>
+            <stl-vector name='read_books' type-name='int32_t' refers-to='$global.world.written_contents.all[$].type $global.world.written_contents.all[$].title'/>
             <stl-vector type-name='int32_t'/>
             <stl-vector>
                 <pointer>

--- a/df.itemimprovements.xml
+++ b/df.itemimprovements.xml
@@ -135,6 +135,8 @@
         <enum-item name='Letter'/>
         <enum-item name='Essay'/>
         <enum-item name='Dialog'/>
+        <enum-item name='MusicalComposition'/>
+        <enum-item name='Choreography'/>
     </enum-type>
 
     <enum-type type-name='written_content_style' base-type='int32_t'>

--- a/df.units.xml
+++ b/df.units.xml
@@ -1633,7 +1633,40 @@
 
         <compound type-name='unit_personality' name='personality'/>
 
-        <int32_t name='unk_v42_1' comment='v0.42.01'/>
+        <pointer name='perfomance_skills' comment='v0.42.01'>
+            <stl-vector pointer-type='unit_instrument_skill' name='musical_instruments'/>
+            <stl-vector pointer-type='unit_poetic_skill' name='poetic_forms'/>
+            <stl-vector pointer-type='unit_musical_skill' name='musical_forms'/>
+            <stl-vector pointer-type='unit_dance_skill' name='dance_forms'/>
+        </pointer>
+    </struct-type>
+
+    <struct-type type-name='unit_instrument_skill'>
+        <int32_t name="id" refers-to='$global.world.raws.itemdefs.instruments[$].name'/>
+        <code-helper name='describe'>(describe-obj $global.world.raws.itemdefs.instruments[$.id].name)</code-helper>
+        <enum base-type='int32_t' name="rating" type-name='skill_rating'/>
+        <int32_t name="experience"/>
+    </struct-type>
+
+    <struct-type type-name='unit_poetic_skill'>
+        <int32_t name="id" refers-to='$global.world.poetic_forms.all[$].name'/>
+        <code-helper name='describe'>(describe-obj $global.world.poetic_forms.all[$.id].name)</code-helper>
+        <enum base-type='int32_t' name="rating" type-name='skill_rating'/>
+        <int32_t name="experience"/>
+    </struct-type>
+
+    <struct-type type-name='unit_musical_skill'>
+        <int32_t name="id" refers-to='$global.world.musical_forms.all[$].name'/>
+        <code-helper name='describe'>(describe-obj $global.world.musical_forms.all[$.id].name)</code-helper>
+        <enum base-type='int32_t' name="rating" type-name='skill_rating'/>
+        <int32_t name="experience"/>
+    </struct-type>
+
+    <struct-type type-name='unit_dance_skill'>
+        <int32_t name="id" refers-to='$global.world.dance_forms.all[$].name'/>
+        <code-helper name='describe'>(describe-obj $global.world.dance_forms.all[$.id].name)</code-helper>
+        <enum base-type='int32_t' name="rating" type-name='skill_rating'/>
+        <int32_t name="experience"/>
     </struct-type>
 
     <struct-type type-name='unit_personality'>


### PR DESCRIPTION
unit_soul.unk_v42_1  points to a structure that contains four vectors with information about unit's skill in musical instruments(concrete instruments, not general instrument type), poetic forms, musical forms and dance forms
Values in these structures are simply instrument/poetic/music/dance form id, skill level and experience on current level. No rust/unused or so counters.

historical_figure_info.secret.read_books - vector contains read by unit books (their ids), including most choreoghaphy, musical compositions and poems that it can perform. Few remaining things that unit (at least adventurer) can perform are prefomance_forms themselves. Stories are also not here.

2 new written_content_types - musical composition and choreography