### PR TITLE
Fix ui->squads.list being misidentified.

### DIFF
--- a/df.ui.xml
+++ b/df.ui.xml
@@ -573,8 +573,7 @@
         </compound>
 
         <compound name='squads'>
-            <stl-vector name='list' has-bad-pointers='true'
-                        comment='valid only when ui is displayed' pointer-type='squad'/>
+            <stl-vector name='unk_44_12'/>
 
             <stl-vector name='unk6e08'/>
             <stl-vector name='unk_44_12a' since='v0.44.12'/>
@@ -588,7 +587,8 @@
             <int32_t name='unk_44_12f' since='v0.44.12' comment='Not vissible in initial xrefs'/>
             <int16_t name='unk_44_12g' since='v0.44.12'/>
             <bool name='unk_44_12h' since='v0.44.12'/>
-            <stl-vector name='unk_44_12i' since='v0.44.12'/>
+            <stl-vector name='list' has-bad-pointers='true'
+                        comment='valid only when ui is displayed' pointer-type='squad'/>
             <stl-vector name='unk_44_12j' since='v0.44.12'/>
 
             <stl-bit-vector name='sel_squads' index-refers-to='$$._parent.list[$]'/>
@@ -602,7 +602,7 @@
             <int32_t name='unk_70'/>
             <int32_t name='unk_74'/>
 
-            <int32_t name='unk48'/>
+            <int32_t name='first_visible_squad' ref-target='squad'/>
             <pointer name='unk4c' type-name='squad'/>
 
             <bool name='in_move_order'/>
@@ -617,7 +617,7 @@
             <bool name='in_kill_list'/>
             <stl-vector name='kill_targets' pointer-type='unit'/>
             <stl-bit-vector name='sel_kill_targets' index-refers-to='$$._parent.kill_target[$]'/>
-            <int32_t name='unk_f0'/>
+            <int32_t name='first_visible_kill_target' refers-to='$$._parent.kill_target[$]'/>
 
             <bool name='in_kill_rect'/>
             <compound name='rect_start' type-name='coord'/>


### PR DESCRIPTION
Also name the fields that df-ai uses to determine which squad and kill target are first in the list.

See BenLubar/df-ai#52.