### PR TITLE
df::creature_raw offset fix

### DIFF
--- a/df.creature-raws.xml
+++ b/df.creature-raws.xml
@@ -1238,6 +1238,10 @@
             <stl-vector name='appointments' pointer-type='creature_graphics_appointment'/>
         </compound>
 
+        <static-array type-name='int32_t' count='7' name='unk_v44_11a' since='v0.44.11'/>
+        <static-array type-name='int32_t' count='6' name='unk_v44_11b' since='v0.44.11'
+            comment='Padding should go before. What type is unk_v44_11b?'/>
+
         <stl-vector name='speech1' type-name='int8_t'/>
         <stl-vector name='speech2' type-name='int32_t'/>
         <stl-vector name='speech3'/>
@@ -1246,8 +1250,8 @@
         <stl-vector name='tissue' pointer-type='tissue'/>
 
         <compound name='profession_name'>
-            <static-array type-name='stl-string' name='singular' count='134' index-enum='profession'/>
-            <static-array type-name='stl-string' name='plural' count='134' index-enum='profession'/>
+            <static-array type-name='stl-string' name='singular' count='135' index-enum='profession'/>
+            <static-array type-name='stl-string' name='plural' count='135' index-enum='profession'/>
         </compound>
 
         <int32_t name='underground_layer_min'/>


### PR DESCRIPTION
There is a new profession but I don't know name for it (yet).
13 unknown ints with padding after 7th in 64bit system. 32bit
system has all 13 ints without padding.

It is possible that there is more new entries after profession_name because I only quickly glanced for obvious offset issue but I didn't notice any.