### PR TITLE
Give the spheres vector a usable name

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -151,7 +151,7 @@
 
     <struct-type type-name='historical_figure_info'>
         <pointer name="spheres">
-            <stl-vector>
+            <stl-vector name="spheres">
                 <enum base-type='int16_t' type-name='sphere_type'/>
             </stl-vector>
             <stl-vector type-name='int32_t' since='v0.47.01'/>


### PR DESCRIPTION
Moddable gods doesn't work without referring to this variable, which is an anon variable for now, which is sure to result in bad news later. Not sure if `spheres.spheres` is okay, but it's better than anon_1.