### PR TITLE
Use the official creature and caste flag names

### DIFF
--- a/df.creature-raws.xml
+++ b/df.creature-raws.xml
@@ -81,7 +81,7 @@
         <enum-item name='MATES_TO_BREED' comment='capable of breeding, [MALE] and [FEMALE] tags'/>
         <enum-item name='HAS_MALE' comment="[MALE]"/>
         <enum-item name='HAS_FEMALE' comment="[FEMALE]"/>
-        <enum-item name='SMALL_RACE' comment = "any vermin"/>
+        <enum-item name='SMALL_RACE' comment="any vermin"/>
         <enum-item name='HAS_ANY_INTELLIGENT_LEARNS'/>
 
         <enum-item name='HAS_ANY_VERMIN_HATEABLE' comment="[VERMIN_HATEABLE]"/>

--- a/df.creature-raws.xml
+++ b/df.creature-raws.xml
@@ -3,8 +3,8 @@
     --  correlated with the flags. Tags with parameters, like those indicating
     --  biomes, are currently not listed.
     <enum-type type-name='creature_raw_flags'>
-        <enum-item name='unk_wagon' comment="[EQUIPMENT_WAGON]"/>
-        <enum-item name='EQUIPMENT_WAGON' comment="[EQUIPMENT_WAGON] as well"/>
+        <enum-item name='EQUIPMENT' comment="[EQUIPMENT_WAGON]"/>
+        <enum-item name='EQUIPMENT_WAGON' comment="[EQUIPMENT_WAGON]"/>
         <enum-item name='MUNDANE' comment="[MUNDANE]"/>
         <enum-item name='VERMIN_EATER' comment="[VERMIN_EATER] and [PENETRATEPOWER]"/>
         <enum-item name='VERMIN_GROUNDER' comment="[VERMIN_GROUNDER]"/>
@@ -77,80 +77,83 @@
 
         <enum-item name='EVIL' comment="[EVIL]"/>
         <enum-item name='SAVAGE' comment="[SAVAGE]"/>
-        <enum-item name='NOT_ASEXUAL' comment="Presence of any CASTE tag"/>
-        <enum-item name='MALE_AND_FEMALE' comment='capable of breeding, [MALE] and [FEMALE] tags'/>
-        <enum-item name='MALE' comment="[MALE]"/>
-        <enum-item name='FEMALE' comment="[FEMALE]"/>
-        <enum-item name='any_vermin'/>
-        <enum-item name='CASTE_CAN_LEARN'/>
+        <enum-item name='TWO_GENDERS'/>
+        <enum-item name='MATES_TO_BREED' comment='capable of breeding, [MALE] and [FEMALE] tags'/>
+        <enum-item name='HAS_MALE' comment="[MALE]"/>
+        <enum-item name='HAS_FEMALE' comment="[FEMALE]"/>
+        <enum-item name='SMALL_RACE' comment = "any vermin"/>
+        <enum-item name='HAS_ANY_INTELLIGENT_LEARNS'/>
 
-        <enum-item name='CASTE_VERMIN_HATEABLE' comment="[VERMIN_HATEABLE]"/>
-        <enum-item name='CIVILIZATION_BUILDING' comment="included in entity_defaults.txt"/>
-        <enum-item name='CASTE_LARGE_PREDATOR' comment="[LARGE_PREDATOR]"/>
-        <enum-item name='CASTE_CURIOUSBEAST'/>
-        <enum-item name='CASTE_BENIGN' comment="[BENIGN]"/>
-        <enum-item name='CASTE_NATURAL' comment="[NATURAL]"/>
-        <enum-item name='CASTE_MEGABEAST' comment="[MEGABEAST]"/>
-        <enum-item name='CASTE_SEMIMEGABEAST' comment="[SEMIMEGABEAST]"/>
+        <enum-item name='HAS_ANY_VERMIN_HATEABLE' comment="[VERMIN_HATEABLE]"/>
+        <enum-item name='OCCURS_AS_ENTITY_RACE' comment="included in entity_defaults.txt"/>
+        <enum-item name='HAS_ANY_LARGE_PREDATOR' comment="[LARGE_PREDATOR]"/>
+        <enum-item name='HAS_ANY_CURIOUS_BEAST'/>
+        <enum-item name='HAS_ANY_BENIGN' comment="[BENIGN]"/>
+        <enum-item name='HAS_ANY_NATURAL_ANIMAL' comment="[NATURAL]"/>
+        <enum-item name='HAS_ANY_MEGABEAST' comment="[MEGABEAST]"/>
+        <enum-item name='HAS_ANY_SEMIMEGABEAST' comment="[SEMIMEGABEAST]"/>
 
