### PR TITLE
Named some summoning effect fields

### DIFF
--- a/df.interaction.xml
+++ b/df.interaction.xml
@@ -132,19 +132,19 @@
     </class-type>
 
     <class-type type-name='interaction_effect_summon_unitst' inherits-from='interaction_effect'>
-        <int32_t/>
-        <stl-string/>
-        <stl-string/>
+        <int32_t name='make_pet'/>
+        <stl-string name='race_str'/>
+        <stl-string name='caste_str'/>
         <stl-vector/>
         <stl-vector/>
         <stl-vector/>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int32_t'/>
+        <stl-vector type-name='int32_t' name='forbidden_creature_flags' comment='contains indexes of flags in creature_raw_flags'/>
+        <stl-vector type-name='int32_t' name='required_caste_flags' comment='contains indexes of flags in caste_raw_flags'/>
+        <stl-vector type-name='int32_t' name='forbidden_caste_flags' comment='contains indexes of flags in caste_raw_flags'/>
         <int32_t init-value='-1'/>
         <int32_t init-value='-1'/>
-        <int32_t/> seen nonzero
-        <int32_t/> seen nonzero
+        <int32_t name='time_range_min'/>
+        <int32_t name='time_range_max'/>
     </class-type>
 
     <enum-type type-name='interaction_source_type'>


### PR DESCRIPTION
Determined by observing modded interactions using gui/gm-editor.

I believe that a `required_creature_flags` field should also be present (probably above `forbidden_creature_flags`), as it is possible to specify these in the interaction raws, but it seems to be missing from the mapped structures at present.