### PR TITLE
Add 0.44.12 unknown member variables to ui.squads

### DIFF
--- a/df.ui.xml
+++ b/df.ui.xml
@@ -577,6 +577,19 @@
                         comment='valid only when ui is displayed' pointer-type='squad'/>
 
             <stl-vector name='unk6e08'/>
+            <stl-vector name='unk_44_12a' since='v0.44.12'/>
+
+            <pointer name='unk_44_12b' since='v0.44.12' init-value='0'/>
+
+            <int32_t name='unk_44_12c' init-value='-1' since='v0.44.12'/>
+            <int32_t name='unk_44_12d' init-value='-1' since='v0.44.12'/>
+
+            <bool name='unk_44_12e' since='v0.44.12'/>
+            <int32_t name='unk_44_12f' since='v0.44.12' comment='Not vissible in initial xrefs'/>
+            <int16_t name='unk_44_12g' since='v0.44.12'/>
+            <bool name='unk_44_12h' since='v0.44.12'/>
+            <stl-vector name='unk_44_12i' since='v0.44.12'/>
+            <stl-vector name='unk_44_12j' since='v0.44.12'/>
 
             <stl-bit-vector name='sel_squads' index-refers-to='$$._parent.list[$]'/>
 


### PR DESCRIPTION
I mapped both structures in ida using. unk_44_12f isn't visible in initial xrefs. Finding it an verifying its sizes would take a bit longer. But padding before it strongly suggest that there must be 4byte value in 32bit and 64bit systems (unless there is a structure border)