### PR TITLE
Make wrappers for custom methods in lua possible

### DIFF
--- a/StructFields.pm
+++ b/StructFields.pm
@@ -495,8 +495,8 @@ sub render_field_metadata($$\@\%) {
     return generate_field_table {
         render_field_metadata_rec($_, $FLD) for @$fields;
 
-        for my $vmtag (@{$info->{vmethods}||[]}) {
-            my $name = $vmtag->getAttribute('name');
+        for my $mtag (@{$info->{vmethods}||[]}, @{$info->{cmethods}||[]}) {
+            my $name = $mtag->getAttribute('name');
             push @field_defs, [ "METHOD(OBJ_METHOD, $name)" ] if $name;
         }
         for my $name (@{$info->{statics}||[]}) {

--- a/df.graphics.xml
+++ b/df.graphics.xml
@@ -196,6 +196,9 @@
         </compound>
 
         <uint32_t name='clock'/>
+        <custom-methods>
+            <cmethod name='zoom_display'/>
+        </custom-methods>
     </struct-type>
 </data-definition>
 

--- a/df.knowledge.xml
+++ b/df.knowledge.xml
@@ -382,10 +382,13 @@
         <flag-bit name='engineering_machine_trip_hammer'/>
     </bitfield-type>
 
-    <struct-type type-name='knowledge_scholar_category_flag' custom-methods='true'>
+    <struct-type type-name='knowledge_scholar_category_flag'>
         <extra-include type-name='dfhack_knowledge_scholar_flag'/>
         <int32_t name='category' comment='determines which bitflags to use'/>
         <uint32_t name='flags' comment='one of the 14 bitflag structs'/>
+        <custom-methods>
+            <cmethod name='value'/>
+        </custom-methods>
         <!-- the compound below does not work because bitfields have constructors -->
 <!--
         <compound name='flags' is-union='true'>

--- a/df.map.xml
+++ b/df.map.xml
@@ -3,6 +3,11 @@
         <int16_t name='x' init-value='-30000'/>
         <int16_t name='y' init-value='-30000'/>
 
+        <custom-methods>
+            <cmethod name='isValid'/>
+            <cmethod name='clear'/>
+        </custom-methods>
+
         <code-helper name='describe'>(fmt "(~A,~A)" $.x $.y)</code-helper>
     </struct-type>
 
@@ -10,6 +15,10 @@
         <stl-vector type-name='int16_t' name='x'/>
         <stl-vector type-name='int16_t' name='y'/>
 
+        <custom-methods>
+            <cmethod name='size'/>
+            <cmethod name='erase'/>
+        </custom-methods>
         <code-helper name='describe'>
             (fmt "[~A]" $.x.count)
             (loop for i from 0 below (min $.x.count 3)
@@ -23,6 +32,11 @@
         <int16_t name='y' init-value='-30000'/>
         <int16_t name='z' init-value='-30000'/>
 
+        <custom-methods>
+            <cmethod name='isValid'/>
+            <cmethod name='clear'/>
+        </custom-methods>
+
         <code-helper name='describe'>(fmt "(~A,~A,~A)" $.x $.y $.z)</code-helper>
     </struct-type>
 
@@ -30,6 +44,13 @@
         <stl-vector type-name='int16_t' name='x'/>
         <stl-vector type-name='int16_t' name='y'/>
         <stl-vector type-name='int16_t' name='z'/>
+
+        <custom-methods>
+            <cmethod name='empty'/>
+            <cmethod name='size'/>
+            <cmethod name='clear'/>
+            <cmethod name='erase'/>
+        </custom-methods>
 
         <code-helper name='describe'>
             (fmt "[~A]" $.x.count)
@@ -180,6 +201,11 @@
         <static-array name='bits' count='16'>
             <uint16_t/>
         </static-array>
+        <custom-methods>
+            <cmethod name='clear'/>
+            <cmethod name='set_all'/>
+            <cmethod name='has_assignments'/>
+        </custom-methods>
     </struct-type>
 
     <struct-type type-name='block_burrow' custom-methods='true'>
@@ -188,6 +214,10 @@
         <compound name='tile_bitmask' type-name='tile_bitmask'/>
 
         <pointer name="link" type-name='block_burrow_link'/>
+
+        <custom-methods>
+            <cmethod name='has_assignments'/>
+        </custom-methods>
     </struct-type>
 
     <struct-type type-name='block_burrow_link'>
@@ -420,6 +450,9 @@
             <flag-bit name='cluster_small'/>
             <flag-bit name='cluster_one'/>
         </bitfield>
+        <custom-methods>
+            <cmethod name='has_assignments'/>
+        </custom-methods>
     </class-type>
 
     <class-type type-name='block_square_event_frozen_liquidst' inherits-from='block_square_event'>

--- a/df.materials.xml
+++ b/df.materials.xml
@@ -312,6 +312,10 @@
 
         <stl-string name='powder_dye_str' comment='temporary'/>
         <static-array name='state_color_str' type-name='stl-string' count='6' index-enum='matter_state'/>
+        <custom-methods>
+            <cmethod name='isGem'/>
+            <cmethod name='isStone'/>
+        </custom-methods>
     </struct-type>
 
     <struct-type type-name='material_vec_ref'>
@@ -439,6 +443,9 @@
         <int32_t name='unk2'/>
 
         <compound name='material' type-name='material'/>
+        <custom-methods>
+            <cmethod name='isOre'/>
+        </custom-methods>
     </struct-type>
 
     <enum-type type-name='organic_mat_category'>

--- a/lower-1.xslt
+++ b/lower-1.xslt
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<!-- 
+<!--
   The original XML format is good for human use, but
   difficult to interpret during code generation. This
   lowers it to more repetitive & verbose, but easier
   for the programs to interpret.
-  
+
   This is the first pass that folds all field tags into ld:field.
  -->
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:ld="http://github.com/peterix/dfhack/lowered-data-definition">
-    <!-- 
+    <!--
         Global templates:
 
         - Copy attributes and simple tags
@@ -40,7 +40,7 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="virtual-methods|cond-if|cond-else">
+    <xsl:template match="virtual-methods|custom-methods|cond-if|cond-else">
         <xsl:param name='level' select='-1'/>
         <xsl:copy>
             <xsl:apply-templates select='@*|node()'>
@@ -50,7 +50,7 @@
     </xsl:template>
 
     <!-- Type defs: convert to one common 'global-type' tag name. -->
-    
+
     <xsl:template match='enum-type|bitfield-type|class-type|struct-type'>
         <ld:global-type>
             <xsl:attribute name='ld:meta'><xsl:value-of select='name(.)'/></xsl:attribute>
@@ -150,7 +150,7 @@
 
     <!--
         Compound, enum or bitfield:
-        
+
         - When a proxy: meta='global' subtype='$tag' type-name='blah'
         - When an ad-hoc compound: meta='compound' subtype='$tag'
         - Level not incremented unless it has a name.
@@ -266,10 +266,10 @@
             </xsl:call-template>
         </ld:field>
     </xsl:template>
-    
+
     <!-- Virtual methods -->
 
-    <xsl:template match='vmethod'>
+    <xsl:template match='vmethod|cmethod'>
         <xsl:param name='level' select='-1'/>
         <xsl:copy>
             <xsl:attribute name='ld:level'><xsl:value-of select='$level'/></xsl:attribute>


### PR DESCRIPTION
For wrappers to be generated, they have to be included in a `<custom-methods>`
node, similar to the existing `<virtual-methods>`:

```xml
<custom-methods>
    <cmethod name='foo'/>
</custom-methods>
```

The actual method signatures and definitions are still kept in custom/*.methods.inc