### PR TITLE
Update win32 global symbols

### DIFF
--- a/symbols.xml
+++ b/symbols.xml
@@ -149,7 +149,7 @@
         <global-address name='gps'value='0x00f930b8'/>
         <global-address name='gview'value='0x01b2ac90'/>
         <global-address name='init'value='0x018ce9c0'/>
-        <global-address name='texture'value='0x018ce99c'/>
+        <global-address name='texture'value='0x018b33cc'/>
         <global-address name='timed_events'value='0x018ce978'/>
         <global-address name='ui' value='0x18b3d28'/>
         <global-address name='ui_advmode'value='0x01ce5678'/>

--- a/symbols.xml
+++ b/symbols.xml
@@ -166,7 +166,7 @@
 
         generated keydisplay
 
-        <global-address name='keydisplay' />
+        <global-address name='keydisplay' value='0x018b3600'/>
 
         .bss primitive
 
@@ -1142,6 +1142,9 @@
         generated cglobals
 
         generated keydisplay
+
+        <global-address name='keydisplay' value='0x14193F928'/>
+        
 
         .bss primitive
 

--- a/symbols.xml
+++ b/symbols.xml
@@ -127,37 +127,37 @@
 
         .data
 
-        <global-address name='cursor'value='0x00f93040'/>
-        <global-address name='selection_rect'value='0x00f93050'/>
-        <global-address name='gamemode'value='0x00f93074'/>
-        <global-address name='gametype'value='0x00f93070'/>
+        <global-address name='cursor' value='0x00f93040'/>
+        <global-address name='selection_rect' value='0x00f93050'/>
+        <global-address name='gamemode' value='0x00f93074'/>
+        <global-address name='gametype' value='0x00f93070'/>
 
-        <global-address name='ui_menu_width'value='0x00f93068'/>
-        <global-address name='ui_area_map_width'value='0x00f93069'/>
+        <global-address name='ui_menu_width' value='0x00f93068'/>
+        <global-address name='ui_area_map_width' value='0x00f93069'/>
 
         .bss compound - THAT IS, NOT SIMPLE INTEGER VARIABLES!
 
-        <global-address name='created_item_type'value='0x018b3d1c'/>
-        <global-address name='created_item_subtype'value='0x01cee808'/>
-        <global-address name='created_item_mattype'value='0x018d09ec'/>
-        <global-address name='created_item_matindex'value='0x018ce984'/>
-        <global-address name='created_item_count'value='0x018bc7d8'/>
-        <global-address name='map_renderer'value='0x018bc7f0'/>
-        <global-address name='d_init'value='0x018b3650'/>
-        <global-address name='enabler'value='0x018b33f0'/>
-        <global-address name='flows'value='0x018bae0c'/>
-        <global-address name='gps'value='0x00f930b8'/>
-        <global-address name='gview'value='0x01b2ac90'/>
-        <global-address name='init'value='0x018ce9c0'/>
-        <global-address name='texture'value='0x018b33cc'/>
-        <global-address name='timed_events'value='0x018ce978'/>
+        <global-address name='created_item_type' value='0x018b3d1c'/>
+        <global-address name='created_item_subtype' value='0x01cee808'/>
+        <global-address name='created_item_mattype' value='0x018d09ec'/>
+        <global-address name='created_item_matindex' value='0x018ce984'/>
+        <global-address name='created_item_count' value='0x018bc7d8'/>
+        <global-address name='map_renderer' value='0x018bc7f0'/>
+        <global-address name='d_init' value='0x018b3650'/>
+        <global-address name='enabler' value='0x018b33f0'/>
+        <global-address name='flows' value='0x018bae0c'/>
+        <global-address name='gps' value='0x00f930b8'/>
+        <global-address name='gview' value='0x01b2ac90'/>
+        <global-address name='init' value='0x018ce9c0'/>
+        <global-address name='texture' value='0x018b33cc'/>
+        <global-address name='timed_events' value='0x018ce978'/>
         <global-address name='ui' value='0x18b3d28'/>
-        <global-address name='ui_advmode'value='0x01ce5678'/>
+        <global-address name='ui_advmode' value='0x01ce5678'/>
         <global-address name='ui_build_selector' value='0x018cfa48'/>