-        <enum-item name='CASTE_POWER'/>
-        <enum-item name='CASTE_VERMIN_MICRO' comment="[VERMIN_MICRO]"/>
-        <enum-item name='CASTE_NOT_FIREIMMUNE'/>
-        <enum-item name='CASTE_MUST_BREATHE_AIR'/>
-        <enum-item name='CASTE_MUST_BREATHE_WATER' comment="[AQUATIC]"/>
-        <enum-item name='unk_55'/>
-        <enum-item name='CASTE_SWIMS_LEARNED'/>
-        <enum-item name='CASTE_COMMON_DOMESTIC' comment="[COMMON_DOMESTIC]"/>
+        <enum-item name='HAS_ANY_POWER'/>
+        <enum-item name='HAS_ANY_VERMIN_MICRO' comment="[VERMIN_MICRO]"/>
+        <enum-item name='HAS_ANY_NOT_FIREIMMUNE'/>
+        <enum-item name='HAS_ANY_CANNOT_BREATHE_WATER'/>
+        <enum-item name='HAS_ANY_CANNOT_BREATHE_AIR' comment="[AQUATIC]"/>
+        <enum-item name='HAS_ANY_NOT_FLIER'/>
+        <enum-item name='HAS_ANY_CAN_SWIM'/>
+        <enum-item name='HAS_ANY_COMMON_DOMESTIC' comment="[COMMON_DOMESTIC]"/>
 
-        <enum-item name='CASTE_UTTERANCES' comment="[UTTERANCES], [FLEEQUICK], and [MENT_ATT_RATES]"/>
-        <enum-item name='CASTE_CAN_SPEAK'/>
-        <enum-item name='CASTE_FEATURE_BEAST' comment="[FEATURE_BEAST]"/>
+        <enum-item name='HAS_ANY_UTTERANCES' comment="[UTTERANCES]"/>
+        <enum-item name='HAS_ANY_INTELLIGENT_SPEAKS'/>
+        <enum-item name='HAS_ANY_FEATURE_BEAST' comment="[FEATURE_BEAST]"/>
         <enum-item name='GENERATED' comment="[GENERATED]"/>
-        <enum-item name='CASTE_TITAN' comment="[TITAN]"/>
-        <enum-item name='CASTE_UNIQUE_DEMON' comment="[UNIQUE_DEMON]"/>
-        <enum-item name='DOES_NOT_EXIST' comment="[DOES_NOT_EXIST] (also missing [DESCRIPTION], [BODY], and [BODY_SIZE])"/>
-        <enum-item name='CASTE_NOT_LIVING' comment="[NOT_LIVING]"/>
+        <enum-item name='HAS_ANY_TITAN' comment="[TITAN]"/>
+        <enum-item name='HAS_ANY_UNIQUE_DEMON' comment="[UNIQUE_DEMON]"/>
+        <enum-item name='DOES_NOT_EXIST' comment="[DOES_NOT_EXIST]"/>
+        <enum-item name='HAS_ANY_NOT_LIVING' comment="[NOT_LIVING]"/>
 
