### PR TITLE
Found that skill.unk_1c is NATURAL_SKILL level

### DIFF
--- a/df.units.xml
+++ b/df.units.xml
@@ -1989,7 +1989,7 @@
         <int32_t name="rusty"/>
         <int32_t name="rust_counter"/>
         <int32_t name="demotion_counter"/>
-        <int32_t name="unk_1c"/>
+        <int32_t name="natural_skill_lvl" comment='This is the NATURAL_SKILL level for the caste in the raws. This skill cannot rust below this level.'/>
     </struct-type>
 
     <struct-type type-name='unit_preference'>


### PR DESCRIPTION
Discovered that skill.unk_1c equals NATURAL_SKILL in the creature's caste raws.  This was found while doing research into FPS loss due to excessive skill rust calculations in game. (Pro tip: Don't train 100+ dwarves in skills, and then let them social/idle for long periods of time.)