-        <global-address name='ui_building_assign_type'value='0x018ce990'/>
-        <global-address name='ui_building_assign_is_marked'value='0x018ce9b4'/>
-        <global-address name='ui_building_assign_units'value='0x018ce96c'/>
-        <global-address name='ui_building_assign_items'value='0x01cee7fc'/>
+        <global-address name='ui_building_assign_type' value='0x018ce990'/>
+        <global-address name='ui_building_assign_is_marked' value='0x018ce9b4'/>
+        <global-address name='ui_building_assign_units' value='0x018ce96c'/>
+        <global-address name='ui_building_assign_items' value='0x01cee7fc'/>
         <global-address name='ui_look_list' value='0x018ce9a8'/>
         <global-address name='ui_sidebar_menus' value='0x018bae18'/>
         <global-address name='world' value='0x018d09f8'/>
@@ -170,47 +170,47 @@
 
         .bss primitive
 
-        <global-address name='announcements'value='0x018b37e0'/>
+        <global-address name='announcements' value='0x018b37e0'/>
 
-        <global-address name='cur_year'value='0x018986b8'/>
-        <global-address name='cur_year_tick'value='0x0188d6b0'/>
-        <global-address name='cur_year_tick_advmode'value='0x0188d678'/>
-        <global-address name='cur_season_tick'value='0x017f74c4'/>
-        <global-address name='cur_season'value='0x017f75e6'/>
+        <global-address name='cur_year' value='0x018986b8'/>
+        <global-address name='cur_year_tick' value='0x0188d6b0'/>
+        <global-address name='cur_year_tick_advmode' value='0x0188d678'/>
+        <global-address name='cur_season_tick' value='0x017f74c4'/>
+        <global-address name='cur_season' value='0x017f75e6'/>
 
-        <global-address name='current_weather'value='0x017f760c'/>
+        <global-address name='current_weather' value='0x017f760c'/>
 
-        <global-address name='process_jobs'value='0x012790b0'/>
-        <global-address name='process_dig'value='0x012790b1'/>
-        <global-address name='pause_state'value='0x017f7ec3'/>
+        <global-address name='process_jobs' value='0x012790b0'/>
+        <global-address name='process_dig' value='0x012790b1'/>
+        <global-address name='pause_state' value='0x017f7ec3'/>
 
-        <global-address name='ui_selected_unit'value='0x017f7ed4'/>
-        <global-address name='ui_unit_view_mode'value='0x017f75d4'/>
-        <global-address name='ui_look_cursor'value='0x017f7a48'/>
-        <global-address name='ui_building_item_cursor'value='0x017f75c8'/>
-        <global-address name='ui_workshop_in_add'value='0x017f75e4'/>
-        <global-address name='ui_workshop_job_cursor'value='0x017f74c0'/>
-        <global-address name='ui_building_in_assign'value='0x017f762b'/>
-        <global-address name='ui_building_in_resize'value='0x017f7eb6'/>
-        <global-address name='ui_lever_target_type'value='0x017f75d2'/>
+        <global-address name='ui_selected_unit' value='0x017f7ed4'/>
+        <global-address name='ui_unit_view_mode' value='0x017f75d4'/>
+        <global-address name='ui_look_cursor' value='0x017f7a48'/>
+        <global-address name='ui_building_item_cursor' value='0x017f75c8'/>
+        <global-address name='ui_workshop_in_add' value='0x017f75e4'/>
+        <global-address name='ui_workshop_job_cursor' value='0x017f74c0'/>
+        <global-address name='ui_building_in_assign' value='0x017f762b'/>
+        <global-address name='ui_building_in_resize' value='0x017f7eb6'/>
+        <global-address name='ui_lever_target_type' value='0x017f75d2'/>
 
-        <global-address name='window_x'value='0x017f7e88'/>
-        <global-address name='window_y'value='0x017f7e9c'/>
-        <global-address name='window_z'value='0x017f7634'/>
+        <global-address name='window_x' value='0x017f7e88'/>
+        <global-address name='window_y' value='0x017f7e9c'/>
+        <global-address name='window_z' value='0x017f7634'/>
 
