### PR TITLE
Location structures for scribe jobs and visitor reputation

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -83,7 +83,8 @@
             <int32_t name="unk_18"/>
             <int32_t name="unk_1c"/>
             <int32_t name="unk_34" since='v0.42.01'/>
-            <int32_t name="unk_38" since='v0.42.01'/>
+            <int16_t name="unk_38" since='v0.42.01'/>
+            <int16_t name="unk_3a" since='v0.42.01'/>
         </pointer>
 
         <pointer name="kills" type-name='historical_kills'/>
@@ -136,9 +137,9 @@
 <!--
             <stl-vector name='read_books' pointer-type='written_content'/>
 -->
-            <stl-vector name="unk_v4201_1" since='v0.42.01'/>
-            <stl-vector name="unk_v4201_2" since='v0.42.01'/>
-            <stl-vector name="unk_v4201_3" since='v0.42.01'/>
+            <stl-vector name="unk_v4201_1" type-name='int32_t' since='v0.42.01'/>
+            <stl-vector name="unk_v4201_2" type-name='int32_t' since='v0.42.01'/>
+            <stl-vector name="unk_v4201_3" type-name='int32_t' since='v0.42.01'/>
             <pointer name="knowledge">
                 <bitfield type-name='knowledge_scholar_flags_0' name='philosophy'/>
                 <bitfield type-name='knowledge_scholar_flags_1' name='philosophy2'/>

--- a/df.meeting.xml
+++ b/df.meeting.xml
@@ -334,7 +334,8 @@
             <pointer>
                 <int32_t/>
                 <int32_t init-value='-1'/>
-                <int32_t name='item_id' ref-target='item' init-value='-1'/>
+                <int32_t name='item_id' ref-target='item' init-value='-1'
+                         comment='is unit ID for writing jobs'/>
                 <int32_t init-value='0'/>
             </pointer>
         </stl-vector>
@@ -862,15 +863,26 @@
     </class-type>
 
     <class-type type-name='activity_event_copy_written_contentst' inherits-from='activity_event'>
-        <int32_t name='histfig_id' ref-target='historical_figure'/>
         <int32_t name='unit_id' ref-target='unit'/>
+        <int32_t name='histfig_id' ref-target='historical_figure'/>
+        <int32_t name='occupation_id'/>
+        <int32_t name='building_id'/>
+        <int32_t name='site_id'/>
+        <int32_t name='location_id'/>
+        <bitfield name='flagsmaybe'>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+        </bitfield>
         <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='timer'/>
     </class-type>
 
     <class-type type-name='activity_event_teach_topicst' inherits-from='activity_event'>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -1,4 +1,57 @@
 <data-definition>
+    <struct-type type-name='scribejob'>
+        <int32_t name='idmaybe'/>
+        <int32_t comment='not locationid'/>
+        <int32_t name='item_id'/>
+        <int32_t name='written_content_id'/>
+        <int32_t name='unit_id'/>
+        <int32_t name='activity_entry_id'/>
+        <int32_t/>
+        <int16_t/>
+        <int16_t name='locationmaybe'/>
+    </struct-type>
+
+    <struct-type type-name='site_reputation_report'>
+        <int32_t name='site_id'/>
+        <int32_t name='location_id'/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t name='year'/>
+        <int32_t name='tickmaybe'/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+        <int16_t/>
+        <int16_t/>
+        <bitfield-type>
+            <flag-bit/>
+        </bitfield-type>
+    </struct-type>
+
+    <struct-type type-name='site_reputation_info'>
+        <stl-vector pointer-type='site_reputation_report'/>
+        <int16_t/>
+        <int16_t/>
+        <int16_t/>
+        <int16_t/>
+    </struct-type>
+
+    <struct-type type-name='location_scribe_jobs'>
+        <stl-vector name='scribejobs' pointer-type='scribejob'/>
+        <int32_t name='nextidmaybe'/>
+        <int32_t name='year'/>
+        <uint16_t/>
+        <int16_t/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+    </struct-type>
+
     <enum-type type-name='abstract_building_type'>
         <enum-item name='MEAD_HALL'/>
         <enum-item name='KEEP'/>
@@ -80,8 +133,8 @@
         <int32_t name='unk3'/>
         <stl-vector name='unk4' type-name='int32_t'/>
         <int32_t name='site_owner_id' ref-target='historical_entity'/>
-        <pointer name='unk_v42_1' since='v0.42.01'/>
-        <pointer name='unk_v42_2' since='v0.42.01'/>
+        <pointer name='scribeinfo' since='v0.42.01' type-name='location_scribe_jobs'/>
+        <pointer name='reputation_reports' since='v0.42.01' type-name='site_reputation_info'/>
         <pointer name='unk_v42_3' since='v0.42.01'/>
         <int32_t name='site_id' ref-target='world_site'
                  comment='not initialized/saved/loaded, assumed member of base class'/>


### PR DESCRIPTION
These commits identify the purpose of two previously-unknown parts of the location information. The first is a list of scribing jobs to be performed at the location; the commit identifies almost all of the fields involved. This is important for fixing library bugs. The second turns out to be a list of visitor reports/reputation -- several of the fields seem to have larger values for "better" locations, but I haven't identified the specifics yet. They may identify things like the number of musical performances, poetic performances, etc. the person witnessed, the value of the location, the presence of alcoholic drinks, etc. (Note that these reports appear several in-game weeks after the visitor has originally departed your site -- presumably when the historical figure finishes their journey back to civilization.)