### PR TITLE
Corrected world_region to align min/max/mid values at the end

### DIFF
--- a/df.legends.xml
+++ b/df.legends.xml
@@ -87,6 +87,9 @@
         <int16_t name='unk10' init-value='-1'/>
         <int32_t name='unk11' init-value='-1'/>
         <int32_t name='unk12' init-value='-1'/>
+        <int32_t name='unk_v47_1'/>
+        <int32_t name='unk_v47_2'/>
+        <int32_t name='unk_v47_3'/>
         <df-flagarray name='flags' index-enum='nemesis_flags'/>
     </struct-type>
 

--- a/df.world-data.xml
+++ b/df.world-data.xml
@@ -194,13 +194,9 @@
         <bool name='evil'/>
         <bool name='good'/>  -- At most one of 'evil' and 'good' is set at a time by DF.
         <int16_t name="lake_surface"/>
-
-        <padding name="unk_1ed" size="34" comment='Seems to change randomly as the same save is loaded' since='v0.47.01'/>
-        
+        <int32_t name="unk_v47_1"/>
         <stl-vector name="forces" type-name='int32_t' ref-target='historical_figure' comment="historical figure IDs of force deities associated with the region"/>
-        
-        <padding name="unk_208" size="4" comment='Seems to change randomly as the same save is loaded'/>
-
+        <int32_t name="unk_v47_2"/>
         <int32_t name="mid_x"/>
         <int32_t name="mid_y"/>
         <int32_t name="min_x"/>


### PR DESCRIPTION
Not sure what has happened, but all that padding that aligned the values at the end before doesn't work. This commit matches with the same elements of the same (copied) save in 0.44.12, and the forces vector contains the same element as they did before (field called unk_1f0 in the old DFHack version used with 0.44.12).
I haven't found any values but 0 in the saves I checked for the unk_v47_1 and unk_v47_2 fields.