-        <global-address name='debug_nopause'value='0x017f75d3'/>
-        <global-address name='debug_nomoods'value='0x01879ce8'/>
-        <global-address name='debug_combat'value='0x01879ceb'/>
-        <global-address name='debug_wildlife'value='0x01879df0'/>
-        <global-address name='debug_nodrink'value='0x01879df1'/>
-        <global-address name='debug_noeat'value='0x01879ce9'/>
-        <global-address name='debug_nosleep'value='0x017f9cdf'/>
-        <global-address name='debug_showambush'value='0x01879cea'/>
-        <global-address name='debug_fastmining'value='0x017f9cde'/>
-        <global-address name='debug_noberserk'value='0x017f7ea2'/>
-        <global-address name='debug_turbospeed'value='0x00f9c9e3'/>
+        <global-address name='debug_nopause' value='0x017f75d3'/>
+        <global-address name='debug_nomoods' value='0x01879ce8'/>
+        <global-address name='debug_combat' value='0x01879ceb'/>
+        <global-address name='debug_wildlife' value='0x01879df0'/>
+        <global-address name='debug_nodrink' value='0x01879df1'/>
+        <global-address name='debug_noeat' value='0x01879ce9'/>
+        <global-address name='debug_nosleep' value='0x017f9cdf'/>
+        <global-address name='debug_showambush' value='0x01879cea'/>
+        <global-address name='debug_fastmining' value='0x017f9cde'/>
+        <global-address name='debug_noberserk' value='0x017f7ea2'/>
+        <global-address name='debug_turbospeed' value='0x00f9c9e3'/>
 
-        <global-address name='save_on_exit'value='0x017f7ec2'/>
+        <global-address name='save_on_exit' value='0x017f7ec2'/>
 
         code
 
@@ -1103,40 +1103,41 @@
 
         .data
 
-        <global-address name='cursor'/>
-        <global-address name='selection_rect'/>
-        <global-address name='gamemode'/>
-        <global-address name='gametype'/>
+        <global-address name='cursor' value='0x140e60058'/>
+        <global-address name='selection_rect' value='0x140e60068'/>
+        <global-address name='gamemode' value='0x140e6008c'/>
+        <global-address name='gametype' value='0x140e60088'/>
 
-        <global-address name='ui_menu_width'/>
-        <global-address name='ui_area_map_width'/>
+        <global-address name='ui_menu_width' value='0x140e60080'/>
+        <global-address name='ui_area_map_width' value='0x140e60081'/>
 
         .bss compound - THAT IS, NOT SIMPLE INTEGER VARIABLES!
 
-        <global-address name='created_item_type'/>
-        <global-address name='created_item_subtype'/>
-        <global-address name='created_item_mattype'/>
-        <global-address name='created_item_matindex'/>
-        <global-address name='created_item_count'/>
-        <global-address name='map_renderer'/>
-        <global-address name='d_init'/>
-        <global-address name='enabler'/>
-        <global-address name='flows'/>
-        <global-address name='gps'/>
-        <global-address name='gview'/>
+        <global-address name='created_item_type' value='0x14193f618'/>
+        <global-address name='created_item_subtype' value='0x141bd36e8'/>
+        <global-address name='created_item_mattype' value='0x14195ecd8'/>
+        <global-address name='created_item_matindex' value='0x14195cbb0'/>
+        <global-address name='created_item_count' value='0x141948d58'/>
+        <global-address name='map_renderer' value='0x14194a9d0'/>
+        <global-address name='d_init' value='0x14193f9d0'/>
+        <global-address name='enabler' value='0x14193f630'/>
+        <global-address name='flows' value='0x14193f9b8'/>
+        <global-address name='gps' value='0x14101aac0'/>
+        <global-address name='gview' value='0x140e600f0'/>
         <global-address name='init' value='0x14195cc10'/>
-        <global-address name='texture'/>
-        <global-address name='timed_events'/>
-        <global-address name='ui'/>
-        <global-address name='ui_advmode'/>
-        <global-address name='ui_build_selector'/>
-        <global-address name='ui_building_assign_type'/>
-        <global-address name='ui_building_assign_is_marked'/>
-        <global-address name='ui_building_assign_units'/>
-        <global-address name='ui_building_assign_items'/>
-        <global-address name='ui_look_list'/>
-        <global-address name='ui_sidebar_menus'/>
-        <global-address name='world'/>
+        <global-address name='texture' value='0x141948d70'/>
+        <global-address name='timed_events' value='0x14195cb98'/>
+        <global-address name='ui' value='0x1419400d0'/>
+        <global-address name='ui_advmode' value='0x141bca170'/>
+        <global-address name='ui_build_selector' value='0x14195dcc0'/>
+        <global-address name='ui_building_assign_type' value='0x14195cbc8'/>
+        <global-address name='ui_building_assign_is_marked' value='0x14195eca8'/>
+        <global-address name='ui_building_assign_units' value='0x14195cb80'/>
+        <global-address name='ui_building_assign_items' value='0x141bd36d0'/>
+        <global-address name='ui_look_list' value='0x14195cbf8'/>
+        <global-address name='ui_sidebar_menus' value='0x141948dd0'/>
+        <global-address name='world' value='0x14195ecf0'/>
+
 
         generated cglobals
 
