### PR TITLE
ui.equipment: rename items_by_type1 -> items_unmanifested

### DIFF
--- a/df.ui.xml
+++ b/df.ui.xml
@@ -457,7 +457,7 @@
         </compound>
 
         <compound name='equipment'>
-            <static-array name='items_by_type1' count='112' index-enum='item_type'>
+            <static-array name='items_unmanifested' count='112' index-enum='item_type'>
                 <stl-vector pointer-type='item'/>
             </static-array>
 


### PR DESCRIPTION
As described by Toady [here](http://www.bay12forums.com/smf/index.php?topic=169696.msg8195533#msg8195533): 
_"When you go to choose a specific item, there are several lists sitting around from back in the arsenal dwarf days - that's an array of item ptr vectors with size item_type_number (ie, a vector of weapons, a vector of helms, etc.).  That's sitting up in the global fort information structure (legacily called 'plotinfo' but I dunno what you all call it -- it has your civ id and the number of reserved bins, tons of fort-type info, along with these item array-vectors which live in a member structure that has equipment data), and there are three arrays like this, one for **'unmanifested' items**, one for 'unassigned' items, and one for 'assigned' items."_

`plotinfo` almost certainly refers to `df.global.ui`, and definitely makes more sense as a name for this structure since it contains a lot of fort mode specific information that is unrelated to the user interface. I don't know whether anyone would want to consider renaming it too.

