### PR TITLE
Identified creature flags, associated to tags. Named entity_raw fields. Issue #102

### DIFF
--- a/df.creature-raws.xml
+++ b/df.creature-raws.xml
@@ -1,18 +1,21 @@
 <data-definition>
+    --  The comments indicate the creature raw tags whose presence/absence are
+    --  correlated with the flags. Tags with parameters, like those indicating
+    --  biomes, are currently not listed.
     <enum-type type-name='creature_raw_flags'>
-        <enum-item name='unk_wagon'/>
-        <enum-item name='EQUIPMENT_WAGON'/>
-        <enum-item name='MUNDANE'/>
-        <enum-item name='VERMIN_EATER'/>
-        <enum-item name='VERMIN_GROUNDER'/>
-        <enum-item name='VERMIN_ROTTER'/>
-        <enum-item name='VERMIN_SOIL'/>
-        <enum-item name='VERMIN_SOIL_COLONY'/>
+        <enum-item name='unk_wagon' comment="[EQUIPMENT_WAGON]"/>
+        <enum-item name='EQUIPMENT_WAGON' comment="[EQUIPMENT_WAGON] as well"/>
+        <enum-item name='MUNDANE' comment="[MUNDANE]"/>
+        <enum-item name='VERMIN_EATER' comment="[VERMIN_EATER] and [PENETRATEPOWER]"/>
+        <enum-item name='VERMIN_GROUNDER' comment="[VERMIN_GROUNDER]"/>
+        <enum-item name='VERMIN_ROTTER' comment="[VERMIN_ROTTER]"/>
+        <enum-item name='VERMIN_SOIL' comment="[VERMIN_SOIL]"/>
+        <enum-item name='VERMIN_SOIL_COLONY' comment="[VERMIN_SOIL_COLONY]"/>
 
-        <enum-item name='LARGE_ROAMING'/>
-        <enum-item name='VERMIN_FISH'/>
-        <enum-item name='LOOSE_CLUSTERS'/>
-        <enum-item name='FANCIFUL'/>
+        <enum-item name='LARGE_ROAMING' comment="[LARGE_ROAMING]"/>
+        <enum-item name='VERMIN_FISH' comment="[VERMIN_FISH]"/>
+        <enum-item name='LOOSE_CLUSTERS' comment="[LOOSE_CLUSTERS]"/>
+        <enum-item name='FANCIFUL' comment="[FANCIFUL]"/>
         <enum-item name='BIOME_MOUNTAIN'/>
         <enum-item name='BIOME_GLACIER'/>
         <enum-item name='BIOME_TUNDRA'/>
@@ -70,61 +73,67 @@
         <enum-item name='BIOME_RIVER_TROPICAL_FRESHWATER'/>
         <enum-item name='BIOME_RIVER_TROPICAL_BRACKISHWATER'/>
         <enum-item name='BIOME_RIVER_TROPICAL_SALTWATER'/>
-        <enum-item name='GOOD'/>
+        <enum-item name='GOOD' comment="[GOOD]"/>
 
-        <enum-item name='EVIL'/>
-        <enum-item name='SAVAGE'/>
-        <enum-item name='NOT_ASEXUAL'/>
-        <enum-item name='unk_43' comment='capable of breeding'/>
-        <enum-item name='unk_44'/>
-        <enum-item name='unk_45'/>
+        <enum-item name='EVIL' comment="[EVIL]"/>
+        <enum-item name='SAVAGE' comment="[SAVAGE]"/>
+        <enum-item name='NOT_ASEXUAL' comment="Presence of any CASTE tag"/>
+        <enum-item name='MALE_AND_FEMALE' comment='capable of breeding, [MALE] and [FEMALE] tags'/>
+        <enum-item name='MALE' comment="[MALE]"/>
+        <enum-item name='FEMALE' comment="[FEMALE]"/>
         <enum-item name='any_vermin'/>
         <enum-item name='CASTE_CAN_LEARN'/>
 
-        <enum-item name='CASTE_VERMIN_HATEABLE'/>
-        <enum-item name='unk_49'/>
-        <enum-item name='CASTE_LARGE_PREDATOR'/>
+        <enum-item name='CASTE_VERMIN_HATEABLE' comment="[VERMIN_HATEABLE]"/>
+        <enum-item name='CIVILIZATION_BUILDING' comment="included in entity_defaults.txt"/>
+        <enum-item name='CASTE_LARGE_PREDATOR' comment="[LARGE_PREDATOR]"/>
         <enum-item name='CASTE_CURIOUSBEAST'/>
-        <enum-item name='CASTE_BENIGN'/>
-        <enum-item name='CASTE_NATURAL'/>
-        <enum-item name='CASTE_MEGABEAST'/>
-        <enum-item name='CASTE_SEMIMEGABEAST'/>
+        <enum-item name='CASTE_BENIGN' comment="[BENIGN]"/>
+        <enum-item name='CASTE_NATURAL' comment="[NATURAL]"/>
+        <enum-item name='CASTE_MEGABEAST' comment="[MEGABEAST]"/>
+        <enum-item name='CASTE_SEMIMEGABEAST' comment="[SEMIMEGABEAST]"/>
 
         <enum-item name='CASTE_POWER'/>
-        <enum-item name='CASTE_VERMIN_MICRO'/>
+        <enum-item name='CASTE_VERMIN_MICRO' comment="[VERMIN_MICRO]"/>
         <enum-item name='CASTE_NOT_FIREIMMUNE'/>
         <enum-item name='CASTE_MUST_BREATHE_AIR'/>
