### PR TITLE
Add improvement type to job union

### DIFF
--- a/df.jobs.xml
+++ b/df.jobs.xml
@@ -113,7 +113,7 @@
         <compound is-union='true'>
             <int32_t name="hist_figure_id" ref-target='historical_figure'/>
             <int32_t name="race" ref-target='creature_raw'/>
-            <enum base-type='int32_t' name="improvement" ref-target='improvement_type'/>
+            <enum base-type='int32_t' name="improvement" type-name='improvement_type'/>
         </compound>
         <bitfield name='material_category' type-name='job_material_category'/>
 

--- a/df.jobs.xml
+++ b/df.jobs.xml
@@ -113,6 +113,7 @@
         <compound is-union='true'>
             <int32_t name="hist_figure_id" ref-target='historical_figure'/>
             <int32_t name="race" ref-target='creature_raw'/>
+            <enum base-type='int32_t' name="improvement" ref-target='improvement_type'/>
         </compound>
         <bitfield name='material_category' type-name='job_material_category'/>
 


### PR DESCRIPTION
Decoration jobs use this union to specify the item improvement type.

Directly lifted from @quietust's suggestion on Discord:
https://discord.com/channels/793331351645323264/807444467140788254/890981752598843462