### PR TITLE
arena_spawn: named 'tame'

### DIFF
--- a/df.world.xml
+++ b/df.world.xml
@@ -1648,7 +1648,7 @@
 
             <int32_t name='side'/>
             <int32_t name='interaction' refers-to='$$._parent.interactions[$]'/>
-            <int32_t since='v0.47.01'/>
+            <int32_t name='tame' since='v0.47.01' comment='sets tame-mountable status when the creature creation menu is opened'/>
 
             <stl-vector name='interactions' pointer-type='interaction_effect' since='v0.34.01'/>
             <stl-vector name='creature_cnt' type-name='int32_t'


### PR DESCRIPTION
This records and sets the tame/mountable status when the arena mode creature creation menu is opened.

0 = not tame/mountable
1 = tame/mountable
Perhaps it should be a bool?