### PR TITLE
restored sel_idx field that went AWOL

### DIFF
--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -884,7 +884,7 @@
 
     <class-type type-name='viewscreen_export_graphical_mapst' inherits-from='viewscreen'>
         <bool name='in_export'/>
-        <int32_t/>
+        <int32_t name='sel_idx'/>
         <int32_t/>
         <stl-vector type-name='int32_t'/>
         <stl-vector/>


### PR DESCRIPTION
Fixes DFHack/dfhack#1494.

Please check that the removal of the field was a mistake before accepting this PR.
Restoring the field allowed the script to export the maps, and the ones I looked at were different from each others, though.