### PR TITLE
identity identification, affects Units.cpp

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,12 +16,16 @@ that repo.
 
 ## Structures
 - Added globals: ``cur_rain``, ``cur_rain_counter``, ``cur_snow``, ``cur_snow_counter``, ``weathertimer``, ``jobvalue``, ``jobvalue_setter``, ``interactitem``, ``interactinvslot``, ``handleannounce``, ``preserveannounce``, ``updatelightstate``
+- ``agreement_details_data_plot_sabotage``: formerly agreement_details_data_unk10, identified fields
+- ``agreement_details_type``: identified unk10->PlotSabotage
 - ``architectural_element``: new enum
 - ``battlefield``: new struct type
 - ``breed``: new struct type
 - ``creature_handler``: identified vmethods
 - ``history_event_context``: identified fields
 - ``image_set``: new struct type
+- ``identity``: renamed fields civ->entity_id, histfig_id->figure.historical/figure.nemesis, unk_4c->type
+- ``identity_type``: new enum
 - ``interrogation_report``: new struct type
 - ``justification``: new enum
 - ``region_weather``: new struct type

--- a/df.entities.xml
+++ b/df.entities.xml
@@ -329,7 +329,7 @@
         <int32_t name='symbol_claim_id' init-value='-1' comment="different small numbers, but all claimed by the greedy necro diplomat, but not complete number range present"/>
         <int32_t name='claim_year' init-value='-1' comment="Written contents often seem to lack info of being claimed"/>
         <int32_t name='claim_year_tick' init-value='-1' comment="usually init"/>
-        <int32_t init-value='-1'/>
+        <int32_t name='unk_1' init-value='-1'/>
         <pointer name='artifact' type-name='artifact_record'/>
         <int32_t name='site' ref-target='world_site'/>
         <int32_t name='structure_local' init-value='-1'/>
@@ -337,11 +337,11 @@
         <int32_t name='subregion' ref-target='world_region'/>
         <int32_t name='feature_layer_id' ref-target='world_underground_region'/>
         <int32_t name='unk_year' init-value='-1' comment="seems to be current year or -1. Matches up with corresponding field of artifact_record"/>
-        <int32_t init-value='-1' comment="only other value seen was 0"/>
-        <int32_t comment='uninitialized'/>
-        <pointer/>
-        <pointer type-name='historical_entity' comment="illegal values seen. Uninitialized?"/>
-        <pointer type-name='historical_entity' comment="illegal values seen. Uninitialized?"/>
+        <int32_t name='unk_2' init-value='-1' comment="only other value seen was 0"/>
+        <int32_t name='unk_3' comment='uninitialized'/>
+        <pointer name='unk_4'/>
+        <pointer name='unk_5' type-name='historical_entity' has-bad-pointers='true'/>
+        <pointer name='unk_6' type-name='historical_entity' has-bad-pointers='true'/>
     </struct-type>
 
     <struct-type type-name='entity_unk_v47_1' comment='The 3 first vectors are of the same length and somehow connected'>
@@ -1338,7 +1338,7 @@
         <enum-item name='PromisePosition'/>
         <enum-item name='PlotAssassination'/>
         <enum-item name='PlotAbduct'/>
-        <enum-item name='unk10'/>
+        <enum-item name='PlotSabotage'/>
         <enum-item name='PlotConviction'/>
         <enum-item name='Location'/>
         <enum-item name='PlotInfiltrationCoup'/>
@@ -1361,7 +1361,7 @@
             <pointer name='PromisePosition' type-name='agreement_details_data_promise_position'/>
             <pointer name='PlotAssassination' type-name='agreement_details_data_plot_assassination'/>
             <pointer name='PlotAbduct' type-name='agreement_details_data_plot_abduct'/>
-            <pointer name='unk10' type-name='agreement_details_data_unk10'/>
+            <pointer name='PlotSabotage' type-name='agreement_details_data_plot_sabotage'/>
             <pointer name='PlotConviction' type-name='agreement_details_data_plot_conviction'/>
             <pointer name='Location' type-name='agreement_details_data_location'/>
             <pointer name='PlotInfiltrationCoup' type-name='agreement_details_data_plot_infiltration_coup'/>
