### PR TITLE
Fix offset of item_body_component->corpse_flags

### DIFF
--- a/df.items.xml
+++ b/df.items.xml
@@ -890,7 +890,7 @@
         </bitfield>
 
         <int32_t name='unit_id2' ref-target='unit'/>
-        <int32_t since='v0.34.01' comment='actual offset unknown'/>
+        <int32_t name='unk_3401' since='v0.34.01'/>
 
         <static-array name='material_amount' type-name='int32_t'
                       count='19' index-enum='corpse_material_type'/>

--- a/df.items.xml
+++ b/df.items.xml
@@ -868,8 +868,6 @@
         <int32_t name="stored_fat"/>
 
         <int32_t name='hist_figure_id2' ref-target='historical_figure'/>
-        <int32_t since='v0.34.01' comment='actual offset unknown'/>
-        <int32_t name='unit_id2' ref-target='unit'/>
 
         <bitfield name='corpse_flags'>
             <flag-bit name='unbutchered'/>
@@ -890,6 +888,9 @@
             <flag-bit name='hair_wool'/>
             <flag-bit name='yarn'/>
         </bitfield>
+
+        <int32_t name='unit_id2' ref-target='unit'/>
+        <int32_t since='v0.34.01' comment='actual offset unknown'/>
 
         <static-array name='material_amount' type-name='int32_t'
                       count='19' index-enum='corpse_material_type'/>


### PR DESCRIPTION
I noticed that anon_1 was mapping to a bitfield. It became quickly
clear that the bitfield is corpse_flags. After checking that unit_id2 is
actually used I decided to swap anon_1 and corpse_flags offsets.