### PR TITLE
Identify some reputation fields

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -200,8 +200,43 @@
             <stl-vector name="wanted">
                 <pointer>
                     <int32_t name='entity_id' ref-target='historical_entity'/>
-                    <stl-vector type-name='int32_t'/>
-                    <stl-vector type-name='int32_t'/>
+                    <stl-vector name='types'>
+                        <enum base-type='int32_t'>
+                            0
+                            <enum-item name='Hero'/>
+                            <enum-item/>
+                            <enum-item/>
+                            <enum-item/>
+                            <enum-item name='Brawler'/>
+                            <enum-item name='Villain'/>
+                            <enum-item/>
+                            <enum-item/>
+                            <enum-item name='Killer'/>
+                            <enum-item name='Murderer'/>
+
+                            10
+                            <enum-item/>
+                            <enum-item/>
+                            <enum-item/>
+                            <enum-item name='EnemyFighter'/>
+                            <enum-item name='Fighter'/>
+                            <enum-item name='Bully'/>
+                            <enum-item name='Brigand'/>
+                            <enum-item name='LoyalSoldier'/>
+                            <enum-item name='Monster'/>
+                            <enum-item/>
+
+                            20
+                            <enum-item/>
+                            <enum-item/>
+                            <enum-item/>
+                            <enum-item/>
+                            <enum-item/>
+                            <enum-item name='Hunter'/>
+                            <enum-item name='ProtectorOfTheWeak'/>
+                        </enum>
+                    </stl-vector>
+                    <stl-vector name='levels' type-name='int32_t' comment='1 to 100: rumored to legendary'/>
                     <int32_t name="discovered_year"/>
                     <int32_t name="discovered_time"/>
                     <int32_t name="unsolved_murders"/>
@@ -219,7 +254,7 @@
             </stl-vector>
             <int32_t name="cur_identity" ref-target='identity'/>
             <stl-vector name="all_identities" type-name='int32_t' ref-target='identity'/>
-            <int32_t/>
+            <int32_t name='next_identity_idx'/>
         </pointer>
 
         <pointer name='relationships'>

--- a/df.history.xml
+++ b/df.history.xml
@@ -204,36 +204,36 @@
                         <enum base-type='int32_t'>
                             0
                             <enum-item name='Hero'/>
-                            <enum-item/>
-                            <enum-item/>
-                            <enum-item/>
-                            <enum-item name='Brawler'/>
-                            <enum-item name='Villain'/>
-                            <enum-item/>
-                            <enum-item/>
+                            <enum-item name='Buddy'/>
+                            <enum-item name='Grudge'/>
+                            <enum-item name='Bonded'/>
+                            <enum-item name='Violent'/>
+                            <enum-item name='Psychopath'/>
+                            <enum-item name='TradePartner'/>
+                            <enum-item name='Friendly'/>
                             <enum-item name='Killer'/>
                             <enum-item name='Murderer'/>
 
                             10
-                            <enum-item/>
-                            <enum-item/>
-                            <enum-item/>
+                            <enum-item name='Comrade'/>
+                            <enum-item name='RespectedGroup'/>
+                            <enum-item name='HatedGroup'/>
                             <enum-item name='EnemyFighter'/>
-                            <enum-item name='Fighter'/>
+                            <enum-item name='FriendlyFighter'/>
                             <enum-item name='Bully'/>
                             <enum-item name='Brigand'/>
                             <enum-item name='LoyalSoldier'/>
                             <enum-item name='Monster'/>
-                            <enum-item/>
+                            <enum-item name='Storyteller'/>
 
                             20
-                            <enum-item/>
-                            <enum-item/>
-                            <enum-item/>
-                            <enum-item/>
-                            <enum-item/>
+                            <enum-item name='Poet'/>
+                            <enum-item name='Bard'/>
+                            <enum-item name='Dancer'/>
+                            <enum-item name='Quarreler'/>
+                            <enum-item name='Flatterer'/>
                             <enum-item name='Hunter'/>
-                            <enum-item name='ProtectorOfTheWeak'/>
+                            <enum-item name='ProtectorOfWeak'/>
                         </enum>
                     </stl-vector>
                     <stl-vector name='levels' type-name='int32_t' comment='1 to 100: rumored to legendary'/>


### PR DESCRIPTION
The new enum is related to `unit_relationship_type`. The enum values given names are those for which strings appear in legends mode. 20 and 21 are attested and are probably `Poet` and `Bard` but I couldn’t verify that.