-        <enum-item name='CASTE_MISCHIEVOUS' comment="[MISCHIEVOUS]"/>
-        <enum-item name='CASTE_FLIER' comment="[FLIER]"/>
-        <enum-item name='CASTE_DEMON'/>
-        <enum-item name='CASTE_NIGHT_CREATURE_ANY'/>
-        <enum-item name='CASTE_NIGHT_CREATURE_HUNTER' comment="[NIGHT_CREATURE_HUNTER]"/>
-        <enum-item name='CASTE_NIGHT_CREATURE_BOGEYMAN' comment="[NIGHT_CREATURE_BOGEYMAN]"/>
-        <enum-item name='CASTE_CARNIVORE'/>
-        <enum-item name='ARTIFICIAL_HIVEABLE' comment="[ARTIFICIAL_HIVEABLE], plus bee specific tags"/>
+        <enum-item name='HAS_ANY_MISCHIEVIOUS' comment="[MISCHIEVOUS]"/>
+        <enum-item name='HAS_ANY_FLIER' comment="[FLIER]"/>
+        <enum-item name='HAS_ANY_DEMON'/>
+        <enum-item name='HAS_ANY_NIGHT_CREATURE'/>
+        <enum-item name='HAS_ANY_NIGHT_CREATURE_HUNTER' comment="[NIGHT_CREATURE_HUNTER]"/>
+        <enum-item name='HAS_ANY_NIGHT_CREATURE_BOGEYMAN' comment="[NIGHT_CREATURE_BOGEYMAN]"/>
+        <enum-item name='HAS_ANY_CARNIVORE'/>
+        <enum-item name='ARTIFICIAL_HIVEABLE' comment="[ARTIFICIAL_HIVEABLE]"/>
 
         <enum-item name='UBIQUITOUS' comment="[UBIQUITOUS]"/>
-        <enum-item name='LIVING' comment='does not have [NOT_LIVING] tag'/>
-        <enum-item name='CASTE_SUPERNATURAL' comment="[SUPERNATURAL]"/>
-        <enum-item name='CASTE_BLOOD' comment="[BLOOD]"/>
-        <enum-item name='CASTE_GRAZER' comment="[STANDARD_GRAZER]"/>
-        <enum-item name='IMMOBILE' comment="[IMMOBILE]"/>
-        <enum-item name='LOCAL_POPS_CONTROLLABLE' comment="[LOCAL_POPS_CONTROLLABLE]"/>
-        <enum-item name='OUTSIDER_CONTROLLABLE' comment="[OUTSIDER_CONTROLLABLE]"/>
-        <enum-item name='LOCAL_POPS_PRODUCE_HEROES' comment="[LOCAL_POPS_PRODUCE_HEROES]"/>
-        <enum-item name='unk_71'/>
-        <enum-item name='unk_72'/>
-        <enum-item name='FLIER' comment="[FLIER]"/>
-        <enum-item name='SLOW_LEARNER'/>
+        <enum-item name='ALL_CASTES_ALIVE' comment='does not have [NOT_LIVING] tag'/>
+        <enum-item name='HAS_ANY_SUPERNATURAL' comment="[SUPERNATURAL]"/>
+        <enum-item name='HAS_ANY_HAS_BLOOD' comment="[BLOOD]"/>
+        <enum-item name='HAS_ANY_GRAZER' comment="[STANDARD_GRAZER]"/>
+        <enum-item name='HAS_ANY_IMMOBILE' comment="[IMMOBILE]"/>
+        <enum-item name='HAS_ANY_LOCAL_POPS_CONTROLLABLE' comment="[LOCAL_POPS_CONTROLLABLE]"/>
+        <enum-item name='HAS_ANY_OUTSIDER_CONTROLLABLE' comment="[OUTSIDER_CONTROLLABLE]"/>
+
+        <enum-item name='HAS_ANY_LOCAL_POPS_PRODUCE_HEROES' comment="[LOCAL_POPS_PRODUCE_HEROES]"/>
+        <enum-item name='HAS_ANY_GRASP'/>
+        <enum-item name='HAS_ANY_RACE_GAIT'/>
+        <enum-item name='HAS_ANY_FLY_RACE_GAIT' comment="[FLIER]"/>
+        <enum-item name='HAS_ANY_SLOW_LEARNER'/>
+        <enum-item name='HAS_ANY_NIGHT_CREATURE_NIGHTMARE'/>
+        <enum-item name='HAS_ANY_NIGHT_CREATURE_EXPERIMENTER'/>
         
     </enum-type>
 
     <enum-type type-name='caste_raw_flags'>
-        <enum-item name='AMPHIBIOUS'/>
-        <enum-item name='AQUATIC'/>
+        <enum-item name='CAN_BREATHE_WATER'/>
+        <enum-item name='CANNOT_BREATHE_AIR'/>
         <enum-item name='LOCKPICKER'/>
