### PR TITLE
use custom-methods for building_handler and machine_handler

### DIFF
--- a/df.world.xml
+++ b/df.world.xml
@@ -357,7 +357,7 @@
         </compound>
     </struct-type>
 
-    <class-type type-name='building_handler' original-name='building_handlerst'>
+    <class-type type-name='building_handler' original-name='building_handlerst' custom-methods='true'>
         dtor 85316f0
 
         <stl-vector name='all' pointer-type='building'/>
@@ -382,7 +382,7 @@
         </virtual-methods>
     </class-type>
 
-    <class-type type-name='machine_handler' original-name='machine_handlerst'>
+    <class-type type-name='machine_handler' original-name='machine_handlerst' custom-methods='true'>
         <stl-vector name='all' pointer-type='machine'/>
         <stl-vector name='bad' has-bad-pointers='true' pointer-type='machine'/>
         <virtual-methods>


### PR DESCRIPTION
required for https://github.com/DFHack/dfhack/pull/838

> 08:47 < angavrilov> lethosor: the constructor problem can be solved by injecting a friend declaration - viewscreen is an example
> 08:48 < angavrilov> using the custom-methods system
> 08:49 < angavrilov> constructors are protected to force the use of df::allocate, but such cases of nested structures are a special case that needs a hack