### PR TITLE
Identify the change log of a culture's membership

### DIFF
--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -385,19 +385,23 @@
         <int32_t name="id"/>
         <int32_t name="site_id" ref-target='world_site'/>
         <int32_t name="civ_id" ref-target='historical_entity'/>
-        <stl-vector name="unk_c">
+        <stl-vector name='group_log' comment='the circumstances of groups joining or leaving this culture'>
             <pointer>
                 <int32_t name="group_id" ref-target='historical_entity'/>
-                <int32_t name="unk_4" init-value='-1'/>
-                <int32_t name="unk_8" init-value='-1'/>
-                <int32_t name="unk_c" init-value='-1'/>
-                <int32_t name="unk_10" init-value='-1'/>
-                <int32_t name="unk_14" init-value='-1'/>
-                <int32_t name="unk_18" init-value='-1'/>
-                <int32_t name="unk_1c"/>
+                <int32_t name='start_year' init-value='-1' comment='when the group joined the culture, or -1 if it founded the culture'/>
+                <int32_t name='start_tick' init-value='-1'/>
+                <int32_t name='end_year' init-value='-1' comment='when the group left the culture, or -1 if it has not left'/>
+                <int32_t name='end_tick' init-value='-1'/>
+                <int32_t name='unk_14' init-value='-1' comment='copy of start_year'/>
+                <int32_t name='unk_18' init-value='-1' comment='copy of start_tick'/>
+                <enum name='join_type'>
+                    <enum-item name='Peaceful'/>
+                    <enum-item name='CompleteTakeOver' comment='The previous group left the culture.'/>
+                    <enum-item name='TakeOver' comment="The previous group's end_year is still -1."/>
+                </enum>
                 <int32_t name="unk_20"/>
                 <stl-vector name="unk_24" type-name="int32_t"/>
-                <stl-vector name="unk_34" type-name="int32_t"/>
+                <stl-vector name='unk_34' type-name='int32_t' comment='same length as unk_24; elements always sum to 10000'/>
                 <int32_t name="unk_44" init-value='100'/>
             </pointer>
         </stl-vector>
@@ -405,12 +409,12 @@
             <enum base-type='int16_t' type-name='ethic_response'/>
         </static-array>
         <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/>
-        <stl-vector name="unk_c8" pointer-type='entity_event'/>
-        <int32_t name="unk_d8"/>
+        <stl-vector name='events' pointer-type='entity_event'/>
+        <int32_t name='unk_d8' init-value='-1'/>
         <stl-vector name="unk_dc" type-name='int32_t'/>
-        <int32_t name="unk_ec"/>
-        <int32_t name="unk_f0"/>
-        <int32_t name="unk_f4"/>
+        <int32_t name='unk_ec' init-value='-1'/>
+        <int32_t name='unk_f0' init-value='-1'/>
+        <int32_t name='unk_f4' comment='0 or 800000'/>
         <int32_t name="unk_f8"/>
     </struct-type>
 


### PR DESCRIPTION
`group_log` lists every change to the list of entities associated with the cultural identity.

`unk_24` and `unk_34` go together but I couldn’t figure out what they do. They look like {4,5,6} / {2000,6000,2000}. There always three elements, except for some which are {3} / {10000}. `unk_24` can also be {0,1,2}. The elements of `unk_34` always sum to 10000. I assume they are proportions.

Some mountain halls’ cultural identities have an `unk_f4` of 800000. All other cultural identities have 0.