-        <enum-item name='MISCHIEVOUS'/>
+        <enum-item name='MISCHIEVIOUS'/>
         <enum-item name='PATTERNFLIER'/>
-        <enum-item name='CURIOUSBEAST_ANY'/>
-        <enum-item name='CURIOUSBEAST_ITEM'/>
-        <enum-item name='CURIOUSBEAST_GUZZLER'/>
+        <enum-item name='CURIOUS_BEAST'/>
+        <enum-item name='CURIOUS_BEAST_ITEM'/>
+        <enum-item name='CURIOUS_BEAST_GUZZLER'/>
 
         <enum-item name='FLEEQUICK'/>
         <enum-item name='AT_PEACE_WITH_WILDLIFE'/>
-        <enum-item name='SWIMS_LEARNED'/>
+        <enum-item name='CAN_SWIM'/>
         <enum-item name='OPPOSED_TO_LIFE'/>
-        <enum-item name='CURIOUSBEAST_EATER'/>
+        <enum-item name='CURIOUS_BEAST_EATER'/>
         <enum-item name='NO_EAT'/>
         <enum-item name='NO_DRINK'/>
         <enum-item name='NO_SLEEP'/>
@@ -191,7 +194,7 @@
         <enum-item name='NOT_BUTCHERABLE'/>
         <enum-item name='COOKABLE_LIVE'/>
 
-        <enum-item name='SECRETION'/>
+        <enum-item name='HAS_SECRETION'/>
         <enum-item name='IMMOBILE'/>
         <enum-item name='MULTIPART_FULL_VISION'/>
         <enum-item name='MEANDERER'/>
@@ -200,13 +203,13 @@
         <enum-item name='PET'/>
         <enum-item name='PET_EXOTIC'/>
 
-        <enum-item name='unk_38'/>
-        <enum-item name='CAN_SPEAK'/>
-        <enum-item name='CAN_LEARN'/>
+        <enum-item name='HAS_ROTTABLE'/>
+        <enum-item name='CAN_SPEAK' comment='aka INTELLIGENT_SPEAKS'/>
+        <enum-item name='CAN_LEARN' comment='aka INTELLIGENT_LEARNS'/>
         <enum-item name='UTTERANCES'/>
         <enum-item name='BONECARN'/>
         <enum-item name='CARNIVORE'/>
-        <enum-item name='UNDERSWIM'/>
+        <enum-item name='AQUATIC_UNDERSWIM'/>
         <enum-item name='NOEXERT'/>
 
         <enum-item name='NOPAIN'/>
@@ -214,13 +217,13 @@
         <enum-item name='NOBREATHE'/>
         <enum-item name='NOSTUN'/>
         <enum-item name='NONAUSEA'/>
-        <enum-item name='BLOOD'/>
+        <enum-item name='HAS_BLOOD'/>
         <enum-item name='TRANCES'/>
         <enum-item name='NOEMOTION'/>
 
         <enum-item name='SLOW_LEARNER'/>
         <enum-item name='NOSTUCKINS'/>
-        <enum-item name='PUS'/>
+        <enum-item name='HAS_PUS'/>
         <enum-item name='NOSKULL'/>
         <enum-item name='NOSKIN'/>
         <enum-item name='NOBONES'/>
@@ -240,14 +243,14 @@
         <enum-item name='NO_THOUGHT_CENTER_FOR_MOVEMENT'/>
         <enum-item name='ARENA_RESTRICTED'/>
         <enum-item name='LAIR_HUNTER'/>
-        <enum-item name='LIKES_FIGHTING'/>
+        <enum-item name='GELDABLE'/>
         <enum-item name='VERMIN_HATEABLE'/>
         <enum-item name='VEGETATION'/>
         <enum-item name='MAGICAL'/>
 
-        <enum-item name='NATURAL'/>
-        <enum-item name='BABY'/>
-        <enum-item name='CHILD'/>
+        <enum-item name='NATURAL_ANIMAL'/>
+        <enum-item name='HAS_BABYSTATE'/>
+        <enum-item name='HAS_CHILDSTATE'/>
         <enum-item name='MULTIPLE_LITTER_RARE'/>
         <enum-item name='MOUNT'/>
         <enum-item name='MOUNT_EXOTIC'/>
