### PR TITLE
Name two historical_kills fields and remove the skeletal flag

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -8,12 +8,11 @@
 
         <stl-vector name="killed_race" type-name='int16_t' ref-target='creature_raw'/>
         <stl-vector name="killed_caste" type-name='int16_t' ref-target='caste_raw' aux-value='$$._parent.killed_race[$._key]'/>
-        <stl-vector name="unk_30" type-name='int32_t' comment='-1'/>
-        <stl-vector name="unk_40" type-name='int32_t' comment='-1'/>
+        <stl-vector name="killed_underground_region" type-name='int32_t' ref-target='world_underground_region'/>
+        <stl-vector name="killed_region" type-name='int32_t' ref-target='world_region'/>
         <stl-vector name="killed_site" type-name='int32_t' ref-target='world_site'/>
         <stl-vector name="killed_undead">
             <bitfield base-type='uint16_t'>
-                <flag-bit name='skeletal'/>
                 <flag-bit name='zombie'/>
                 <flag-bit name='ghostly'/>
             </bitfield>


### PR DESCRIPTION
Just as `killed_site` is a list of site IDs where unimportant things were killed, `killed_underground_region` and `killed_region` are lists of underground region and region IDs.

The `skeletal` bit in `killed_undead` was a relic of old versions of the game where creatures could be skeletons or zombies. Zombies live on in the current night creature ark but skeletons are no more.