### PR TITLE
identify two fields in occupation

### DIFF
--- a/df.art.xml
+++ b/df.art.xml
@@ -486,8 +486,8 @@
         <enum name='type' base-type='int32_t' type-name='occupation_type'/>
         <int32_t name='histfig_id' ref-target='historical_figure'/>
         <int32_t name='unit_id' ref-target='unit'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='location_id' ref-target='abstract_building' aux-value='$$.site_id'/>
+        <int32_t name='site_id' ref-target='world_site'/>
         <int32_t comment='appears to be an entity_id?'/>
         <stl-vector pointer-type='occupation_sub1'/>
         <int32_t/>

--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -1275,7 +1275,7 @@
             <enum-item name='None'/>
             <enum-item name='Goblets'/>
             <enum-item name='Instruments'/>
-            <enum-item name='Bookcases'/>
+            <enum-item name='WritingCopies'/>
             <enum-item name='WritingMaterial'/>
         </enum>
         <int32_t/>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -33,7 +33,7 @@
         <int32_t name="desired_goblets"/>
         <int32_t name="desired_instruments"/>
         <int32_t name="desired_paper"/>
-        <int32_t name="unk_f4"/>
+        <int32_t name="desired_copies"/>
 
         the following is not saved:
         <int32_t name="unk_f8"/>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -29,17 +29,11 @@
     </struct-type>
 
     <struct-type type-name='abstract_building_contents'> used within Temple, Library, and Inn/Tavern
-        <enum name="type" base-type='int32_t'>
-            <enum-item/>
-            <enum-item/>
-            <enum-item name='Temple'/>
-            <enum-item name='Tavern'/>
-            <enum-item name='Library'/>
-        </enum>
+        <int32_t name="unk_e4"/>
         <int32_t name="desired_goblets"/>
         <int32_t name="desired_instruments"/>
         <int32_t name="desired_paper"/>
-        <int32_t name="desired_bookcases"/>
+        <int32_t name="unk_f4"/>
 
         the following is not saved:
         <int32_t name="unk_f8"/>


### PR DESCRIPTION
also removes two incorrect field names. there is no setting for wanted bookcases and the field that was previously identified as type is 2 for a tavern and a temple I have but 0 for a library.