### PR TITLE
Identify the decade for historical maps

### DIFF
--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -1399,7 +1399,7 @@
         <int16_t name='map_y'/>
         <int16_t name='hide_territories'/>
         <int16_t name='civ_site_mode'/>
-        <int16_t/>
+        <int16_t name='decade'/>
         <stl-string name='filter_text'/>
         <int8_t name='filter_editing'/>
         <stl-vector type-name='int32_t' comment='index into histfigs'/>


### PR DESCRIPTION
`decade` is the year of the historical map in legends mode divided by 10. Exceptionally, a `decade` of 0 is displayed as the year 1.