### PR TITLE
Add Parchment to DFHack::EntitySellCategory

### DIFF
--- a/df.entities.xml
+++ b/df.entities.xml
@@ -273,6 +273,7 @@
         <enum-item name='ThreadYarn'/>
         <enum-item name='Tools'/>
         <enum-item name='Clay'/>
+        <enum-item name='Parchment'/>
     </enum-type>
 
     <struct-type type-name='entity_sell_prices'>


### PR DESCRIPTION
Value 62 in DFHack::EntitySellCategory should be Parchment.  I've got working code at  the following link that allows for adding and removing creatures and their materials from the trade agreement, as well as the civilizations resources lists.  Currently it only runs on the latest DFHack version, as it requires the Ruby 2.0.0 interpreter shipped with it.
 https://github.com/rndmvar/DFHack_scripts/blob/master/populate.rb