@@ -1432,17 +1432,16 @@
     </struct-type>
     <struct-type type-name='agreement_details_data_plot_abduct'>
         <int32_t name='actor_index' comment="agreement.parties index"/>
-        <int32_t name='influencer_index' comment="agreement.parties index"/>
         <int32_t name='intermediary_index' init-value='-1' comment="agreement.parties index"/>
         <int32_t name='target_id' ref-target='historical_figure'/>
     </struct-type>
-    <struct-type type-name='agreement_details_data_unk10'>
-        <int32_t/>
-        <int32_t/>
-        <int32_t init-value='-1'/>
-        <int32_t/>
-        <int32_t init-value='-1'/>
-        <int32_t init-value='-1'/>
+    <struct-type type-name='agreement_details_data_plot_sabotage'>
+        <int32_t name='plotter_index' comment="agreement.parties index"/>
+        <int32_t name='actor_index' comment="agreement.parties index"/>
+        <int32_t name='intermediary_index' init-value='-1' comment="agreement.parties index. A guess, as no intermediary cases have been seen"/>
+        <int32_t name='victim_id' ref-target='historical_figure'/>
+        <int32_t name='unk_1' init-value='-1'/>
+        <int32_t name='unk_2' init-value='-1'/>
     </struct-type>
     <struct-type type-name='agreement_details_data_plot_conviction'>
         <stl-vector name='criminal_indices' type-name='int32_t' comment="agreement.parties index. All indices listed, regardless of confessions"/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -779,10 +779,10 @@
     </struct-type>
 
     <enum-type type-name='identity_type' base-type='int32_t'>
-         <enum-item name='Hiding_Curse' comment="Inferred from Units.cpp after examining code using 'unk_4c'"/>
+         <enum-item name='HidingCurse' comment="Inferred from Units.cpp after examining code using 'unk_4c'"/>
          <enum-item name='Unk_1' comment="Not seen. A guess is that it might have been used by deities under cover"/>
-         <enum-item name='True_Name' comment="E.g. of demonic overlords. Can be used by adventurers to gain sway over them"/>
-         <enum-item name='False_Identity' comment="For underhanded purposes"/>
+         <enum-item name='TrueName' comment="E.g. of demonic overlords. Can be used by adventurers to gain sway over them"/>
+         <enum-item name='FalseIdentity' comment="For underhanded purposes"/>
          <enum-item name='Unk_4'/>
          <enum-item name='Identity' comment="Claim a new official identity, seen when religious appointments are received"/>
    </enum-type>
@@ -804,7 +804,7 @@
         <int16_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
 
         <int32_t name='unk_1'/>
-        <int32_t name='histfig_nemesis_id' comment='reference depending on type (below): historical_figure for Hiding_Curse, True_Name and Identity, nemesis_record for False_Identity'/>
+        <int32_t name='histfig_nemesis_id' comment='reference depending on type (below): historical_figure for HidingCurse, TrueName and Identity, nemesis_record for FalseIdentity'/>
         <enum name='type' type-name='identity_type' base-type='int32_t'/>
 
         <int32_t name='birth_year' comment='the fake one, that is'/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -794,12 +794,31 @@
     </struct-type>
 
     <enum-type type-name='identity_type' base-type='int32_t'>