@@ -1144,47 +1145,47 @@
 
         .bss primitive
 
-        <global-address name='announcements'/>
+        <global-address name='announcements' value='0x14193fb90'/>
 
-        <global-address name='cur_year'/>
-        <global-address name='cur_year_tick'/>
-        <global-address name='cur_year_tick_advmode'/>
-        <global-address name='cur_season_tick'/>
-        <global-address name='cur_season'/>
+        <global-address name='cur_year' value='0x141904248'/>
+        <global-address name='cur_year_tick' value='0x141904240'/>
+        <global-address name='cur_year_tick_advmode' value='0x141884110'/>
+        <global-address name='cur_season_tick' value='0x1413030d4'/>
+        <global-address name='cur_season' value='0x1413030e5'/>
 
-        <global-address name='current_weather'/>
+        <global-address name='current_weather' value='0x141303110'/>
 
-        <global-address name='process_jobs'/>
-        <global-address name='process_dig'/>
-        <global-address name='pause_state'/>
+        <global-address name='process_jobs' value='0x14190423b'/>
+        <global-address name='process_dig' value='0x141026a03'/>
+        <global-address name='pause_state' value='0x141305bf3'/>
 
-        <global-address name='ui_selected_unit'/>
-        <global-address name='ui_unit_view_mode'/>
-        <global-address name='ui_look_cursor'/>
-        <global-address name='ui_building_item_cursor'/>
-        <global-address name='ui_workshop_in_add'/>
-        <global-address name='ui_workshop_job_cursor'/>
-        <global-address name='ui_building_in_assign'/>
-        <global-address name='ui_building_in_resize'/>
-        <global-address name='ui_lever_target_type'/>
+        <global-address name='ui_selected_unit' value='0x141303de8'/>
+        <global-address name='ui_unit_view_mode' value='0x141884118'/>
+        <global-address name='ui_look_cursor' value='0x141303544'/>
+        <global-address name='ui_building_item_cursor' value='0x1413030d8'/>
+        <global-address name='ui_workshop_in_add' value='0x141026a0f'/>
+        <global-address name='ui_workshop_job_cursor' value='0x141305bfc'/>
+        <global-address name='ui_building_in_assign' value='0x14130312a'/>
+        <global-address name='ui_building_in_resize' value='0x141303dc2'/>
+        <global-address name='ui_lever_target_type' value='0x141026a0e'/>
 
-        <global-address name='window_x'/>
-        <global-address name='window_y'/>
-        <global-address name='window_z'/>
+        <global-address name='window_x' value='0x141303d9c'/>
+        <global-address name='window_y' value='0x141303db8'/>
+        <global-address name='window_z' value='0x141303540'/>
 
-        <global-address name='debug_nopause'/>
-        <global-address name='debug_nomoods'/>
-        <global-address name='debug_combat'/>
-        <global-address name='debug_wildlife'/>
-        <global-address name='debug_nodrink'/>
-        <global-address name='debug_noeat'/>
-        <global-address name='debug_nosleep'/>
-        <global-address name='debug_showambush'/>
-        <global-address name='debug_fastmining'/>
-        <global-address name='debug_noberserk'/>
-        <global-address name='debug_turbospeed'/>
+        <global-address name='debug_nopause' value='0x141884007'/>
+        <global-address name='debug_nomoods' value='0x14188400e'/>
+        <global-address name='debug_combat' value='0x141884004'/>
+        <global-address name='debug_wildlife' value='0x141884117'/>
+        <global-address name='debug_nodrink' value='0x14188411e'/>
+        <global-address name='debug_noeat' value='0x14188400f'/>
+        <global-address name='debug_nosleep' value='0x141884006'/>
+        <global-address name='debug_showambush' value='0x141884116'/>
+        <global-address name='debug_fastmining' value='0x141884005'/>
+        <global-address name='debug_noberserk' value='0x14188411f'/>
+        <global-address name='debug_turbospeed' value='0x14190423a'/>
 
