### PR TITLE
Identify field as flags and its values in df::entity_site_link

### DIFF
--- a/df.refs.xml
+++ b/df.refs.xml
@@ -610,7 +610,23 @@
         <int32_t/>
         <int32_t/>
         <int32_t/>
-        <int32_t/>
+        <bitfield name='flags' base-type='uint32_t'>
+          <flag-bit name='residence'             comment='site is residence'/>
+          <flag-bit name='capital'               comment='site is capital'/>          
+          <flag-bit name='fortress'              comment='used at least by those castles which arent currently in'/>
+          <flag-bit name='local_market'          comment='for villages to think about their market town'/>
+          <flag-bit name='trade_partner'         comment='for markets to think about other markets'/>
+          <flag-bit name='monument'              comment='for a civ to know its tomb sites'/>
+          <flag-bit name='primary_criminal_gang'/>
+          <flag-bit name='criminal_gang'        />
+          <flag-bit name='invasion_marked'       comment='marked for invasion'/>
+          <flag-bit name='land_for_holding'      comment='all regular sites get this if civ has nobles, whether they have a noble or not'/>
+          <flag-bit name='central_holding_land'  comment='only dwarf fortresses get this for now'/>
+          <flag-bit name='land_holder_residence' comment='the regular sites where a baron etc. actually lives'/>
+          <flag-bit name='invasion_push_out'     comment='pushed out by invasion'/>
+          <flag-bit name='reclaim'               comment='marked for reclaim'/>
+          <flag-bit name='ocuppation_failed'     comment='failed to hold hostile occupation'/>
+        </bitfield>  
         <int32_t/>
         <int32_t name="link_strength" init-value='100'/>
         <int32_t/>


### PR DESCRIPTION
This was the answer from Toady about this field values  from a question asked by me in the last Future of the Fortress thread in DF Forums.
They are used extensively in diplomacy, trading and nobility map exports