### PR TITLE
Identified incident crime, reordered features

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -1727,7 +1727,6 @@
 
     <class-type type-name='history_event_masterpiece_created_itemst'
                 inherits-from='history_event_masterpiece_createdst'>
-        <enum base-type='int32_t' name='skill_used' type-name='job_skill'/>
         <enum base-type='int16_t' name='item_type' type-name='item_type'/>
         <int16_t name='item_subtype' refers-to='(item-subtype-target $$._parent.item_type $)'/>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -1975,8 +1975,10 @@
             <enum-item name='Slash'/>
             <enum-item name='Stab'/>
             <enum-item name='Rip'/>
+            <enum-item name='Burn'/>
         </enum>
-        <int8_t name='part_lost'/>
+        <int16_t name='part_lost'/>
+        <bool name='torture' since='0.47.01'/>
     </class-type>
 
     <enum-type type-name='history_event_simple_battle_subtype' base-type='int16_t'>

--- a/df.history.xml
+++ b/df.history.xml
@@ -1422,6 +1422,7 @@
         <enum-item name='FALLING_OBJECT'/>
         <enum-item name='LEAPT_FROM_HEIGHT'/>
         <enum-item name='DROWN_ALT2'/>
+        <enum-item name='EXECUTION_GENERIC'/>
         <enum-item/>
     </enum-type>
 
@@ -1989,8 +1990,8 @@
         <enum-item name='LOSE_AFTER_RECEIVE_WOUND'/>
         <enum-item name='LOSE_AFTER_INFLICT_WOUND'/>
         <enum-item name='LOSE_AFTER_EXCHANGE_WOUND'/>
-        <enum-item/>
-        <enum-item/>
+        <enum-item name='SUBDUED'/>
+        <enum-item name='GOT_INTO_A_BRAWL'/>
     </enum-type>
 
     <class-type type-name='history_event_hist_figure_simple_battle_eventst' inherits-from='history_event'>

--- a/df.meeting.xml
+++ b/df.meeting.xml
@@ -606,6 +606,8 @@
             <int32_t/>
             <stl-vector type-name='int32_t'/>
         </compound>
+        <int32_t name='unk_v47_1'/>
+        <int32_t name='unk_v47_2'/>
         <stl-vector name='turns'>
             <pointer>
                 <int32_t name='speaker' ref-target='unit'/>

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -128,18 +128,16 @@
     </enum-type>
 
     <struct-type type-name='punishment'>
-        <pointer name="criminal" type-name='unit'/>
-        <pointer name="officer" type-name='unit'/>
+        <int32_t name="criminal" ref-target='unit'/>
+        <int32_t name="officer" ref-target='unit'/>
         <int16_t name="beating"/>
         <int16_t name="hammer_strikes"/>
         <int32_t name="prison_counter"/>
-        <int16_t name="unk_10" comment='10080'/>
-        <pointer name="chain" type-name='building'/>
-        <stl-vector name="victims">
-            <pointer type-name="unit"/>
-        </stl-vector>
+        <int16_t name="unk_10" comment='647, 651, 10080. Changes when when hammerer and captain of the guard are appointed'/>
+        <int32_t name="chain" ref-target='building'/>
+        <stl-vector name="victims" type-name='int32_t' ref-target='unit'/>
     </struct-type>
-
+    
     <enum-type type-name="kitchen_exc_type" base-type="int8_t">
         <enum-item name="Cook" value="1"/>
         <enum-item name="Brew"/>

--- a/df.world.xml
+++ b/df.world.xml
@@ -1583,12 +1583,7 @@
         <pointer name='unk_v40_7s' since='v0.40.01'/>
 
         <compound name='features'>
-            <int32_t name='unk_v47_1' comment="It's quite likely these elements are actually an stl-vector. I've only seen 0, and so can't tell"/>
-            <int32_t name='unk_v47_2'/>
-            <int32_t name='unk_v47_3'/>
-            <int32_t name='unk_v47_4'/>
-            <int32_t name='unk_v47_5'/>
-            <int32_t name='unk_v47_6'/>
+            <stl-vector name='unk_v47_1' since='0.47.01'/>
             <stl-vector name='map_features' pointer-type='feature_init'/>
             <stl-vector type-name='int16_t' name='feature_x'/>
             <stl-vector type-name='int16_t' name='feature_y'/>

--- a/df.world.xml
+++ b/df.world.xml
@@ -69,7 +69,7 @@
         <int32_t name='id'/>
         <enum name='subtype' base-type='int32_t'>
             <enum-item name='Combat'/>
-            <enum-item/>
+            <enum-item name='Crime' comment="Visible indirectly through convictions or crime effects (e.g. killing/maiming someone)"/>
             <enum-item/>
             <enum-item/>
             <enum-item/>
@@ -1583,12 +1583,17 @@
         <pointer name='unk_v40_7s' since='v0.40.01'/>
 
         <compound name='features'>
+            <int32_t name='unk_v47_1' comment="It's quite likely these elements are actually an stl-vector. I've only seen 0, and so can't tell"/>
+            <int32_t name='unk_v47_2'/>
+            <int32_t name='unk_v47_3'/>
+            <int32_t name='unk_v47_4'/>
+            <int32_t name='unk_v47_5'/>
+            <int32_t name='unk_v47_6'/>
             <stl-vector name='map_features' pointer-type='feature_init'/>
             <stl-vector type-name='int16_t' name='feature_x'/>
             <stl-vector type-name='int16_t' name='feature_y'/>
             <stl-vector type-name='int16_t' name='feature_local_idx' comment='same as map_block.local_feature'/>
             <stl-vector type-name='int32_t' name='feature_global_idx' ref-target='world_underground_region'/>
-
             <stl-vector pointer-type='feature_init' comment='from unk_9C'/>
             <stl-vector type-name='int16_t' comment='unk_9C.region.x'/>
             <stl-vector type-name='int16_t' comment='unk_9C.region.y'/>
@@ -1603,7 +1608,6 @@
             <stl-vector type-name='int16_t' comment='unk_9C.z_min'/>
             <stl-vector type-name='int16_t' comment='unk_9C.z_min; yes, seemingly duplicate'/>
             <stl-vector type-name='int16_t' comment='unk_9C.z_max'/>
-            <stl-vector since='v0.47.01'/>
             <stl-bit-vector since='v0.40.11'/>
         </compound>
 


### PR DESCRIPTION
I think the incident subtype value 1 corresponds to Crime. In one of the saves I used the "Crime" incidents matched up with convictions as well as crime entries on the Justice screen. In the other no Injustice system had been used, so there were no convictions, but quite a few "Crime" incidents. Enabling the Injustice system showed a lot of incidents, but it wasn't possible to match them up with the incidents, as there appeared to be no witnesses, and thus no indication of whether the incident report "killer" was actually the criminal, while it matched up in the save with the convictions.
The evidence is a bit thin for the naming of the field, but it's gone unidentified for quite a long time, and I think it's better with an uncertain identification than none at all.

A new 0.47.X vector had been added to world.features. However, examining the structure  I realized it was out of alignment, with the space for the vector actually having to go to the front. I used the same 0.44.12 save with 0.44.12 and 0.47.03 to compare the fields, and with the moved "padding" the data matched up. Everything apart from the identified feature fields (including the bit at the beginning) was 0, however, so I can't say anything about the rest.