-        <global-address name='save_on_exit'/>
+        <global-address name='save_on_exit' value='0x141305bf2'/>
 
         code
 
@@ -1220,8 +1221,8 @@
         <global-address name='process_dig' value='0x141026a03'/>
         <global-address name='cursor' value='0x140e60058'/>
         <global-address name='selection_rect' value='0x140e60068'/>
-        <global-address name='gamemode' value='0x140e60088'/>
-        <global-address name='gametype' value='0x140e6008c'/> -4
+        <global-address name='gamemode' value='0x140e6008c'/>
+        <global-address name='gametype' value='0x140e60088'/>
         <global-address name='pause_state' value='0x141305bf3'/>
 
         generated standingorders

--- a/symbols.xml
+++ b/symbols.xml
@@ -1309,6 +1309,16 @@
 
 
         generated vtables
+        <vtable-address name='renderer' value='0x140cac968'/>
+        <vtable-address name='renderer_once' value='0x140cac9c0'/>
+        <vtable-address name='renderer_accum_buffer' value='0x140cac8e8'/>
+        <vtable-address name='renderer_vbo' value='0x140cac868'/>
+        <vtable-address name='renderer_opengl' value='0x140cac688'/>
+        <vtable-address name='renderer_framebuffer' value='0x140cac708'/>
+        <vtable-address name='renderer_2d' value='0x140cac788'/>
+        <vtable-address name='renderer_2d_base' value='0x140cac7e8'/>
+        <vtable-address name='renderer_partial' value='0x140cac5c8'/>
+
         <vtable-address name='abstract_building_dungeonst' value='0x140c49ff8'/>
         <vtable-address name='abstract_building_inn_tavernst' value='0x140c4a068'/>
         <vtable-address name='abstract_building_marketst' value='0x140c49f88'/>

--- a/symbols.xml
+++ b/symbols.xml
@@ -127,90 +127,90 @@
 
         .data
 
-        <global-address name='cursor'/>
-        <global-address name='selection_rect'/>
-        <global-address name='gamemode'/>
-        <global-address name='gametype'/>
+        <global-address name='cursor'value='0x00f93040'/>
+        <global-address name='selection_rect'value='0x00f93050'/>
+        <global-address name='gamemode'value='0x00f93074'/>
+        <global-address name='gametype'value='0x00f93070'/>
 
-        <global-address name='ui_menu_width'/>
-        <global-address name='ui_area_map_width'/>
+        <global-address name='ui_menu_width'value='0x00f93068'/>
+        <global-address name='ui_area_map_width'value='0x00f93069'/>
 
         .bss compound - THAT IS, NOT SIMPLE INTEGER VARIABLES!
 
-        <global-address name='created_item_type'/>
-        <global-address name='created_item_subtype'/>
-        <global-address name='created_item_mattype'/>
-        <global-address name='created_item_matindex'/>
-        <global-address name='created_item_count'/>
-        <global-address name='map_renderer'/>
-        <global-address name='d_init'/>
-        <global-address name='enabler'/>
-        <global-address name='flows'/>
-        <global-address name='gps'/>
-        <global-address name='gview'/>
-        <global-address name='init'/>
-        <global-address name='texture'/>
-        <global-address name='timed_events'/>
+        <global-address name='created_item_type'value='0x018b3d1c'/>
+        <global-address name='created_item_subtype'value='0x01cee808'/>
+        <global-address name='created_item_mattype'value='0x018d09ec'/>
+        <global-address name='created_item_matindex'value='0x018ce984'/>
+        <global-address name='created_item_count'value='0x018bc7d8'/>
+        <global-address name='map_renderer'value='0x018bc7f0'/>
+        <global-address name='d_init'value='0x018b3650'/>
+        <global-address name='enabler'value='0x018b33f0'/>
+        <global-address name='flows'value='0x018bae0c'/>
+        <global-address name='gps'value='0x00f930b8'/>
+        <global-address name='gview'value='0x01b2ac90'/>
+        <global-address name='init'value='0x018ce9c0'/>
+        <global-address name='texture'value='0x018ce99c'/>
+        <global-address name='timed_events'value='0x018ce978'/>
         <global-address name='ui' value='0x18b3d28'/>
