### PR TITLE
historical_figure: renamed 'unit_id2' to 'nemesis_id'

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -654,7 +654,7 @@
         <df-flagarray name='flags' index-enum='histfig_flags'/>
 
         <int32_t name='unit_id' ref-target='unit'/>
-        <int32_t name='unit_id2' ref-target='unit' since='v0.40.01' comment='sometimes garbage'/>
+        <int32_t name='nemesis_id' ref-target='nemesis_record' since='v0.40.01' comment='sometimes garbage'/>
         <int32_t name='id'/>
 
         <int32_t name='unk4'/>


### PR DESCRIPTION
As indicated in DFHack/scripts/pull/103.

`modtools/create-unit.lua` appears to be the only script which makes reference to `unit_id2`, so this change shouldn't involve much work.