### PR TITLE
sync ui_sidebar_menus.command_line with g_src

### DIFF
--- a/df.ui-menus.xml
+++ b/df.ui-menus.xml
@@ -430,15 +430,15 @@
         </compound>
 
         <compound name='command_line'>
-            <stl-string name='raw'/>
-            <stl-vector name='argv' pointer-type='stl-string'/>
+            <stl-string name='original'/>
+            <stl-vector name='arg_vect' pointer-type='stl-string'/>
 
-            <long name="world_id"/>
+            <long name="gen_id"/>
             <long name="world_seed"/>
-            <bool name="in_worldgen"/>
+            <bool name="use_seed"/>
 
-            <stl-string name='worldgen_param_set'/>
-            <int8_t name="unk_17d0"/>
+            <stl-string name='world_param'/>
+            <int8_t name="use_param"/>
         </compound>
         <int32_t name="num_speech_tokens"/>
         <int8_t name="unk_17d8"/>


### PR DESCRIPTION
DFHack's `core.cpp` will need to be updated to refer to `df::global::ui_sidebar_menus->command_line.original` instead of `df::global::ui_sidebar_menus->command_line.raw`.