### PR TITLE
identify the entity colors

### DIFF
--- a/df.entities.xml
+++ b/df.entities.xml
@@ -480,8 +480,8 @@
             <stl-vector name='discovered_creatures' type-name='bool' index-refers-to='(find-creature $)'/>
             <stl-vector name='discovered_plant_foods' type-name='bool' index-refers-to='(find-plant-raw $)'/>
             <stl-vector name='discovered_plants' type-name='bool' index-refers-to='(find-plant-raw $)'/>
-            <stl-vector name='unk23' type-name='int16_t'/>
-            <stl-vector name='unk24' type-name='int16_t'/>
+            <stl-vector name='foreground_color' comment="foreground color used for the entity symbol in legends mode and the historical maps." type-name='descriptor_color'/>
+            <stl-vector name='background_color' comment="background color used for the entity symbol in legends mode and the historical maps." type-name='descriptor_color'/>
         </compound>
 
         <stl-vector name='uniforms' pointer-type='entity_uniform'/>


### PR DESCRIPTION
This identifies the unk23 and unk24 in entity resources as the fore and background colors for their entity symbol used in the historical maps and entity list in legends mode.

I hope I set the type name correctly? I am still a bit shakey on how the struct definitions work exactly