### PR TITLE
Identify two squad_order_types

### DIFF
--- a/df.military.xml
+++ b/df.military.xml
@@ -210,6 +210,8 @@
         <enum-item name='TRAIN'/>
         <enum-item name='DRIVE_ENTITY_OFF_SITE'/>
         <enum-item name='CAUSE_TROUBLE_FOR_ENTITY'/>
+        <enum-item name='KILL_HF'/>
+        <enum-item name='DRIVE_ARMIES_FROM_SITE'/>
     </enum-type>
 
     <enum-type type-name='squad_order_cannot_reason'>


### PR DESCRIPTION
There are two corresponding classes, `squad_order_kill_hfst` and `squad_order_drive_armies_from_sitest`, but I don’t know how to investigate new classes.