@@ -273,17 +276,17 @@
         <enum-item name='LISP'/>
 
         <enum-item name='GETS_INFECTIONS_FROM_ROT'/>
-        <enum-item name='CASTE_SOLDIER_TILE'/>
+        <enum-item name='HAS_SOLDIER_TILE'/>
         <enum-item name='ALCOHOL_DEPENDENT'/>
-        <enum-item name='SWIMS_INNATE'/>
+        <enum-item name='CAN_SWIM_INNATE'/>
         <enum-item name='POWER'/>
         <enum-item name='TENDONS'/>
         <enum-item name='LIGAMENTS'/>
-        <enum-item name='CASTE_TILE'/>
+        <enum-item name='HAS_TILE'/>
 
-        <enum-item name='CASTE_COLOR'/>
-        <enum-item name='CASTE_GLOWTILE'/>
-        <enum-item name='CASTE_GLOWCOLOR'/>
+        <enum-item name='HAS_COLOR'/>
+        <enum-item name='HAS_GLOW_TILE'/>
+        <enum-item name='HAS_GLOW_COLOR'/>
         <enum-item name='FEATURE_BEAST'/>
         <enum-item name='TITAN'/>
         <enum-item name='UNIQUE_DEMON'/>
@@ -297,7 +300,7 @@
         <enum-item name='MANNERISM_POSTURE'/>
         <enum-item name='MANNERISM_STRETCH'/>
         <enum-item name='MANNERISM_EYELIDS'/>
-        <enum-item name='NIGHT_CREATURE_ANY'/>
+        <enum-item name='NIGHT_CREATURE'/>
 
         <enum-item name='NIGHT_CREATURE_HUNTER'/>
         <enum-item name='NIGHT_CREATURE_BOGEYMAN'/>
@@ -312,8 +315,8 @@
         <enum-item name='RETURNS_VERMIN_KILLS_TO_OWNER'/>
         <enum-item name='HUNTS_VERMIN'/>
         <enum-item name='ADOPTS_OWNER'/>
-        <enum-item name='SOUND_ALERT'/>
-        <enum-item name='SOUND_PEACEFUL_INTERMITTENT'/>
+        <enum-item name='HAS_SOUND_ALERT'/>
+        <enum-item name='HAS_SOUND_PEACEFUL_INTERMITTENT'/>
         <enum-item name='NOT_LIVING'/>
         <enum-item name='NO_PHYS_ATT_GAIN'/>
 
@@ -322,7 +325,7 @@
         <enum-item name='BLOODSUCKER'/>
         <enum-item name='NO_VEGETATION_PERTURB'/>
         <enum-item name='DIVE_HUNTS_VERMIN'/>
-        <enum-item name='GOBBLE_VERMIN'/>
+        <enum-item name='VERMIN_GOBBLER'/>
         <enum-item name='CANNOT_JUMP'/>
         <enum-item name='STANCE_CLIMBER'/>
 
@@ -331,6 +334,12 @@
         <enum-item name='OUTSIDER_CONTROLLABLE'/>
         <enum-item name='LOCAL_POPS_PRODUCE_HEROES'/>
         <enum-item name='STRANGE_MOODS'/>
+        <enum-item name='HAS_GRASP'/>
+        <enum-item name='HAS_FLY_RACE_GAIT'/>
+        <enum-item name='HAS_RACE_GAIT'/>
+        <enum-item name='NIGHT_CREATURE_NIGHTMARE'/>
+        <enum-item name='NIGHT_CREATURE_EXPERIMENTER'/>
+        <enum-item name='SPREAD_EVIL_SPHERES_IF_RULER'/>
     </enum-type>
 
     <enum-type type-name='body_part_raw_flags'>


### PR DESCRIPTION
I've renamed a bunch of creature and caste flags to use their official names as indicated by Toady in the latest Future of the Fortress edition (March 2020): http://www.bay12forums.com/smf//index.php?topic=169696.msg8099138#msg8099138.

I verified the position of the new flags (and many of the previously identified ones) by checking the flag index set in the interaction effect of modded summoning interactions making reference to them (see DFHack/df-structures/pull/375).

This will of course require changes to any scripts/plugins using the old flag names.