### PR TITLE
Added missing fields and rename a fews others in df::world_site_realization

### DIFF
--- a/df.military.xml
+++ b/df.military.xml
@@ -332,7 +332,7 @@
         <stl-vector name="unk_44"/>
         <int32_t name="unk_54"/>
         <pointer name="unk_58" comment='target structure varies'/>
-        <int32_t name="unk_5c"/>
+        <int32_t name="type"/>
     </struct-type>
 
     <enum-type type-name='army_flags'>

--- a/df.resource.xml
+++ b/df.resource.xml
@@ -69,7 +69,7 @@
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_cropst' inherits-from='resource_allotment_specifier'>
-        <int32_t/>
+        <int32_t name='mat_type' ref-target='plant_raw' aux-value='$$.mat_index' comment='index to world.raws.plant.all' />
         <int32_t/>
         <int32_t name='unk_v40_01' comment='v0.40.01'/>
         <static-array count='5' type-name='int32_t'/>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -633,8 +633,8 @@
         <enum-item name='hillock_house'/>
         <enum-item name='mead_hall'/>
         <enum-item name='fortress_entrance'/>
-        <enum-item name='unknown_1'/>
-        <enum-item name='unknown_2'/>
+        <enum-item name='library'/>
+        <enum-item name='tavern'/>
     </enum-type>
 
     <struct-type type-name='site_realization_building' key-field='id'>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -785,6 +785,8 @@
         <enum-item name='HomeTree'/>
         <enum-item name='ShapingTree'/>
         <enum-item name='MarketTree'/>
+        <enum-item name='Unknown1'/>
+        <enum-item name='Unknown2'/>
     </enum-type>
 
     <class-type type-name='site_realization_building_info_tree_housest'

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -516,6 +516,7 @@
                     <enum-item name="Orchard"/>
                     <enum-item name="Woodland"/>
                     <enum-item name="Waste"/>
+                    <enum-item name="Unknown1"/>
                 </enum>
                 <int32_t name="index"/>
                 <int32_t name="unk_8"/>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -430,7 +430,7 @@
         <static-array name='road_map' count='51'>
             <static-array count='51' pointer-type='site_realization_crossroads'/>
         </static-array>
-        <static-array name='unk_2d44' count='51'>
+        <static-array name='river_map' count='51'>
             <static-array count='51' type-name='pointer'/>
         </static-array>
         <static-array name='unk_55e8' count='17'>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -565,16 +565,15 @@
         <int32_t name='num_unk_193bc'/>
         <int32_t/>
         <int32_t/>
-        <static-array name='building_type13' pointer-type='site_realization_building' count='20'/>
-        <int32_t name='num_building_type13'/>
-        <static-array name='building_type5' pointer-type='site_realization_building' count='20'/>
-        <int32_t name='num_building_type5'/>
-        <static-array name='building_shop_house' pointer-type='site_realization_building' count='20'/>
-        <int32_t name='num_building_shop_house'/>
-        <int32_t/>
-        <int32_t/>?
-        <int32_t/>?
-        <int32_t/>?
+        <static-array name='building_well' pointer-type='site_realization_building' count='20'/>
+        <int32_t name='num_building_well'/>
+        <static-array name='building_temple' pointer-type='site_realization_building' count='20'/>
+        <int32_t name='num_building_temple'/>
+        <static-array name='building_type22' pointer-type='site_realization_building' count='20'/>
+        <int32_t name='num_building_type22'/>
+        <static-array name='building_type21' pointer-type='site_realization_building' count='20'/>
+        <int32_t name='num_building_type21'/>
+        <stl-vector name="unk_wsr_vector"/>        
     </struct-type>
 
     <struct-type type-name='site_realization_crossroads'>
@@ -634,6 +633,8 @@
         <enum-item name='hillock_house'/>
         <enum-item name='mead_hall'/>
         <enum-item name='fortress_entrance'/>
+        <enum-item name='unknown_1'/>
+        <enum-item name='unknown_2'/>
     </enum-type>
 
     <struct-type type-name='site_realization_building' key-field='id'>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -487,7 +487,7 @@
             </static-array>
         </static-array>
 
-        <static-array name='unk_v40_1' count='51' comment='v0.40.01'>
+        <static-array name='flags_map' count='51' comment='v0.40.01'>
             <static-array count='51' type-name='uint32_t'/>
         </static-array>
 

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -529,8 +529,8 @@
         </stl-vector>
 
         <int32_t/>
-        <int32_t/>?
-        <int32_t/>?
+        <int32_t name="army_controller_pos_x"/>
+        <int32_t name="army_controller_pos_y"/>
         <static-array name='unk_193bc' count='500'>
             <int32_t/>
             <int32_t/>


### PR DESCRIPTION
Checking DF code with ÍDA in Windows shows that the constructor for df::world_site_realization allocates more memory than the size showed in the symbols.xml.

This new space is used for a array of 20 pointers and a totalizer similar to the previous ones and a std::vector of pointers.

Unfortunately, I think that the pointer points to a local subtype created inside df::world_site_realization  with a size of 420 bytes, so I defined the pointer as void* until I can identify this type.

Also site_realization_building_type has 22 types, not 20 as before. Types 21 and 22 are marked unknown_1 and unknown_2 respectively.

These new enums are used in the new arrays mentioned above.

Finally, the names building_type_5 and building_type_13 are changed to well and temple, as those are its names according to df::site_realization_building. The one referring to plot_house was also wrong, as it refers to Type22