-         <enum-item name='HidingCurse' comment="Inferred from Units.cpp after examining code using 'unk_4c'"/>
-         <enum-item name='Unk_1' comment="Not seen. A guess is that it might have been used by deities under cover"/>
-         <enum-item name='TrueName' comment="E.g. of demonic overlords. Can be used by adventurers to gain sway over them"/>
-         <enum-item name='FalseIdentity' comment="For underhanded purposes"/>
-         <enum-item name='Unk_4'/>
-         <enum-item name='Identity' comment="Claim a new official identity, seen when religious appointments are received"/>
+         <enum-attr name='tag' comment='for identity.id'/>
+         
+         <enum-item name='HidingCurse' comment="Inferred from Units.cpp after examining code using 'unk_4c'">
+            <item-attr name='tag' value='history'/>
+         </enum-item>
+         
+         <enum-item name='Unk_1' comment="Not seen. A guess is that it might have been used by deities under cover">
+            <item-attr name='tag' value='history' comment="guess as to what the ref-target is"/>
+         </enum-item>
+         
+         <enum-item name='TrueName' comment="E.g. of demonic overlords. Can be used by adventurers to gain sway over them">
+            <item-attr name='tag' value='history'/>
+         </enum-item>
+         
+         <enum-item name='FalseIdentity' comment="For underhanded purposes">
+            <item-attr name='tag' value='nemesis'/>
+         </enum-item>
+         
+         <enum-item name='Unk_4'>
+            <item-attr name='tag' value='history' comment="guess as to what the ref-target is"/>
+         </enum-item>
+
+         <enum-item name='Identity' comment="Claim a new official identity, seen when religious appointments are received">
+            <item-attr name='tag' value='history'/>
+         </enum-item>
    </enum-type>
    
     <struct-type type-name='identity'
@@ -819,7 +838,11 @@
         <int16_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
 
         <int32_t name='unk_1'/>
-        <int32_t name='histfig_nemesis_id' comment='reference depending on type (below): historical_figure for HidingCurse, TrueName and Identity, nemesis_record for FalseIdentity'/>
+        <compound name='figure' is-union='true' union-tag-attribute='tag'>
+            <int32_t name='historical' ref-target='historical_figure'/>
+            <int32_t name='nemesis' ref-target='nemesis_record'/>
+        </compound>
+        
         <enum name='type' type-name='identity_type' base-type='int32_t'/>
 
         <int32_t name='birth_year' comment='the fake one, that is'/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -838,9 +838,9 @@
         <int16_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
 
         <int32_t name='unk_1'/>
-        <compound name='figure' is-union='true' union-tag-attribute='tag'>
-            <int32_t name='historical' ref-target='historical_figure'/>
-            <int32_t name='nemesis' ref-target='nemesis_record'/>
+        <compound is-union='true' union-tag-attribute='tag'>
+            <int32_t name='histfig_id' ref-target='historical_figure'/>
+            <int32_t name='nemesis_id' ref-target='nemesis_record'/>
         </compound>
         
         <enum name='type' type-name='identity_type' base-type='int32_t'/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -780,8 +780,8 @@
 
     <enum-type type-name='identity_type' base-type='int32_t'>
          <enum-item name='Hiding_Curse' comment="Inferred from Units.cpp after examining code using 'unk_4c'"/>
-         <enum-item name='Unk_1'/>
-         <enum-item name='Demon_Alias' comment="Seems Demonic overlords acquire those by default, without using them"/>
+         <enum-item name='Unk_1' comment="Not seen. A guess is that it might have been used by deities under cover"/>
+         <enum-item name='True_Name' comment="E.g. of demonic overlords. Can be used by adventurers to gain sway over them"/>
          <enum-item name='False_Identity' comment="For underhanded purposes"/>
          <enum-item name='Unk_4'/>
          <enum-item name='Identity' comment="Claim a new official identity, seen when religious appointments are received"/>
@@ -804,7 +804,7 @@
         <int16_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
 
         <int32_t name='unk_1'/>
-        <int32_t name='histfig_nemesis_id' comment='reference depending on type (below): historical_figure for Hiding_Curse, Demon_Alias and Identity, nemesis_record for False_Identity'/>
+        <int32_t name='histfig_nemesis_id' comment='reference depending on type (below): historical_figure for Hiding_Curse, True_Name and Identity, nemesis_record for False_Identity'/>
         <enum name='type' type-name='identity_type' base-type='int32_t'/>
 
         <int32_t name='birth_year' comment='the fake one, that is'/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -759,7 +759,7 @@
 
         <pointer name='info' type-name='historical_figure_info'/>
 
