### PR TITLE
Align ui_sidebar_menus 0.47.01/0.47.02

### DIFF
--- a/df.ui-menus.xml
+++ b/df.ui-menus.xml
@@ -405,6 +405,7 @@
 
         <stl-vector since='v0.42.01'/>
         <padding size='4' since='v0.42.01'/>
+        <int32_t since='v0.47.01'/>
 
         <compound name='minimap'>
             -- Abstract representation of contents; updated by need_scan

--- a/df.unit-thoughts.xml
+++ b/df.unit-thoughts.xml
@@ -220,7 +220,7 @@
         </enum-item>
         <enum-item/>
         <enum-item name='EUPHORIA'>
-            <item-attr name='color' value='10 '/>
+            <item-attr name='color' value='10'/>
             <item-attr name='divider' value='-1'/>
         </enum-item>
 


### PR DESCRIPTION
Related to https://github.com/DFHack/df-structures/issues/346#issuecomment-585759517 . Tested on linux 32 bits and 64 bits. **Not tested on windows.**

I also sneaked in a small typo fix that was annoying for my too strict parser, but if you think spaces in numbers are okay, I can fix my parser instead.