### PR TITLE
Add hex values to df enums

### DIFF
--- a/Enum.pm
+++ b/Enum.pm
@@ -58,8 +58,17 @@ sub render_enum_core($$) {
             $count++;
             $last_value = $real_value;
 
+            my $value_out = '';
+            if (defined $value) {
+                $value_out = ' = '.$value;
+            } elsif ($real_value < 0) {
+                $value_out = ' = '.$real_value;
+            } elsif ($real_value >= 0) {
+                $value_out = sprintf(' = 0x%X',$real_value);
+            }
+
             emit_comment $item, -attr => 1;
-            emit $name, (defined($value) ? ' = '.$value : ''), ',';
+            emit $name, $value_out, ',';
         }
 
         $lines[-1] =~ s/,$//;

--- a/Enum.pm
+++ b/Enum.pm
@@ -58,17 +58,10 @@ sub render_enum_core($$) {
             $count++;
             $last_value = $real_value;
 
-            my $value_out = '';
-            if (defined $value) {
-                $value_out = ' = '.$value;
-            } elsif ($real_value < 0) {
-                $value_out = ' = '.$real_value;
-            } elsif ($real_value >= 0) {
-                $value_out = sprintf(' = 0x%X',$real_value);
-            }
+            my $value_comment = sprintf(' // %d, 0x%X',$real_value, $real_value);
 
             emit_comment $item, -attr => 1;
-            emit $name, $value_out, ',';
+            emit $name, (defined($value)? ' = '.$value : ''), ','.$value_comment;
         }
 
         $lines[-1] =~ s/,$//;


### PR DESCRIPTION
Seeing enum values in header makes it easier to match those values to
dissambler numbers. This helps me with both gdb and IDA. IDA has descent
suppot for offsets and constands but it requires manual setup. To help
matching values manually I like to browser headers in my source editor
because it is the fastest tool to find types and variables.