-        <global-address name='ui_advmode'/>
-        <global-address name='ui_build_selector' value='0x18cfa48'/>
-        <global-address name='ui_building_assign_type'/>
-        <global-address name='ui_building_assign_is_marked'/>
-        <global-address name='ui_building_assign_units'/>
-        <global-address name='ui_building_assign_items'/>
-        <global-address name='ui_look_list' value='0x18ce9a8'/>
-        <global-address name='ui_sidebar_menus' value='0x18bae18'/>
-        <global-address name='world' value='0x18d09f8'/>
+        <global-address name='ui_advmode'value='0x01ce5678'/>
+        <global-address name='ui_build_selector' value='0x018cfa48'/>
+        <global-address name='ui_building_assign_type'value='0x018ce990'/>
+        <global-address name='ui_building_assign_is_marked'value='0x018ce9b4'/>
+        <global-address name='ui_building_assign_units'value='0x018ce96c'/>
+        <global-address name='ui_building_assign_items'value='0x01cee7fc'/>
+        <global-address name='ui_look_list' value='0x018ce9a8'/>
+        <global-address name='ui_sidebar_menus' value='0x018bae18'/>
+        <global-address name='world' value='0x018d09f8'/>
 
         generated cglobals
 
         generated keydisplay
 
-        <global-address name='keydisplay' value='0x018b35fc'/>
+        <global-address name='keydisplay' />
 
         .bss primitive
 
-        <global-address name='announcements'/>
+        <global-address name='announcements'value='0x018b37e0'/>
 
-        <global-address name='cur_year'/>
-        <global-address name='cur_year_tick'/>
-        <global-address name='cur_year_tick_advmode'/>
-        <global-address name='cur_season_tick'/>
-        <global-address name='cur_season'/>
+        <global-address name='cur_year'value='0x018986b8'/>
+        <global-address name='cur_year_tick'value='0x0188d6b0'/>
+        <global-address name='cur_year_tick_advmode'value='0x0188d678'/>
+        <global-address name='cur_season_tick'value='0x017f74c4'/>
+        <global-address name='cur_season'value='0x017f75e6'/>
 
-        <global-address name='current_weather'/>
+        <global-address name='current_weather'value='0x017f760c'/>
 
-        <global-address name='process_jobs'/>
-        <global-address name='process_dig'/>
-        <global-address name='pause_state'/>
+        <global-address name='process_jobs'value='0x012790b0'/>
+        <global-address name='process_dig'value='0x012790b1'/>
+        <global-address name='pause_state'value='0x017f7ec3'/>
 
-        <global-address name='ui_selected_unit'/>
-        <global-address name='ui_unit_view_mode'/>
-        <global-address name='ui_look_cursor'/>
-        <global-address name='ui_building_item_cursor'/>
-        <global-address name='ui_workshop_in_add'/>
-        <global-address name='ui_workshop_job_cursor'/>
-        <global-address name='ui_building_in_assign'/>
-        <global-address name='ui_building_in_resize'/>
-        <global-address name='ui_lever_target_type'/>
+        <global-address name='ui_selected_unit'value='0x017f7ed4'/>
+        <global-address name='ui_unit_view_mode'value='0x017f75d4'/>
+        <global-address name='ui_look_cursor'value='0x017f7a48'/>
+        <global-address name='ui_building_item_cursor'value='0x017f75c8'/>
+        <global-address name='ui_workshop_in_add'value='0x017f75e4'/>
+        <global-address name='ui_workshop_job_cursor'value='0x017f74c0'/>
+        <global-address name='ui_building_in_assign'value='0x017f762b'/>
+        <global-address name='ui_building_in_resize'value='0x017f7eb6'/>
+        <global-address name='ui_lever_target_type'value='0x017f75d2'/>
 
-        <global-address name='window_x'/>
-        <global-address name='window_y'/>
-        <global-address name='window_z'/>
+        <global-address name='window_x'value='0x017f7e88'/>
+        <global-address name='window_y'value='0x017f7e9c'/>
+        <global-address name='window_z'value='0x017f7634'/>
 
