### PR TITLE
Import docs build workflow from scripts repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,33 @@ name: Build
 on: [push, pull_request]
 
 jobs:
+  docs:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Set up Python 3
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3
+    - name: Install dependencies
+      run: |
+        pip install 'sphinx<4.4.0'
+    - name: Clone df-structures
+      uses: actions/checkout@v1
+    - name: Set up DFHack
+      run: |
+        git clone https://github.com/DFHack/dfhack.git $HOME/dfhack --depth 1 --branch develop
+        git -C $HOME/dfhack submodule update --init --depth 1 --remote plugins/stonesense scripts
+        rmdir $HOME/dfhack/library/xml
+        ln -sv $(pwd) $HOME/dfhack/library/xml
+    - name: Build docs
+      run: |
+        sphinx-build -W --keep-going -j3 $HOME/dfhack html
+    - name: Upload docs
+      if: success() || failure()
+      uses: actions/upload-artifact@master
+      with:
+        name: docs
+        path: html
   validate:
     runs-on: ubuntu-18.04
     steps:

--- a/how-to-update.rst
+++ b/how-to-update.rst
@@ -4,7 +4,7 @@ Updating DF-structures for a new DF version
 
 .. contents:: Contents
   :local:
-  :depth: 1
+  :depth 1
 
 General Process
 ===============
@@ -31,7 +31,7 @@ directory layout::
 - Commit.
 - Use the tool to verify that the layout of the compound globals
   on linux is correct, and update xml as necessary. Check that
-  unit seems reasonable, etc. Compare the changes in g_src between
+  unit seems reasonable, etc. Compare the changes in `g_src` between
   releases. Delete redundant entries for some linux & osx globals
   in symbols.xml.
 - Compile DFHack without plugins for windows and run devel/find-offsets


### PR DESCRIPTION
This should help catch issues like the changelog entry introduced in #451 sooner.

Dropped "Check for missing docs" (script-docs.py) step because scripts aren't added in df-structures.