### PR TITLE
Add header dependencies

### DIFF
--- a/Bitfield.pm
+++ b/Bitfield.pm
@@ -94,6 +94,8 @@ sub render_bitfield_core {
             emit "static bitfield_identity identity;";
             emit "static bitfield_identity *get() { return &identity; }";
         } "template<> struct ${export_prefix}identity_$traits_name ", ";";
+        header_ref("Export.h");
+        header_ref("DataDefs.h");
     };
 
     with_emit_static {

--- a/Common.pm
+++ b/Common.pm
@@ -204,6 +204,9 @@ sub get_primitive_base($;$) {
     my ($tag, $default) = @_;
 
     my $base = $tag->getAttribute('base-type') || $default || 'uint32_t';
+    if ($base =~ /u?int[136]?[2468]_t/) {
+        header_ref("cstdint");
+    }
     $primitive_types{$base} or die "Must be primitive: $base\n";
 
     return $base;

--- a/Common.pm
+++ b/Common.pm
@@ -310,8 +310,7 @@ sub with_header_file(&$) {
     # Add wrapping
     my @all = with_emit {
         my $def = type_header_def($header_name);
-        emit "#ifndef $def";
-        emit "#define $def";
+        emit "#pragma once";
         emit "#ifdef __GNUC__";
         emit "#pragma GCC system_header";
         emit "#endif";
@@ -321,10 +320,7 @@ sub with_header_file(&$) {
         }
 
         for my $strong (sort { $a cmp $b } keys %strong_refs) {
-            my $sdef = type_header_def($strong);
-            emit "#ifndef $sdef";
             emit "#include \"$strong.h\"";
-            emit "#endif";
         }
 
         emit_block {
@@ -341,8 +337,6 @@ sub with_header_file(&$) {
 
             push @lines, @code;
         } "namespace $main_namespace ";
-
-        emit "#endif";
     };
 
     $header_data{$header_name} = \@all;

--- a/Enum.pm
+++ b/Enum.pm
@@ -91,6 +91,8 @@ sub render_enum_tables($$$$$$) {
             emit "static enum_identity identity;";
             emit "static enum_identity *get() { return &identity; }";
         } "template<> struct ${export_prefix}identity_$traits_name ", ";";
+        header_ref("Export.h");
+        header_ref("DataDefs.h");
     };
 
     # Enumerate enum attributes

--- a/StructFields.pm
+++ b/StructFields.pm
@@ -39,6 +39,8 @@ sub with_struct_block(&$;$%) {
     my $is_union = is_attr_true($tag,'is-union');
     my $kwd = ($is_union ? "union" : "struct");
     my $exp = $export_prefix; #$flags{-export} ? $export_prefix : '';
+    header_ref("Export.h");
+    header_ref("DataDefs.h");
     my $prefix = $kwd.' '.$exp.($name ? $name.' ' : '');
 
     emit_comment $tag, -attr => 1;

--- a/StructFields.pm
+++ b/StructFields.pm
@@ -92,8 +92,8 @@ our $cur_init_value = undef;
 sub add_simple_init($);
 
 my %custom_primitive_handlers = (
-    'stl-string' => sub { return "std::string"; },
-    'stl-fstream' => sub { return "std::fstream"; },
+    'stl-string' => sub { header_ref("string"); return "std::string"; },
+    'stl-fstream' => sub { header_ref("fstream"); return "std::fstream"; },
 );
 
 my %custom_primitive_inits = (
@@ -110,17 +110,21 @@ my %custom_container_handlers = (
     'stl-vector' => sub {
         my $item = get_container_item_type($_, -void => 'void*');
         $item = 'char' if $item eq 'bool';
+        header_ref("vector");
         return "std::vector<$item >";
     },
     'stl-deque' => sub {
         my $item = get_container_item_type($_, -void => 'void*');
+        header_ref("deque");
         return "std::deque<$item >";
     },
     'stl-set' => sub {
         my $item = get_container_item_type($_, -void => 'void*');
+        header_ref("set");
         return "std::set<$item >";
     },
     'stl-bit-vector' => sub {
+        header_ref("vector");
         return "std::vector<bool>";
     },
     'df-flagarray' => sub {
@@ -415,6 +419,7 @@ sub render_field_metadata_rec($$) {
     local $_;
     local %weak_refs;
     local %strong_refs;
+    local %header_refs;
 
     my $meta = $field->getAttribute('ld:meta');
     my $subtype = $field->getAttribute('ld:subtype');

--- a/StructType.pm
+++ b/StructType.pm
@@ -198,7 +198,12 @@ sub render_struct_type {
     my $ispec = '';
 
     for my $extra ($tag->findnodes('extra-include')) {
-        register_ref $extra->getAttribute('type-name'), 1;
+        my $tname = $extra->getAttribute('type-name');
+        if ($tname) {
+            register_ref $tname, 1;
+        } else {
+            header_ref $extra->getAttribute('filename');
+        }
     }
 
     if ($inherits) {

--- a/codegen.pl
+++ b/codegen.pl
@@ -96,6 +96,7 @@ with_header_file {
                     my $prefix = get_container_item_type($tag, -weak => 1, -void => 'void');
                     emit_comment $tag;
                     emit 'extern ', $export_prefix, $prefix, ' *', $name, ';', get_comment($tag);
+                    header_ref("Export.h");
 
                     push @items, [ $prefix, $name ];
                     push @fields, $tag->findnodes('ld:item');

--- a/df.graphics.xml
+++ b/df.graphics.xml
@@ -92,6 +92,7 @@
     </enum-type>
 
     <class-type type-name='enabler' original-name='enablerst' custom-methods='true'>
+        <extra-include filename='Hooks.h'/>
         <bool name='fullscreen'/>
 
         <stl-deque name='overridden_grid_sizes'>


### PR DESCRIPTION
Support header dependecies

This allows removing Core.h include from DataDefs.h.

Include all dependecies in df headers

Include all dependecies in df headers  …
This allows including df/*.h without including any dependecies first. It
also helps ycm error reporting to avoid wrong errors when opening
headers when it tries to compile header as c++ source file.