-        <global-address name='debug_nopause'/>
-        <global-address name='debug_nomoods'/>
-        <global-address name='debug_combat'/>
-        <global-address name='debug_wildlife'/>
-        <global-address name='debug_nodrink'/>
-        <global-address name='debug_noeat'/>
-        <global-address name='debug_nosleep'/>
-        <global-address name='debug_showambush'/>
-        <global-address name='debug_fastmining'/>
-        <global-address name='debug_noberserk'/>
-        <global-address name='debug_turbospeed'/>
+        <global-address name='debug_nopause'value='0x017f75d3'/>
+        <global-address name='debug_nomoods'value='0x01879ce8'/>
+        <global-address name='debug_combat'value='0x01879ceb'/>
+        <global-address name='debug_wildlife'value='0x01879df0'/>
+        <global-address name='debug_nodrink'value='0x01879df1'/>
+        <global-address name='debug_noeat'value='0x01879ce9'/>
+        <global-address name='debug_nosleep'value='0x017f9cdf'/>
+        <global-address name='debug_showambush'value='0x01879cea'/>
+        <global-address name='debug_fastmining'value='0x017f9cde'/>
+        <global-address name='debug_noberserk'value='0x017f7ea2'/>
+        <global-address name='debug_turbospeed'value='0x00f9c9e3'/>
 
-        <global-address name='save_on_exit'/>
+        <global-address name='save_on_exit'value='0x017f7ec2'/>
 
         code
 
@@ -219,22 +219,22 @@
         generated standingorders
 
         <global-address name='standing_orders_mix_food' value='0x00f9303d'/>
-        <global-address name='standing_orders_gather_bodies' value='0x00f9303e'/>
-        <global-address name='standing_orders_gather_food' value='0x00f9303e'/>
-        <global-address name='standing_orders_gather_furniture' value='0x00f9303e'/>
-        <global-address name='standing_orders_gather_animals' value='0x00f9303e'/>
+        <global-address name='standing_orders_gather_bodies' value='0x00f93039'/>
+        <global-address name='standing_orders_gather_food' value='0x00f93030'/>
+        <global-address name='standing_orders_gather_furniture' value='0x00f9302f'/>
+        <global-address name='standing_orders_gather_animals' value='0x00f9302d'/>
         <global-address name='standing_orders_job_cancel_announce' value='0x00f9303e'/>
-        <global-address name='standing_orders_gather_wood' value='0x00f9303e'/>
-        <global-address name='standing_orders_gather_minerals' value='0x00f9303e'/>
+        <global-address name='standing_orders_gather_wood' value='0x00f93037'/>
+        <global-address name='standing_orders_gather_minerals' value='0x00f93031'/>
         <global-address name='standing_orders_farmer_harvest' value='0x00f9304c'/>
         <global-address name='standing_orders_gather_refuse' />
-        <global-address name='standing_orders_gather_refuse_outside' value='0x00f9302e'/>
-        <global-address name='standing_orders_dump_shells' value='0x012790b3'/>
-        <global-address name='standing_orders_dump_bones' value='0x012790b3'/>
-        <global-address name='standing_orders_dump_skulls' value='0x012790b3'/>
-        <global-address name='standing_orders_dump_skins' value='0x012790b3'/>
-        <global-address name='standing_orders_dump_hair' value='0x012790b3'/>
-        <global-address name='standing_orders_dump_other' value='0x012790b3'/>
+        <global-address name='standing_orders_gather_refuse_outside' value='0x012790b2'/>
+        <global-address name='standing_orders_dump_shells' value='0x017f7ec0'/>
+        <global-address name='standing_orders_dump_bones' value='0x017f7a56'/>
+        <global-address name='standing_orders_dump_skulls' value='0x017f762a'/>
+        <global-address name='standing_orders_dump_skins' value='0x017f7a57'/>
+        <global-address name='standing_orders_dump_hair' value='0x017f7ea1'/>
+        <global-address name='standing_orders_dump_other' value='0x017f7a5b'/>
         <global-address name='standing_orders_forbid_used_ammo' value='0x00f9304d'/>
         <global-address name='standing_orders_auto_smelter' value='0x00f9302c'/>
         <global-address name='standing_orders_auto_other' value='0x00f93032'/>


### PR DESCRIPTION
Update for win32 symbols based on my analysis.  Removed keydisplay since it crashes my df and I'm not familiar with the address.   

I am not familiar with testing and analysis tools used by the team so these have only been evaluated static code inspection between the 0.43.03 and 0.43.05 images.  

I offer the update in case it speeds up someone else's analysis.