### PR TITLE
Expand show_menu from a bool to an enum

### DIFF
--- a/df.advmode.xml
+++ b/df.advmode.xml
@@ -364,7 +364,13 @@
             <enum-item name='MapSite'/>
             <enum-item name='MapWorld'/>
         </enum>
-        <bool name='show_menu' comment='bottom menu in travel mode'/>
+        <enum base-type='int8_t' name='show_menu' init-value='TwoRowsWithKeybindingHints' comment='bottom menu in travel mode'>
+            <enum-item name='TwoBlankRows' value='-1'/>
+            <enum-item name='Hidden'/>
+            <enum-item name='TwoRowsWithKeybindingHints'/>
+            <enum-item name='TwoRows'/>
+            <enum-item name='OneRow'/>
+        </enum>
         <stl-string name='message' comment='you must move from surrounding obstacles'/>
         <int16_t name='message_color'/>
         <int8_t name='message_brightness'/>


### PR DESCRIPTION
The `A_TRAVEL_HIDE_INSTRUCTIONS` key (default: h) cycles through the last four enum values. `TwoBlankRows` (or any unnamed value) reserves two rows below the map like `TwoRows` but leaves them blank. It does not occur in the vanilla game.