### PR TITLE
Identify some plant_raw fields

### DIFF
--- a/df.plant-raws.xml
+++ b/df.plant-raws.xml
@@ -103,7 +103,7 @@
     <struct-type type-name='plant_raw' instance-vector='$global.world.raws.plants.all'>
         <stl-string name='id'/>
 
-        <int32_t since='v0.40.01'/>
+        <int32_t name='index' since='v0.40.01'/>
         <stl-vector since='v0.40.01'/>
 
         <code-helper name='describe'>$.id</code-helper>
@@ -228,8 +228,13 @@
         <int32_t name='root_density'/>
         <int32_t name='root_radius'/>
 
-        <stl-vector/>
-        <stl-vector/>
+        <stl-vector name='stockpile_growths' type-name='int32_t' refers-to='$$._parent._parent.growths[$]' comment='indices of edible growths that are marked with STOCKPILE_PLANT_GROWTH'/>
+        <stl-vector name='stockpile_growth_flags' index-refers-to='$$._parent.stockpile_growths[$].refers-to'>
+            <bitfield>
+                <flag-bit name='EDIBLE_RAW'/>
+                <flag-bit name='EDIBLE_COOKED'/>
+            </bitfield>
+        </stl-vector>
     </struct-type>
 
     <struct-type type-name='plant_growth'>


### PR DESCRIPTION
`index` is the index of the `plant_raw` in the instance vector, as reported in #195. I could have added `key-field='index'` to the struct definition but chose not to, because `df.plant_raw.find` already works, so changing it to use binary search is unnecessary.

`stockpile_growths` is a vector of indices into `growths` corresponding to growths that are marked with `[STOCKPILE_PLANT_GROWTH]` and also `[EDIBLE_RAW]` or `[EDIBLE_COOKED]`. Inedible growths do not go in food stockpiles, so the former tag alone does not qualify a growth for this vector.

`stockpile_growth_flags` is a vector of bitfields associated with the growths identified by `stockpile_growths`. Each bitfield reports whether the growth is edible raw or cooked. Inedible growths are not listed in this vector so the bitfield is never 0.