### PR TITLE
derate world.entities.unknown2.unk18 & .unk28

### DIFF
--- a/df.entities.xml
+++ b/df.entities.xml
@@ -749,7 +749,12 @@
             <int32_t name='unk16' comment='uninitialized'/>
             <int16_t name='unk17' comment='0'/>
 
-            <stl-vector name='unk18' type-name='pointer' comment='empty'/>
+            this was listed as a STL vector but it obviously is not since not later than 0.43.05
+            <int16_t name='unk18'/>
+            <int16_t name='unk18a'/>
+            <int32_t name='unk18b'/>
+            <pointer name='unk18c'/>
+            <pointer name='unk18d'/>
             <stl-vector name='unk19' type-name='pointer' comment='empty'/>
 
             <int16_t name='unk20' comment='0'/>
@@ -762,7 +767,11 @@
 
             <static-array name='unk26' count='177' type-name='int32_t' comment='Uninitialized'/>
 
-            <stl-vector name='unk28' type-name='pointer' comment='empty'/>
+            this was listed as a STL vector but obviously is not since not later than 0.43.05
+            <pointer name='unk28'/>
+            <pointer name='unk28a'/>
+            <pointer name='unk28b'/>
+
             <stl-vector name='unk29' type-name='pointer' since='v0.34.01'/>
         </compound>
     </struct-type>


### PR DESCRIPTION
Derating `unk18` and `unk28` in `world.entities.unknown` from STL-vector
because this is obviously not correct in 0.43.05 at least.

This should resolve the crash in DFHack/DFhack#1049