### PR TITLE
Identified 'syndrome_dilution_identifier' and 'syndrome_dilution_factor'

### DIFF
--- a/df.creature-raws.xml
+++ b/df.creature-raws.xml
@@ -1047,8 +1047,8 @@
         <stl-vector name='creature_class' pointer-type='stl-string'/>
 
         <compound name='unknown2'>
-            <stl-vector name='unk_v4201_1' pointer-type='stl-string' since='v0.42.01' comment='syndrome-related (seen INEBRIATION)'/>
-            <stl-vector name='unk_v4201_2' type-name='int32_t' since='v0.42.01'/>
+            <stl-vector name='syndrome_dilution_identifier' pointer-type='stl-string' since='v0.42.01' comment='SYNDROME_DILUTION_FACTOR'/>
+            <stl-vector name='syndrome_dilution_factor' type-name='int32_t' since='v0.42.01' comment='SYNDROME_DILUTION_FACTOR'/>
 
             <stl-vector name='gobble_vermin_class' pointer-type='stl-string'/>
             <stl-vector name='gobble_vermin_creature_1' pointer-type='stl-string'/>


### PR DESCRIPTION
Tied to the [SYNDROME_DILUTION_FACTOR](https://dwarffortresswiki.org/index.php/DF2014:Creature_token#SYNDROME_DILUTION_FACTOR) creature token.