### PR TITLE
Corrected named fields: Were one field off

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -311,12 +311,12 @@
                 <pointer>
                     <int32_t name='histfig_id' ref-target='historical_figure'/>
                     <int32_t/>
+                    <stl-vector type-name='int32_t'/>
                     <stl-vector name="attitude">
                         <enum type-name='reputation_type' comment="Probably ordered"/>
                     </stl-vector>
                     <stl-vector name="counter" type-name='int32_t' comment="One element for each 'attitude' element"/>
-                    <stl-vector name="rank" type-name='int32_t'/>
-                    <int32_t/>
+                    <int32_t name="rank"/>
                     <int32_t name='year'/>
                     <int32_t name='year_tick'/>
                 </pointer>


### PR DESCRIPTION
I screwed up when when naming the fields, causing the fields to be one field off. The original anon_2 is still unidentified and should end up as anon_2 again, while the original anon_5 should be "rank", not anon_2.