### PR TITLE
Name several building related items.

### DIFF
--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -929,11 +929,11 @@
         <enum-item name='fortress_entrance'/>
         <enum-item name='library'/>
         <enum-item name='tavern'/>
-        <enum-item name='countring_house'/>
+        <enum-item name='counting_house'/>
         <enum-item name='guild_hall'/>
         <enum-item name='city_tower'/>
         <enum-item name='shrine'/>
-        <enum-item /> From the string dump the most likely candidate is vault.
+        <enum-item />
         <enum-item name='dormitory'/>
         <enum-item name='dininghall'/>
         30

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -53,7 +53,7 @@
     <enum-type type-name='abstract_building_flags'>
         <enum-item name='Unk0'/>
         <enum-item name='Unk1'/>
-        <enum-item name='Unk2'/>
+        <enum-item name='Unk2' comment="gets toggled when an adventurer has visited it."/>
         <enum-item name='Unk3'/>
         <enum-item name='AllowVisitors'/>
         <enum-item name='AllowResidents'/>
@@ -113,14 +113,14 @@
         <pointer name='unk1' comment='in temples; hfig is the god'>
             <stl-vector name='hfig' ref-target='historical_figure' type-name='int32_t'/>
             <int32_t/>
-            <stl-vector type-name='int16_t'/>
+            <stl-vector name='architectural_elements' comment='used by temples' type-name='architectural_element'/>
 
             <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index' comment='just a guess'/>
             <int32_t name='mat_index'/>
         </pointer>
         <stl-vector name='unk2' type-name='int32_t'/>
-        <int32_t name='unk3'/>
-        <stl-vector name='unk4' type-name='int32_t'/>
+        <int32_t name='parent_building_id' ref-target='abstract_building' comment='Tombs use this to hold which catacomb they are part of.'/>
+        <stl-vector name='child_building_ids' type-name='int32_t' ref-target='abstract_building' comment='Used by catacombs to hold their tombs'/>
         <int32_t name='site_owner_id' ref-target='historical_entity'/>
         <pointer name='scribeinfo' since='v0.42.01' type-name='location_scribe_jobs'/>
         <pointer name='reputation_reports' since='v0.42.01' type-name='site_reputation_info'/>
@@ -914,6 +914,7 @@
         <enum-item name='shop_house'/>
         <enum-item name='warehouse'/>
         <enum-item name='market_square'/>
+        10
         <enum-item name='pasture'/>
         <enum-item name='waste'/>
         <enum-item name='courtyard'/>
@@ -924,9 +925,21 @@
         <enum-item name='tree_house'/>
         <enum-item name='hillock_house'/>
         <enum-item name='mead_hall'/>
+        20
         <enum-item name='fortress_entrance'/>
         <enum-item name='library'/>
         <enum-item name='tavern'/>
+        <enum-item name='countring_house'/>
+        <enum-item name='guild_hall'/>
+        <enum-item name='city_tower'/>
+        <enum-item name='shrine'/>
+        <enum-item /> From the string dump the most likely candidate is vault.
+        <enum-item name='dormitory'/>
+        <enum-item name='dininghall'/>
+        30
+        <enum-item name='necromancer_tower'/>
+        <enum-item name='barrow'/>
+        
     </enum-type>
 
     <struct-type type-name='site_realization_building' key-field='id'>


### PR DESCRIPTION
This extends the site realiziation type enum with the new buildings, and identifies some entries in the abstract buildings as indicated in #397

I would like to visit a vault still to double check if that's the last site realization building entry missing, and my world has a vault in the middle of elf-sites, so maybe I could figure out if I can find a bit more for the elf sites too. That's gonna take a bit though.