### PR TITLE
Specify lair types

### DIFF
--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -381,7 +381,13 @@
         <pointer name="subtype_info">
             <int16_t name="is_tower" init-value='-1' comment='1 => not fortress'/>
             <int16_t name="is_monument" init-value='-1' comment='not tomb'/>
-            <int16_t name="lair_type" comment='2 monument, 3 shrine'/>
+            <enum name="lair_type" base-type="int16_t">
+                <enum-item name="Mound lair" value="0" />
+                <enum-item name="Burrow lair" />
+                <enum-item name="Labyrinth"/>
+                <enum-item name="Shrine"/>
+                <enum-item name="Wildernis Location" comment="These are roc nests, but the dfwiki calls them wildernis locations" />
+            </enum>
             <stl-vector name="unk_8" type-name='int16_t'/>
             <int32_t name="unk_14" init-value='-1000000'/>
             <int32_t name="unk_18" init-value='-1000000'/>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -381,12 +381,12 @@
         <pointer name="subtype_info">
             <int16_t name="is_tower" init-value='-1' comment='1 => not fortress'/>
             <int16_t name="is_monument" init-value='-1' comment='not tomb'/>
-            <enum name="lair_type" base-type="int16_t">
-                <enum-item name="MoundLair" value="0" />
-                <enum-item name="BurrowLair" />
-                <enum-item name="Labyrinth"/>
-                <enum-item name="Shrine"/>
-                <enum-item name="WildernessLocation" comment="These are roc nests, but the dfwiki calls them wilderness locations" />
+            <enum name="lair_type" base-type="int16_t" comment="Corresponds to the the LAIR creature raw token.">
+                <enum-item name="SIMPLE_MOUND" value="0" />
+                <enum-item name="SIMPLE_BURROW" />
+                <enum-item name="LABYRINTH"/>
+                <enum-item name="SHRINE"/>
+                <enum-item name="WILDERNESS_LOCATION"/>
             </enum>
             <stl-vector name="unk_8" type-name='int16_t'/>
             <int32_t name="unk_14" init-value='-1000000'/>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -382,11 +382,11 @@
             <int16_t name="is_tower" init-value='-1' comment='1 => not fortress'/>
             <int16_t name="is_monument" init-value='-1' comment='not tomb'/>
             <enum name="lair_type" base-type="int16_t">
-                <enum-item name="Mound lair" value="0" />
-                <enum-item name="Burrow lair" />
+                <enum-item name="MoundLair" value="0" />
+                <enum-item name="BurrowLair" />
                 <enum-item name="Labyrinth"/>
                 <enum-item name="Shrine"/>
-                <enum-item name="Wildernis Location" comment="These are roc nests, but the dfwiki calls them wildernis locations" />
+                <enum-item name="WildernessLocation" comment="These are roc nests, but the dfwiki calls them wilderness locations" />
             </enum>
             <stl-vector name="unk_8" type-name='int16_t'/>
             <int32_t name="unk_14" init-value='-1000000'/>


### PR DESCRIPTION
This specifies the lair types as discussed in #336.

I ended up calling the last entry 'Wilderness Location' as that is what the wiki uses for the Roc Nests, and I didn't want to have a split in terms.

https://dwarffortresswiki.org/index.php/DF2014:Lair