### PR TITLE
identified a few enum values

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ that repo.
 ## Structures
 - ``viewscreen_loadgamest``: renamed ``cur_step`` enumeration to match style of ``viewscreen_adopt_regionst`` and ``viewscreen_savegamest``
 - ``viewscreen_savegamest``: identified ``cur_step`` enumeration
+- Identified scattered enum values (some rhythm beats, a couple of corruption unit thoughts, and a few language name categories)
 
 # 0.47.05-beta1
 

--- a/df.art.xml
+++ b/df.art.xml
@@ -1046,16 +1046,17 @@
         <enum-item name='Beat' comment="x"/>
         <enum-item name='PrimaryAccent' comment="!"/>
         <enum-item/>
-        <enum-item/>
-        <enum-item/>
+        <enum-item name='AccentedBeatEarly' comment="X`"/>
+        <enum-item name='BeatEarly' comment="x`"/>
         <enum-item/>
         <enum-item/>
         <enum-item name='AccentedBeatSyncopated' comment="X'"/>
         <enum-item name='BeatSyncopated' comment="x'"/>
+        <enum-item/>
     </enum-type>
 
     <struct-type type-name='beat' comment="Work around to allow 'is-array' of enums">
-        <enum type-name='beat_type' base-type='int32_t'/>
+        <enum name='value' type-name='beat_type' base-type='int32_t'/>
     </struct-type>
 
     <struct-type type-name='rhythm_pattern'>

--- a/df.language.xml
+++ b/df.language.xml
@@ -368,7 +368,7 @@
         <enum-item name='AdventuringGroup'/>
         <enum-item name='Unk13'/>
         <enum-item name='SiteGovernment'/>
-        <enum-item name='Unk15'/> uses site word table
+        <enum-item name='NomadicGroup'/> uses site word table. Can also be SiteGovernment founded by a group not belonging to a civ.
         <enum-item name='Vessel'/>
         <enum-item name='MilitaryUnit'/>
         <enum-item name='Religion'/>
@@ -394,9 +394,9 @@
         <enum-item name='Bridge'/>
         <enum-item name='Tunnel'/>
         <enum-item name='PretentiousEntityPosition'/>
-        <enum-item name='Unk37'/>
+        <enum-item name='Monument'/>
         <enum-item name='Tomb'/>
-        <enum-item name='MigratingGroup'/>
+        <enum-item name='OutcastGroup'/>
 
         40
         <enum-item name='Unk40'/>
@@ -411,7 +411,7 @@
         <enum-item name='MerchantCompany'/>
 
         50
-        <enum-item name='Unk50'/>
+        <enum-item name='CountingHouse'/>
         <enum-item name='CraftGuild'/>
         <enum-item name='Guildhall'/>
         <enum-item name='NecromancerTower'/>

--- a/df.unit-thoughts.xml
+++ b/df.unit-thoughts.xml
@@ -1625,11 +1625,11 @@
             subthought is histfig_relationship_type
         </enum-item>
 
-        <enum-item>
+        <enum-item name='PromisedVampireImmortality'> seen as corruption circumstance
             <item-attr name='xml_caption' value='preying on civilized for blood'/>
         </enum-item>
 
-        <enum-item>
+        <enum-item name='PromisedNecroImmortality'>  seen as corruption circumstance
             <item-attr name='xml_caption' value='unnaturally ageless'/>
         </enum-item>
 
@@ -1692,8 +1692,8 @@
             <item-attr name='xml_caption' value='guildhall petition accepted'/> sic
         </enum-item>
 
-        <enum-item>
-            <item-attr name='xml_caption' value='is entity subordinate'/>
+        <enum-item name="DeferredToSuperior">
+            <item-attr name='xml_caption' value='is entity subordinate'/> seen as intrigue circumstance info
         </enum-item>
 
         <enum-item name='AcceptedGuildhallPetition'>


### PR DESCRIPTION
The changes affect the strangemood plugin as it has a "case" statement listing some of these values.

Edit: The added "empty" beat enum value was added because I've seen it used in a save, but as that pattern wasn't actually used in any music exported legends info doesn't provide any description of it.