### PR TITLE
identified remaining beat enum values

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,9 @@ that repo.
 
 # Future
 
+## Structures
+- Identified remaining rhythm beat enum values
+
 # 0.47.05-r1
 
 ## Structures

--- a/df.art.xml
+++ b/df.art.xml
@@ -931,10 +931,10 @@
     </struct-type>
 
     <enum-type type-name='dance_form_move_group_type' base-type='int32_t'>
-        <enum-item/>
+        <enum-item comment="Might be a null value. Hacked in it did not result in any entry in exported Legends info"/>
         <enum-item name='BasicMovement'/>
         <enum-item name='DancePosition'/>
-        <enum-item/>
+        <enum-item comment="Might not be a group value. Hacked into a group dance it did result in the name but not any description in exported Legends info"/>
         <enum-item name='DanceMove'/>
     </enum-type>
 
@@ -1045,14 +1045,14 @@
         <enum-item name='AccentedBeat' comment="X"/>
         <enum-item name='Beat' comment="x"/>
         <enum-item name='PrimaryAccent' comment="!"/>
-        <enum-item/>
+        <enum-item name='SilentEarly' comment="-`"/>
         <enum-item name='AccentedBeatEarly' comment="X`"/>
         <enum-item name='BeatEarly' comment="x`"/>
-        <enum-item/>
-        <enum-item/>
+        <enum-item name='AccentedEarly' comment="!`"/>
+        <enum-item name='SilentSyncopated' comment="-'"/>
         <enum-item name='AccentedBeatSyncopated' comment="X'"/>
         <enum-item name='BeatSyncopated' comment="x'"/>
-        <enum-item/>
+        <enum-item name='AccentedSyncopated' comment="!'"/>
     </enum-type>
 
     <struct-type type-name='beat' comment="Work around to allow 'is-array' of enums">


### PR DESCRIPTION
Realized you can do the same trick as with unit thoughts, i.e. hack the unknown values in and then see what DF generates (in this case in the form of exported Legends XML).

That didn't work out for the dance moves, though, as DF didn't generate anything identifiable...