### PR TITLE
fix bitfield-type used as a nested bitfield

### DIFF
--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -28,9 +28,9 @@
         <int32_t/>
         <int16_t/>
         <int16_t/>
-        <bitfield-type>
+        <bitfield>
             <flag-bit/>
-        </bitfield-type>
+        </bitfield>
     </struct-type>
 
     <struct-type type-name='site_reputation_info'>


### PR DESCRIPTION
This one is annoying me when I try to use the structures xml. If I read the documentation correctly, this is a typo.