### PR TITLE
Investigate cultural values and ethics

### DIFF
--- a/df.entities.xml
+++ b/df.entities.xml
@@ -482,8 +482,7 @@
                 <enum base-type='int16_t' type-name='ethic_response'/>
             </static-array>
 
-            <static-array name='values' type-name='int32_t' count='32' index-enum='value_type'/>
-            <static-array name='values_2' type-name='int32_t' count='32' index-enum='value_type' since='v0.42.01'/>
+            <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/>
 
             <int32_t since='v0.42.01'/>
             <static-array name='permitted_skill' type-name='bool' index-enum='job_skill' count='135'/>

--- a/df.entity-raws.xml
+++ b/df.entity-raws.xml
@@ -235,9 +235,7 @@
             <enum base-type='int16_t' type-name='ethic_response'/>
         </static-array>
 
-        <static-array name='values' type-name='int32_t' count='32' index-enum='value_type'/>
-
-        <static-array name='unk_v42_1' type-name='int32_t' count='32' since='v0.42.01'/>
+        <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/>
         <static-array name='unk_v42_2' type-name='int32_t' count='128' since='v0.42.01'/>
         <int32_t name='unk_v42_3' since='v0.42.01'/>
 

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -390,9 +390,10 @@
                 <int32_t name="unk_44" init-value='100'/>
             </pointer>
         </stl-vector>
-        <static-array name='unk_1c' count='22' type-name='int16_t'/>
-        <static-array name='unk_48' count='32' type-name='int32_t'/>
-        <static-array name='unk_v42_1' count='32' type-name='int32_t' since='v0.42.01'/>
+        <static-array name='ethic' count='22' index-enum='ethic_type'>
+            <enum base-type='int16_t' type-name='ethic_response'/>
+        </static-array>
+        <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/>
         <stl-vector name="unk_c8" pointer-type='entity_event'/>
         <int32_t name="unk_d8"/>
         <stl-vector name="unk_dc" type-name='int32_t'/>


### PR DESCRIPTION
Resolves #50.

There should probably be a test that the count of every static array is at least the number of values of its index enum, if it has one. For example, with the addition of `KNOWLEDGE` there are now 33 `value_type`s, so it no longer makes sense for a 32-element array to be indexed by `value_type`.