### PR TITLE
add new unit stl-string

### DIFF
--- a/df.units.xml
+++ b/df.units.xml
@@ -1062,6 +1062,7 @@
         <int32_t name='combat_side_id'/>
         <int32_t comment='v0.40.01'/>
         <stl-vector comment='v0.42.01'/>
+        <stl-string name='adjective' comment='from physical descriptions for use in adv'/>
     </struct-type>
 
     <enum-type type-name='ghost_goal' base-type='int16_t'>


### PR DESCRIPTION
contains string for new 42.06 feature "Used adjectives from physical
descriptions for use in adv mode creature designations"
updates #79