-        <enum-item name='CASTE_MUST_BREATHE_WATER'/>
+        <enum-item name='CASTE_MUST_BREATHE_WATER' comment="[AQUATIC]"/>
         <enum-item name='unk_55'/>
         <enum-item name='CASTE_SWIMS_LEARNED'/>
-        <enum-item name='CASTE_COMMON_DOMESTIC'/>
+        <enum-item name='CASTE_COMMON_DOMESTIC' comment="[COMMON_DOMESTIC]"/>
 
-        <enum-item name='CASTE_UTTERANCES'/>
+        <enum-item name='CASTE_UTTERANCES' comment="[UTTERANCES], [FLEEQUICK], and [MENT_ATT_RATES]"/>
         <enum-item name='CASTE_CAN_SPEAK'/>
-        <enum-item name='CASTE_FEATURE_BEAST'/>
-        <enum-item name='GENERATED'/>
-        <enum-item name='CASTE_TITAN'/>
-        <enum-item name='CASTE_UNIQUE_DEMON'/>
-        <enum-item name='DOES_NOT_EXIST'/>
-        <enum-item name='CASTE_NOT_LIVING'/>
+        <enum-item name='CASTE_FEATURE_BEAST' comment="[FEATURE_BEAST]"/>
+        <enum-item name='GENERATED' comment="[GENERATED]"/>
+        <enum-item name='CASTE_TITAN' comment="[TITAN]"/>
+        <enum-item name='CASTE_UNIQUE_DEMON' comment="[UNIQUE_DEMON]"/>
+        <enum-item name='DOES_NOT_EXIST' comment="[DOES_NOT_EXIST] (also missing [DESCRIPTION], [BODY], and [BODY_SIZE])"/>
+        <enum-item name='CASTE_NOT_LIVING' comment="[NOT_LIVING]"/>
 
-        <enum-item name='CASTE_MISCHIEVOUS'/>
-        <enum-item name='CASTE_FLIER'/>
+        <enum-item name='CASTE_MISCHIEVOUS' comment="[MISCHIEVOUS]"/>
+        <enum-item name='CASTE_FLIER' comment="[FLIER]"/>
         <enum-item name='CASTE_DEMON'/>
         <enum-item name='CASTE_NIGHT_CREATURE_ANY'/>
-        <enum-item name='CASTE_NIGHT_CREATURE_HUNTER'/>
-        <enum-item name='CASTE_NIGHT_CREATURE_BOGEYMAN'/>
+        <enum-item name='CASTE_NIGHT_CREATURE_HUNTER' comment="[NIGHT_CREATURE_HUNTER]"/>
+        <enum-item name='CASTE_NIGHT_CREATURE_BOGEYMAN' comment="[NIGHT_CREATURE_BOGEYMAN]"/>
         <enum-item name='CASTE_CARNIVORE'/>
-        <enum-item name='ARTIFICIAL_HIVEABLE'/>
+        <enum-item name='ARTIFICIAL_HIVEABLE' comment="[ARTIFICIAL_HIVEABLE], plus bee specific tags"/>
 
-        <enum-item name='UBIQUITOUS'/>
-        <enum-item name='unk_69'/>
-        <enum-item name='CASTE_SUPERNATURAL'/>
-        <enum-item name='CASTE_BLOOD'/>
-        <enum-item name='CASTE_GRAZER'/>
-        <enum-item name='CASTE_unk_31'/>
-        <enum-item name='unk_6e'/>
-        <enum-item name='unk_6f'/>
+        <enum-item name='UBIQUITOUS' comment="[UBIQUITOUS]"/>
+        <enum-item name='LIVING' comment='does not have [NOT_LIVING] tag'/>
+        <enum-item name='CASTE_SUPERNATURAL' comment="[SUPERNATURAL]"/>
+        <enum-item name='CASTE_BLOOD' comment="[BLOOD]"/>
+        <enum-item name='CASTE_GRAZER' comment="[STANDARD_GRAZER]"/>
+        <enum-item name='IMMOBILE' comment="[IMMOBILE]"/>
+        <enum-item name='LOCAL_POPS_CONTROLLABLE' comment="[LOCAL_POPS_CONTROLLABLE]"/>
+        <enum-item name='OUTSIDER_CONTROLLABLE' comment="[OUTSIDER_CONTROLLABLE]"/>
+        <enum-item name='LOCAL_POPS_PRODUCE_HEROES' comment="[LOCAL_POPS_PRODUCE_HEROES]"/>
+        <enum-item name='unk_71'/>
+        <enum-item name='unk_72'/>
+        <enum-item name='FLIER' comment="[FLIER]"/>
+        <enum-item name='SLOW_LEARNER'/>
+        
     </enum-type>
 
     <enum-type type-name='caste_raw_flags'>

--- a/df.entity-raws.xml
+++ b/df.entity-raws.xml
@@ -165,8 +165,8 @@
 
     <struct-type type-name='entity_raw' instance-vector='$global.world.raws.entities'>
         <stl-string name='code'/>
-        <int32_t since='v0.40.01'/>
-        <stl-vector since='v0.40.01'/>
+        <int32_t name='index' since='v0.40.01' comment='into instace-vector'/>
+        <stl-vector name='raws' pointer-type='stl-string' since='v0.40.01'/>
 
         <code-helper name='describe'>$.translation</code-helper>
 


### PR DESCRIPTION
For the creature_raw_flags I ran a script that matched presence/absence of flags against the tags present in the raw structure, on top of/confirming previous research in issue #102.
I found it useful to reference the controlling tags directly as comments, and so added them.

For entity_raw I noted that the first named field matched the index of the element (as is normal for raws), and that the second named field looked like the raw tag structure present in other raw entries, and verified that I did indeed get the tags out of it when first reinterpret_cast (Lua) and then typed (XML and code generation).