### PR TITLE
Various fixes

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -587,9 +587,8 @@
         <int32_t/>
         <enum base-type='int16_t' name='profession' type-name='profession'/>
         <int32_t name='civ' ref-target='historical_entity'/>
-        <int32_t name="unk_v47_1"/>
+        <int16_t name="unk_v47_1"/>
         <int32_t name="unk_v47_2"/>
-        <int32_t name="unk_v47_3"/>
         <stl-vector pointer-type='identity_unk_94'/>
         <stl-vector pointer-type='identity_unk_94'/>
     </struct-type>

--- a/df.military.xml
+++ b/df.military.xml
@@ -628,6 +628,7 @@
         </stl-vector>
         <int32_t name="unk_3c"/>
         <int32_t since='v0.44.01'/>
+        <int32_t since='v0.47.03'/>
         <int32_t name="controller_id" ref-target='army_controller'/>
         <pointer name="controller" type-name="army_controller"/>
         <df-flagarray name="flags" index-enum='army_flags'/>

--- a/df.unit-thoughts.xml
+++ b/df.unit-thoughts.xml
@@ -220,7 +220,7 @@
         </enum-item>
         <enum-item/>
         <enum-item name='EUPHORIA'>
-            <item-attr name='color' value='10 '/>
+            <item-attr name='color' value='10'/>
             <item-attr name='divider' value='-1'/>
         </enum-item>
 


### PR DESCRIPTION
Based on vector/pointer checking on linux32. But some fixes affect both bitness like `army.controller_id` or the unknown fields in `identity` (previous fields were containing uninitialized data). Tested on linux32/linux64 only.