### PR TITLE
Identifying the next_id field for manager orders.

### DIFF
--- a/df.world.xml
+++ b/df.world.xml
@@ -430,7 +430,7 @@
         --
 
         <stl-vector name='manager_orders' pointer-type='manager_order'/>
-        <padding size='4'/>
+        <int32_t name='manager_order_next_id'/>
 
         <stl-vector name='mandates' pointer-type='mandate'/>
 


### PR DESCRIPTION
This field is recalculated on world load, instead of saved.
Required by the stockflow and df-ai plugins.