### PR TITLE
Announcement display timers are tied to GFPS

### DIFF
--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -410,7 +410,7 @@
         <int16_t name='color' init-value='7'/>
         <bool name='bright' init-value='true'/>
 
-        <int32_t name='duration' init-value='100'/>
+        <int32_t name='duration' init-value='100' comment='remaining graphical frames to display this report in announcement bar'/>
 
         <bitfield name='flags' base-type='uint8_t'>
             <flag-bit name='continuation'
@@ -456,7 +456,7 @@
         <enum base-type='int32_t' type-name='report_zoom_type' name='zoom_type'/>
         <compound type-name='coord' name='pos2'/>
         <enum base-type='int32_t' type-name='report_zoom_type' name='zoom_type2'/>
-        <int16_t name='display_timer' init-value='5000'/>
+        <int16_t name='display_timer' init-value='2000' comment='graphical frames for announcement bar to linger on last line with no new announcement'/>
         <pointer type-name='unit' name='unit1'/>
         <pointer type-name='unit' name='unit2'/>
         <int32_t name='unk_v40_1' init-value='-1' comment='same as unknown field in report'/>


### PR DESCRIPTION
``duration`` and ``display_timer`` values are in graphical frames. Each report line ticks down from 100 before the next line is displayed in the announcement bar. When the last report line is displayed, ``display_timer`` ticks down from the value it was set to. If no new report occurs to reset it, the announcement bar will clear when it hits -1. Some actions like entering a full screen menu will clear all timers.

``display_timer`` value of 2000 is more typical of DF announcements. Value of 5000 is used for "taken by strange mood", but is a bit long to be suited as our default. At 30 GFPS, that's 1.1 minutes versus 2.8.