### PR TITLE
Identified entity.resources.organic.anon_1

### DIFF
--- a/df.entities.xml
+++ b/df.entities.xml
@@ -383,7 +383,7 @@
 
             <compound name='organic'>
                 <compound name='leather' type-name='material_vec_ref'/>
-                <compound type-name='material_vec_ref' since='v0.42.01'/>
+                <compound name='parchment' type-name='material_vec_ref' since='v0.42.01'/>
                 <compound name='fiber' type-name='material_vec_ref'/>
                 <compound name='silk' type-name='material_vec_ref'/>
                 <compound name='wool' type-name='material_vec_ref'/>


### PR DESCRIPTION
entity.resources.organic.anon_1 should be changed to entity.resources.organic.parchment
I found that anon_1 holds parchment material entries while researching how to modify parchment materials in a civilization for https://github.com/rndmvar/DFHack_scripts/blob/master/populate.rb