### PR TITLE
Added names in interaction_instance.

### DIFF
--- a/df.interaction.xml
+++ b/df.interaction.xml
@@ -307,9 +307,9 @@
 
     <struct-type type-name='interaction_instance' instance-vector='$global.world.interaction_instances.all' key-field='id'>
         <int32_t name='id'/>
+        <int32_t name='interation_id'/>
         <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='region_index'/>
         <stl-vector type-name='int32_t'/>
     </struct-type>
 


### PR DESCRIPTION
Added names for interaction_id and region_index in interaction_instance. Tested in 42.06.

I tried changing the interaction_id to change which interaction was applied to the region indicated by the region_index. (formerly anon_1 and anon_3) The weather in the evil region changed as expected. 

I haven't tried any more exotic changes (interactions in non-evil regions, multiple interactions per region), but the structure appears to describe one interaction per evil region, so it works for reporting on all evil weather.