### PR TITLE
Identify some conversation fields

### DIFF
--- a/df.advmode.xml
+++ b/df.advmode.xml
@@ -547,9 +547,9 @@
             <stl-vector name='activity_event' pointer-type='activity_event'/>
             <int32_t name='cursor_activity' refers-to='$$._parent.activity[$]'/>
             <int32_t name='cursor_choice' refers-to='$$._parent.choices[$]'/>
-            <int32_t name='unk4'/>
-            <stl-vector name='unk5' type-name='int32_t'/>
-            <stl-vector name='unk6' type-name='int32_t'/>
+            <int32_t name='current_page'/>
+            <stl-vector name='page_top_choices' type-name='int32_t'/>
+            <stl-vector name='page_bottom_choices' type-name='int32_t'/>
             <stl-vector name='choices'>
                 <pointer>
                     <pointer name="choice" type-name='talk_choice'/>


### PR DESCRIPTION
I’m not sure these proposed names are clear, but they’re better than `unk4`. The two vectors are vectors of indexes into `choices`; can that be expressed with `refers-to`? Something like `$$._parent.choices[$]`?