### PR TITLE
Identify written contents variable and flag names

### DIFF
--- a/df.itemimprovements.xml
+++ b/df.itemimprovements.xml
@@ -124,7 +124,7 @@
     </class-type>
 
     <class-type type-name='itemimprovement_writingst' inherits-from='itemimprovement'>
-        <stl-vector type-name='int32_t'/>
+        <stl-vector name='contents' type-name='int32_t' ref-target='written_content'/>
     </class-type>
 
     <enum-type type-name='written_content_type' base-type='int32_t'>

--- a/df.items.xml
+++ b/df.items.xml
@@ -47,6 +47,7 @@
         <flag-bit name='has_rider' comment='vehicle with a rider'/>
         <flag-bit name='unk1'/>
         <flag-bit name='grown'/>
+        <flag-bit name='has_written_content'/>
     </bitfield-type>
 
     <enum-type type-name='item_magicness_type' base-type='int16_t'>


### PR DESCRIPTION
Finally got around to doing this myself: this names the item_flags2 flag and the vector in itemimprovement_writingst which are used for written contents things in quires, scrolls, and books.  

The name for the flag comes from the [HAS_WRITTEN_CONTENTS] requirement in the BIND_BOOK reaction.  The name for itemimprovement_writingst::anon_1 comes from the apparently-identical vector in itemimprovement_pagesst.  (I haven't personally seen a pagesst, myself, but the ref says it points to written_contents, and that's what the writingst one does.)