### PR TITLE
add comment to getItemDescription's 2nd parameter

### DIFF
--- a/df.items.xml
+++ b/df.items.xml
@@ -561,7 +561,7 @@
 
             <vmethod name='getItemDescription'>
                 <pointer type-name='stl-string'/>
-                <int8_t name='mode'/>
+                <int8_t name='plurality' comment="0 = prickle berries [2], 1 = prickle berry, 2 = prickle berries"/>
             </vmethod>
             <vmethod name='getItemDescriptionPrefix' comment='"a " or "the "'>
                 <pointer type-name='stl-string'/>


### PR DESCRIPTION
some experimentation with the 2nd argument to `item::getItemDescription` shows that it affects the plurality of the returned string.