-        <pointer name='vague_relationships' comment="Do hot have to be available mutually, i.e. DF can display Legends relations forming for the other party that does not have an entry (plus time and other conditions not located)">
+        <pointer name='vague_relationships' comment="Do not have to be available mutually, i.e. DF can display Legends relations forming for the other party that does not have an entry (plus time and other conditions not located)">
             <static-array name='hfid' ref-target='historical_figure' type-name='int32_t' init-value='0' count='6'/>
             <static-array name='relationship' type-name='vague_relationship_type' count='6' comment="unused elements are uninitialized"/>
             <int32_t name='count' comment="number of hf/relationship pairs above"/>
@@ -778,6 +778,15 @@
         <int32_t init-value='-1'/>
     </struct-type>
 
+    <enum-type type-name='identity_type' base-type='int32_t'>
+         <enum-item name='Hiding_Curse' comment="Inferred from Units.cpp after examining code using 'unk_4c'"/>
+         <enum-item name='Unk_1'/>
+         <enum-item name='Demon_Alias' comment="Seems Demonic overlords acquire those by default, without using them"/>
+         <enum-item name='False_Identity' comment="For underhanded purposes"/>
+         <enum-item name='Unk_4'/>
+         <enum-item name='Identity' comment="Claim a new official identity, seen when religious appointments are received"/>
+   </enum-type>
+   
     <struct-type type-name='identity'
                  instance-vector='$global.world.identities.all' key-field='id'>
         dtor 0x8C17FA0
@@ -794,21 +803,20 @@
         <int32_t name='race' ref-target='creature_raw'/>
         <int16_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
 
-        <int32_t/>
-        <int32_t name='histfig_id' ref-target='historical_figure'
-                 comment='when masquerading as another historical figure'/>
-        <int32_t name='unk_4c'/>
+        <int32_t name='unk_1'/>
+        <int32_t name='histfig_nemesis_id' comment='reference depending on type (below): historical_figure for Hiding_Curse, Demon_Alias and Identity, nemesis_record for False_Identity'/>
+        <enum name='type' type-name='identity_type' base-type='int32_t'/>
 
         <int32_t name='birth_year' comment='the fake one, that is'/>
         <int32_t name='birth_second'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <int16_t name='unk_v47_1' init-value='-1'/>
+        <int32_t name='unk_v47_2' init-value='-1'/>
         <enum base-type='int16_t' name='profession' type-name='profession'/>
-        <int32_t name='civ' ref-target='historical_entity'/>
-        <int16_t name="unk_v47_1"/>
-        <int32_t name="unk_v47_2"/>
-        <stl-vector pointer-type='identity_unk_94'/>
-        <stl-vector pointer-type='identity_unk_94'/>
+        <int32_t name='entity_id' ref-target='historical_entity'/>
+        <stl-vector name='unk_4' pointer-type='identity_unk_94'/>
+        <stl-vector name='unk_5' pointer-type='identity_unk_94'/>
     </struct-type>
 
     <struct-type type-name='identity_unk_94'>


### PR DESCRIPTION
This PR requires some extra reviewing and coordination, as it affects Units.cpp and remotefortressreader.cpp as well (a PR will be produced for that after this one).

Toady has thrown us a curve ball in the form of a varying type field. df.identity's field identifying who the character assuming the identity really is is usually a histfig reference, but for some reason it's a nemesis_record reference when it's a spy/criminal.

The good news is that I think I've identified the enum field used to determine the type of identity, while the bad news is that 2½ out of 6 values are unknown, as I haven't seen any examples of them in the two worlds examined. The ½ value is 0, which I haven't seen, but the Units.cpp code implies is used for cursed creatures to hide their identities.
The cases seen are Demons, who seem to routinely get themselves an alias, even if I've failed to find it used anywhere (and it doesn't hide anything as all the fields are -1), False_Identity, for all the ones that extract info and whatnot, and assumed identities for religion position figures, which, like a Demon Alias, doesn't contain any replacement info (obviously, both Demon Alias and Identity has a name field).

Apart from these, there are two unknown enum values, one old (as it sits between Hiding_Curse and Demon_Alias), and one new. The old one might (have been?) used for gods and/or demons assuming false identities, as that was hinted at in Units.cpp.

See also:
https://github.com/DFHack/dfhack/pull/1539
https://github.com/DFHack/scripts/pull/144