### PR TITLE
Named fields related to art and belief systems

### DIFF
--- a/df.art.xml
+++ b/df.art.xml
@@ -459,8 +459,8 @@
     <struct-type type-name='musical_form' instance-vector='$global.world.musical_forms.all' key-field='id'>
         <int32_t name='id'/>
         <compound name='name' type-name='language_name'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name="originating_entity" ref-target="historical_entity" comment="ID of the entity from which the musical form originated."/>
+        <int32_t name="original_author" ref-target="historical_figure" comment="historical figure ID of the composer"/>
         <stl-vector pointer-type='musical_form_sub1'/>
         <stl-vector name='voices' pointer-type='musical_form_instruments'/>
         <stl-vector pointer-type='musical_form_sub3'/>
@@ -547,8 +547,8 @@
         <int32_t name='musical_form_id'/>
         <int32_t name='music_written_content_id'  ref-target='written_content' comment='at most one of this and musical_form_id is non null'/>
         <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name="originating_entity" ref-target="historical_entity" comment="ID of the entity from which the dance form originated."/>
+        <int32_t name="original_author" ref-target="historical_figure" comment="ID of the historical figure who developed the dance form."/>
         <int32_t/>
         <int32_t/>
         <int32_t/>

--- a/df.entities.xml
+++ b/df.entities.xml
@@ -491,7 +491,7 @@
             <stl-vector name='unk32a' type-name='int32_t'/>
             <stl-vector name='deities' type-name='int32_t' ref_target='historical_figure'/>
             <stl-vector name='worship' type-name='int32_t' comment="Same length as deities(?). Some kind of relationship strength?"/>
-            <stl-vector name='unk32d' type-name='int32_t'/>
+            <stl-vector name='belief_systems' type-name='int32_t' ref-target="belief_system" comment="In Religion type entities established by prophets after having developed their own belief system, the ID of this belief system is contained here."/>
             <stl-vector name='unk32e'>
                 <pointer>
                     <stl-vector type-name='int16_t'/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -149,7 +149,7 @@
         <pointer name='secret' since='v0.34.01'>
             <stl-vector name="interactions" pointer-type='interaction'/>
             <int32_t name="unk_10"/>
-            <stl-vector name='read_books' type-name='int32_t' refers-to='$global.world.written_contents.all[$].type $global.world.written_contents.all[$].title'/>
+            <stl-vector name='known_written_contents' type-name='int32_t' ref-target='written_content' comment="ID of written_contents known to the historical figure. Aside from the contents of read books, these so-called written contents also include known derivations of poetic forms, dance forms and musical forms"/>
             <stl-vector name="known_identities" type-name='int32_t' ref-target='identity' comment="identity ID of identities known to the historical figure, such as demon true names"/>
             <stl-vector>
                 <pointer>

--- a/df.history.xml
+++ b/df.history.xml
@@ -179,9 +179,9 @@
 <!--
             <stl-vector name='read_books' pointer-type='written_content'/>
 -->
-            <stl-vector name="unk_v4201_1" type-name='int32_t' since='v0.42.01'/>
-            <stl-vector name="unk_v4201_2" type-name='int32_t' since='v0.42.01'/>
-            <stl-vector name="unk_v4201_3" type-name='int32_t' since='v0.42.01'/>
+            <stl-vector name="known_poetic_forms" type-name='int32_t' ref-target='poetic_form' since='v0.42.01'/>
+            <stl-vector name="known_musical_forms" type-name='int32_t' ref-target='musical_form' since='v0.42.01'/>
+            <stl-vector name="known_dance_forms" type-name='int32_t' ref-target='dance_form' since='v0.42.01'/>
             <pointer name="knowledge">
                 <bitfield type-name='knowledge_scholar_flags_0' name='philosophy'/>
                 <bitfield type-name='knowledge_scholar_flags_1' name='philosophy2'/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -115,7 +115,7 @@
             <int32_t name="site" ref-target='world_site'/>
             <int32_t name="region_id" ref-target='world_region'/>
             <int32_t name="beast_id" init-value='-1' comment='for FB'/>
-            <int32_t/>
+            <int32_t name="army_id" ref-target='army'/>
             <int32_t/>
             <int32_t/>
             <int32_t/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -208,8 +208,8 @@
                 <uint32_t name='research_points' comment='research is finished at 100k? amount gained depends on skills, attributes'/>
                 <uint16_t name='times_pondered' comment='one per ponder no matter what. turns into research_points somewhere around 40-60.'/>
             </pointer>
-            <pointer name='unk_a4'>
-                <stl-vector type-name='int32_t'/>
+            <pointer name='belief_systems' comment="found in prophets; contains the ID of the belief system developed by that particular prophet">
+                <stl-vector type-name='int32_t' ref-target='belief_system'/>
             </pointer>
             <pointer name='unk_a8'>
                 <stl-vector>

--- a/df.military.xml
+++ b/df.military.xml
@@ -586,8 +586,8 @@
                 <int32_t name="nemesis_id" init-value='-1'/>
                 <int32_t name="hunger_timer"/>
                 <int32_t name="thirst_timer"/>
+                <int32_t name="sleepiness_timer"/>
                 <int32_t name="stored_fat"/>
-                <int32_t name="unk_10"/>
                 <int32_t name="unk_14"/>
                 <int32_t name="unk_18"/>
                 <int32_t name="unk_1c" init-value='-1000000'/>

--- a/df.world.xml
+++ b/df.world.xml
@@ -576,8 +576,8 @@
                 <stl-vector pointer-type='mental_picture'/>
             </pointer>
         </stl-vector>
-        <stl-vector name='unk_2' type-name='int32_t'/> e.g. 757
-        <stl-vector name='unk_3' type-name='int32_t'/> e.g. 1000000
+        <stl-vector name='deities' type-name='int32_t' ref-target="historical_figure" comment="historical figure ID of gods the belief system is concerned with"/>
+        <stl-vector name='worship_levels' type-name='int32_t' comment="worship level for each god referenced in the deities field"/>
 
         <int32_t/>
         <int32_t/>


### PR DESCRIPTION
Note the renaming of `read_books` to `known_written_contents`. This is more accurate as `read_books` implies the artifact or item ID of books read, which is not the case, as this is a list of written_content IDs. More importantly, the ID of art form derivations including choreography and musical compositions known to the historical figure are also listed here, as these derivations are stored in the form of a `written_content` despite being unrelated to books. `read_books` does not currently seem to be used by any scripts in the repository.