### PR TITLE
De-anon-ify all structures.

### DIFF
--- a/df.advmode.xml
+++ b/df.advmode.xml
@@ -373,13 +373,13 @@
         <enum name='type' base-type='int32_t' type-name='talk_choice_type'/>
         <compound name='unk'>
             <pointer name='event' type-name='entity_event'/>
-            <pointer/>
-            <int32_t/>
+            <pointer name='unk_1'/>
+            <int32_t name='unk_2'/>
         </compound>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t init-value='-1'/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4' init-value='-1'/>
     </struct-type>
 
     <struct-type type-name='ui_advmode'>
@@ -656,7 +656,7 @@
                 </pointer>
             </stl-vector>
             <stl-string name='filter'/>
-            <int32_t since='v0.47.01'/>
+            <int32_t name='unk_1' since='v0.47.01'/>
             <stl-vector name='targets'>
                 <pointer>
                     <int32_t name="unit_id" ref-target='unit'/>
@@ -702,7 +702,7 @@
             <stl-vector name='all_histfigs' comment='includes dead' type-name='int32_t' ref-target='historical_figure'/>
         </compound>
 
-        <int32_t since='v0.47.01'/>
+        <int32_t name='unk_1' since='v0.47.01'/>
 
         <compound name='interactions'>
             <stl-vector name='party_core_members' type-name='int32_t' ref-target='historical_figure' since='v0.47.01' comment='Contains IDs of the non-pet historical figures that the player party started off with. Figures in this list are eligible for control via tactical mode.'/>
@@ -711,7 +711,7 @@
             <stl-vector name='party_extra_members' type-name='int32_t' ref-target='historical_figure' comment='Contains IDs of non-pet historical figures who joined the player party later on.'/>
             <stl-vector name='unk_86'/>
 
-            <stl-vector since='v0.47.01'/>
+            <stl-vector name='unk_1' since='v0.47.01'/>
             <int32_t name='unk_1e4'/>
             <int32_t name='unk_1e8'/>
             <int32_t name='selected_ability' init-value='-1' comment='natural ability'/>
@@ -792,11 +792,11 @@
             <int32_t name='worship_object' ref-target='historical_figure'/>
             <enum base-type='int32_t' name='profession' type-name='profession'/>
             <int32_t name='origin' ref-target='historical_entity'/>
-            <stl-vector/>
-            <stl-vector/>
+            <stl-vector name='unk_1'/>
+            <stl-vector name='unk_2'/>
             <stl-string name='filter'/>
-            <int8_t/>
-            <int32_t/>
+            <int8_t name='unk_3'/>
+            <int32_t name='unk_4'/>
         </compound>
 
         <int16_t name='move_direction_x' comment='x-axis direction for the last attempted player unit movement: -1 = west, 0 = none, 1 = east'/>
@@ -807,7 +807,7 @@
         <int16_t name='careful_direction_x' comment='x-axis direction for the last attempted careful player unit movement: -1 = west, 0 = none, 1 = east'/>
         <int16_t name='careful_direction_y' comment='y-axis direction for the last attempted careful player unit movement: -1 = north, 0 = none, 1 = south'/>
         <stl-string name='interrupt_performance_warning' comment='the message displayed when the player attempts to move while their unit is performing'/>
-        <int32_t/>
+        <int32_t name='unk_2'/>
         <compound type-name='language_name' name='name_item' comment='used when naming items'/>
     </struct-type>
 
@@ -902,7 +902,7 @@
     </class-type>
 
     <class-type type-name='adventure_environment_pickup_ignite_vegst' inherits-from='adventure_environment_optionst'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='adventure_environment_ingest_materialst' inherits-from='adventure_environment_optionst'>
@@ -914,7 +914,7 @@
     <class-type type-name='adventure_environment_pickup_make_campfirest' inherits-from='adventure_environment_optionst'/>
 
     <class-type type-name='adventure_environment_place_in_bld_containerst' inherits-from='adventure_environment_optionst'>
-        <pointer type-name='building'/>
+        <pointer name='building' type-name='building'/>
     </class-type>
 
     <class-type type-name='adventure_environment_pickup_vermin_eventst' inherits-from='adventure_environment_optionst'>
@@ -940,7 +940,7 @@
     <class-type type-name='adventure_movement_release_hold_itemst' inherits-from='adventure_movement_optionst'/>
     <class-type type-name='adventure_movement_release_hold_tilest' inherits-from='adventure_movement_optionst'/>
     <class-type type-name='adventure_movement_attack_creaturest' inherits-from='adventure_movement_optionst'>
-        <stl-vector type-name='int32_t' ref-target='unit'/>
+        <stl-vector name='targets' type-name='int32_t' ref-target='unit'/>
     </class-type>
 
     <class-type type-name='adventure_movement_hold_tilest' inherits-from='adventure_movement_optionst'>
@@ -984,33 +984,33 @@
     <class-type type-name='adventure_item_interact_pull_outst' inherits-from='adventure_item_interact_choicest'/>
 
     <class-type type-name='adventure_item_interact_heat_from_tilest' inherits-from='adventure_item_interact_choicest'>
-        <pointer type-name='item'/>
-        <compound type-name='coord'/>
-        <compound type-name='coord'/>
+        <pointer name='item' type-name='item'/>
+        <compound name='unk_1' type-name='coord'/>
+        <compound name='unk_2' type-name='coord'/>
     </class-type>
 
     <class-type type-name='adventure_item_interact_fill_from_containerst' inherits-from='adventure_item_interact_choicest'>
-        <pointer type-name='item'/>
-        <pointer type-name='item'/>
-        <compound type-name='coord'/>
-        <compound type-name='coord'/>
+        <pointer name='unk_1' type-name='item'/>
+        <pointer name='unk_2' type-name='item'/>
+        <compound name='unk_3' type-name='coord'/>
+        <compound name='unk_4' type-name='coord'/>
     </class-type>
 
     <class-type type-name='adventure_item_interact_readst' inherits-from='adventure_item_interact_choicest'/>
 
     <class-type type-name='adventure_item_interact_fill_with_materialst' inherits-from='adventure_item_interact_choicest'>
-        <pointer type-name='item'/>
-        <compound type-name='coord'/>
-        <compound type-name='coord'/>
-        <int16_t/>
-        <int32_t/>
-        <int16_t/>
+        <pointer name='unk_1' type-name='item'/>
+        <compound name='unk_2' type-name='coord'/>
+        <compound name='unk_3' type-name='coord'/>
+        <int16_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int16_t name='unk_6'/>
     </class-type>
 
     <class-type type-name='adventure_item_interact_strugglest' inherits-from='adventure_item_interact_choicest'/>
 
     <class-type type-name='adventure_item_interact_give_namest' inherits-from='adventure_item_interact_choicest'>
-        <pointer type-name='item'/>
+        <pointer name='item' type-name='item'/>
     </class-type>
 
 </data-definition>

--- a/df.art.xml
+++ b/df.art.xml
@@ -185,7 +185,7 @@
         <int32_t name='site' ref-target='world_site'/>
         <pointer name='ref' type-name='general_ref'/>
         <int32_t name='year'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='id' ref-target='art_image_chunk'/>
         <int16_t name='subid' ref-target='art_image' aux-value='$$.id'/>
     </struct-type>
@@ -389,10 +389,10 @@
         size_in_lines is not set: "brief verse" if less than 6, otherwise "full verse"
         <int32_t name='size'/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
         <stl-vector name='line_endings' type-name='int32_t'/>
         <stl-vector name='line_feet' type-name='int32_t'/> "the Nth line has XX feet"
         <stl-vector name='line_patterns'>
@@ -425,7 +425,7 @@
         <stl-vector name='line_action'>
             <enum base-type='int32_t' type-name='poetic_form_action'/>
         </stl-vector>
-        <stl-vector type-name='int32_t'/>
+        <stl-vector name='unk_5' type-name='int32_t'/>
 
         <int32_t name='some_lines_syllables'/> "it has lines with ... syllables"
         <int32_t name='some_lines_pattern'/> "it has lines with a tone/accent pattern of ..."
@@ -439,11 +439,11 @@
         </stl-vector>
 
         <enum name='mood' base-type='int32_t' type-name='poetic_form_mood'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
         <enum name='action' base-type='int32_t' type-name='poetic_form_action'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
     </struct-type>
 
     <struct-type type-name='poetic_form_perspective'>
@@ -459,7 +459,7 @@
             <enum-item name='Animal'/>
         </enum>
         <int32_t name='histfig' ref-target='historical_figure'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </struct-type>
 
     <enum-type type-name='musical_form_purpose' base-type='int32_t'>
@@ -1105,25 +1105,25 @@
     </struct-type>
 
     <struct-type type-name='occupation_sub1'>
-        <int32_t/>
-        <int32_t/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int16_t name='unk_3'/>
+        <int16_t name='unk_4'/>
+        <int16_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
+        <int32_t name='unk_10'/>
+        <int32_t name='unk_11'/>
+        <int32_t name='unk_12'/>
+        <int32_t name='unk_13'/>
+        <int32_t name='unk_14'/>
+        <int32_t name='unk_15'/>
+        <int32_t name='unk_16'/>
+        <int32_t name='unk_17'/>
+        <int32_t name='unk_18'/>
+        <int32_t name='unk_19'/>
     </struct-type>
 
 </data-definition>

--- a/df.buildings.xml
+++ b/df.buildings.xml
@@ -669,10 +669,10 @@
             <flag-bit name='animal_training'/>
             <flag-bit name='gather'/>
         </bitfield>
-        <int32_t init-value='-1'/>
-        <int32_t init-value='-1'/>
+        <int32_t name='unk_1' init-value='-1'/>
+        <int32_t name='unk_2' init-value='-1'/>
         <int32_t name='zone_num' init-value='-1'/>
-        <int32_t/>
+        <int32_t name='unk_3'/>
         <bitfield name='pit_flags' base-type='uint32_t'>
             <flag-bit name='is_pond'/>
             <flag-bit/>
@@ -845,7 +845,7 @@
         <compound name='links' type-name='stockpile_links'/>
         <int32_t name='max_general_orders'/>
         <bool name='block_general_orders'/>
-        <padding size='3'/>
+        <padding name='pad_1' size='3'/>
         <static-array name='blocked_labors' type-name='bool' count='94' index-enum='unit_labor'/>
     </struct-type>
 
@@ -912,7 +912,7 @@
     <class-type type-name='building_bookcasest' inherits-from='building_actual'/>
 
     <class-type type-name='building_boxst' inherits-from='building_actual'>
-        <int16_t/>
+        <int16_t name='unk_1'/>
         <stl-vector name='squads' pointer-type='building_squad_use'/>
         <int32_t name='specific_squad' ref-target='squad'/>
         <int32_t name='specific_position' init-value='-1'/>
@@ -932,7 +932,7 @@
     </class-type>
 
     <class-type type-name='building_cabinetst' inherits-from='building_actual'>
-        <int16_t/>
+        <int16_t name='unk_1'/>
         <stl-vector name='squads' pointer-type='building_squad_use'/>
         <int32_t name='specific_squad' ref-target='squad'/>
         <int32_t name='specific_position' init-value='-1'/>
@@ -956,7 +956,7 @@
     </class-type>
 
     <class-type type-name='building_chairst' inherits-from='building_actual'>
-        <int16_t/>
+        <int16_t name='unk_1'/>
         <compound name='users' type-name='building_users'/>
     </class-type>
 
@@ -1071,7 +1071,7 @@
     </class-type>
 
     <class-type type-name='building_instrumentst' inherits-from='building_actual'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='building_nestst' inherits-from='building_actual'/>
@@ -1133,11 +1133,11 @@
     </class-type>
 
     <class-type type-name='building_slabst' inherits-from='building_actual'>
-        <int16_t/>
+        <int16_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='building_statuest' inherits-from='building_actual'>
-        <int16_t/>
+        <int16_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='building_supportst' inherits-from='building_actual'>
@@ -1154,7 +1154,7 @@
     </class-type>
 
     <class-type type-name='building_traction_benchst' inherits-from='building_actual'>
-        <int16_t/>
+        <int16_t name='unk_1'/>
         <compound name='users' type-name='building_users'/>
     </class-type>
 
@@ -1243,14 +1243,14 @@
             <flag-bit name='lowering'/>
             <flag-bit name='just_raised'/>
         </bitfield>
-        <int8_t/>
+        <int8_t name='unk_1'/>
         <int16_t name='bucket_z'/>
         <int8_t name='bucket_timer' comment='0-9; counts up when raising, down when lowering'/>
         <int16_t name='check_water_timer'/>
     </class-type>
 
     <class-type type-name='building_windowst' inherits-from='building_actual'>
-        <int16_t/>
+        <int16_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='building_window_glassst' inherits-from='building_windowst'/>

--- a/df.creature-raws.xml
+++ b/df.creature-raws.xml
@@ -549,8 +549,8 @@
         <int32_t name='growth_end'/>
         <int32_t name='importance'/>
         <stl-string name='noun'/>
-        <int16_t/>
-        <int16_t/>
+        <int16_t name='unk_1'/>
+        <int16_t name='unk_2'/>
         <int32_t name='id'/>
         <int32_t name='id2' comment='same as id'/>
     </struct-type>
@@ -662,8 +662,8 @@
     <struct-type type-name='creature_interaction'>
         <stl-vector pointer-type='stl-string' name='bp_required_type'/>
         <stl-vector pointer-type='stl-string' name='bp_required_name'/>
-        <stl-string/>
-        <stl-string/>
+        <stl-string name='unk_1'/>
+        <stl-string name='unk_2'/>
         <stl-string name='material_str0'/>
         <stl-string name='material_str1'/>
         <stl-string name='material_str2'/>
@@ -684,13 +684,13 @@
             <flag-bit name='VERBAL'/>
             <flag-bit name='FREE_ACTION'/>
         </bitfield>
-        <stl-vector pointer-type='stl-string'/>
+        <stl-vector name='unk_3' pointer-type='stl-string'/>
         <stl-vector name='target_flags' type-name='creature_interaction_target_flags'/>
         <stl-vector name='target_ranges' type-name='int32_t'/>
-        <stl-vector pointer-type='stl-string'/>
+        <stl-vector name='unk_4' pointer-type='stl-string'/>
         <stl-vector name='max_target_numbers' type-name='int32_t'/>
         <stl-vector name='verbal_speeches' type-name='int32_t'/>
-        <stl-vector/>
+        <stl-vector name='unk_5'/>
         <stl-string name='adv_name'/>
         <int32_t name='wait_period'/>
     </struct-type>
@@ -713,19 +713,19 @@
 
         <stl-vector name='extra_butcher_objects'>
             <pointer>
-                <int16_t/>
-                <stl-string/>
-                <int32_t/>
-                <stl-string/>
-                <stl-string/>
-                <stl-string/>
-                <stl-string/>
-                <stl-string/>
-                <int16_t/>
-                <int16_t/>
-                <int16_t/>
-                <int32_t/>
-                <int32_t/>
+                <int16_t name='unk_1'/>
+                <stl-string name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <stl-string name='unk_4'/>
+                <stl-string name='unk_5'/>
+                <stl-string name='unk_6'/>
+                <stl-string name='unk_7'/>
+                <stl-string name='unk_8'/>
+                <int16_t name='unk_9'/>
+                <int16_t name='unk_10'/>
+                <int16_t name='unk_11'/>
+                <int32_t name='unk_12'/>
+                <int32_t name='unk_13'/>
             </pointer>
         </stl-vector>
 
@@ -1093,21 +1093,21 @@
         <stl-vector name='lair_characteristic_1' type-name='int16_t'/>
         <stl-vector name='lair_characteristic_2' type-name='int32_t'/>
         <compound name='lair_hunter_speech'>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector/>
+            <stl-vector name='unk_1' type-name='int32_t'/>
+            <stl-vector name='unk_2'/>
         </compound>
         <compound name='unk29'>
-            <stl-vector/>
-            <stl-vector type-name='int32_t'/>
+            <stl-vector name='unk_1'/>
+            <stl-vector name='unk_2' type-name='int32_t'/>
         </compound>
         <static-array name='specific_food' count='2'><stl-vector/></static-array>
 
         <stl-vector name='sound'>
             <pointer>
-                <int32_t/>
-                <int32_t init-value='100'/>
-                <int32_t init-value='1000'/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2' init-value='100'/>
+                <int32_t name='unk_3' init-value='1000'/>
+                <int32_t name='unk_4'/>
                 <static-array name='caption' type-name='stl-string' count='3'/>
             </pointer>
         </stl-vector>
@@ -1115,15 +1115,15 @@
         <stl-vector type-name='int32_t' name='sound_peaceful_intermittent'
                     refers-to='$$._global.sound[$]'/>
 
-        <stl-vector since='v0.34.01'>
+        <stl-vector name='unk_1' since='v0.34.01'>
             <pointer>
-                <stl-string/>
-                <stl-string/>
-                <stl-string/>
-                <int16_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <stl-string name='unk_1'/>
+                <stl-string name='unk_2'/>
+                <stl-string name='unk_3'/>
+                <int16_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
+                <int32_t name='unk_7'/>
             </pointer>
         </stl-vector>
 

--- a/df.entities.xml
+++ b/df.entities.xml
@@ -40,9 +40,9 @@
         <enum name='type' base-type='int32_t' type-name='occasion_schedule_type'/>
         <int32_t name='reference' comment="art form / event / item_type /procession start abstract building"/>
         <int32_t name='reference2' comment="item_subtype / procession stop abstract building"/>
-        <int32_t />
-        <int32_t />
-        <int32_t />
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
         <stl-vector name='features' pointer-type='entity_occasion_schedule_feature' />
         <int32_t name='start_year_tick'/>
         <int32_t name='end_year_tick'/>
@@ -71,9 +71,9 @@
     <struct-type type-name='entity_occasion_schedule_feature'>
         <enum name='feature' base-type='int32_t' type-name='occasion_schedule_feature'/>
         <int32_t name='reference' />
-        <int32_t />
-        <int32_t />
-        <int32_t />
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
     </struct-type>
     <struct-type type-name='entity_activity_statistics'>
         <compound name='food'>
@@ -87,13 +87,13 @@
         </compound>
         <static-array name='unit_counts' type-name='int16_t' count='152' index-enum='profession'/>
         <int16_t name='population'/>
-        <int16_t/>
-        <int16_t comment='in 0.23, omnivores'/>
-        <int16_t comment='in 0.23, carnivores'/>
+        <int16_t name='unk_1'/>
+        <int16_t name='unk_2' comment='in 0.23, omnivores'/>
+        <int16_t name='unk_3' comment='in 0.23, carnivores'/>
         <int16_t name='trained_animals'/>
         <int16_t name='other_animals'/>
-        <int16_t comment='in 0.23, potential soldiers'/>
-        <int32_t comment='in 0.23, combat aptitude'/>
+        <int16_t name='unk_4' comment='in 0.23, potential soldiers'/>
+        <int32_t name='unk_5' comment='in 0.23, combat aptitude'/>
         <static-array name='item_counts' type-name='int32_t' count='112' index-enum='item_type'/>
         <stl-vector name='created_weapons' type-name='int32_t' index-refers-to='$global.world.raws.itemdefs.weapons[$]'/>
         <compound name='wealth'>
@@ -106,7 +106,7 @@
             <int32_t name='displayed'/>
             <int32_t name='held'/>
             <int32_t name='imported'/>
-            <int32_t/>
+            <int32_t name='unk_1'/>
             <int32_t name='exported'/>
         </compound>
         <static-array name='recent_jobs' count='7'>
@@ -121,7 +121,7 @@
         <int32_t name='total_insanities'/>
         <int32_t name='total_executions'/>
         <int32_t name='num_artifacts'/>
-        <int32_t comment='in 0.23, total siegers'/>
+        <int32_t name='unk_6' comment='in 0.23, total siegers'/>
         <stl-vector name='discovered_creature_foods' type-name='bool' index-refers-to='(find-creature $)'/>
         <stl-vector name='discovered_creatures' type-name='bool' index-refers-to='(find-creature $)'/>
         <stl-vector name='discovered_plant_foods' type-name='bool' index-refers-to='(find-plant-raw $)'/>
@@ -141,7 +141,7 @@
 
     <struct-type type-name='caravan_state'>
         <int32_t name='total_capacity'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <enum name='trade_state' base-type='int8_t'>
             <enum-item name='None'/>
             <enum-item name='Approaching'/>
@@ -173,7 +173,7 @@
         <pointer type-name='entity_buy_prices' name='buy_prices'/>
         <stl-vector name='goods' type-name='int32_t' ref-target='item'/>
         <int32_t name='mood' comment='reflects satisfaction with last trading session'/>
-        <int32_t/>
+        <int32_t name='unk_2'/>
     </struct-type>
 
     <struct-type type-name='entity_buy_prices'>
@@ -447,7 +447,7 @@
             <stl-vector name='instrument_type' type-name='int16_t' ref-target='itemdef_instrumentst'/>
             <stl-vector name='siegeammo_type' type-name='int16_t' ref-target='itemdef_siegeammost'/>
             <stl-vector name='tool_type' type-name='int16_t' ref-target='itemdef_toolst'/>
-            <stl-vector type-name='int32_t' since='v0.42.01'/>
+            <stl-vector name='unk_1' type-name='int32_t' since='v0.42.01'/>
 
             <compound name='metal'>
                 <compound name='pick' type-name='material_vec_ref'/>
@@ -562,7 +562,7 @@
 
             <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/>
 
-            <int32_t since='v0.42.01'/>
+            <int32_t name='unk_2' since='v0.42.01'/>
             <static-array name='permitted_skill' type-name='bool' index-enum='job_skill' count='147'/>
 
             <stl-vector type-name='int16_t' name='art_image_types' comment='0 = civilization symbol'/>
@@ -596,8 +596,8 @@
                     <int32_t name='source_site' ref-target='world_site'/>
                     <int32_t name='destination_site' ref-target='world_site'/>
                     <stl-vector name='construction' ref-target='construction' type-name='int32_t' comment="set only for the first (source) entry in pairs"/>
-                    <int16_t comment="0 and 1 seen, paired with same value in the next field"/>
-                    <int16_t comment="0 and 1 seen"/>
+                    <int16_t name='unk_1' comment="0 and 1 seen, paired with same value in the next field"/>
+                    <int16_t name='unk_2' comment="0 and 1 seen"/>
                 </pointer>
             </stl-vector>
 
@@ -608,7 +608,7 @@
                     <int32_t name='war_event_collection' ref-target='history_event_collection' comment="always and only with relation = 1/5"/>
                     <stl-vector name='historic_events' type-name='int32_t' ref-target='history_event'/>
                     <stl-vector name='historic_events_collection' type-name='int32_t' ref-target='history_event_collection' comment="seen with war_event_collection set"/>
-                    <int32_t comment="0, 1, 4 seen. Non zero seen with relation 0/1"/>
+                    <int32_t name='unk_1' comment="0, 1, 4 seen. Non zero seen with relation 0/1"/>
                     <enum base-type='int32_t' type-name='season' name='tribute_season'/>
                 </pointer>
             </stl-vector>
@@ -676,7 +676,7 @@
         <stl-vector name='performed_dance_forms' type-name='int32_t' ref-target='dance_form' since='v0.42.01'/>
         <stl-vector name='major_civ_number' type-name='int32_t' since='v0.42.01' comment="Single item increasing from 0 linearly as major race civs are created, i.e. all civs except cavern and Kobold, but including spire breach released goblin ones"/>
         <stl-vector name='major_civ_number_2' type-name='int32_t' since='v0.42.01' comment="Identical to major_civ_number on the same entries. Presumably some properties only major civs have, such as e.g. accepting outsiders as members, engage in conquest, etc."/>
-        <stl-vector type-name='int32_t' since='v0.42.01' comment="Only on major civs, but not all"/>
+        <stl-vector name='unk_1' type-name='int32_t' since='v0.42.01' comment="Only on major civs, but not all"/>
         <pointer name='occasion_info' type-name='entity_occasion_info' comment="only seen on Civilization, SiteGovernment, and Religion, but not all"/>
 
         <stl-vector name='artifact_claims' pointer-type='artifact_claim' since='v0.44.01' comment='sorted on artifact id'/>
@@ -712,9 +712,9 @@
             <static-array name='offerings_history' count='10' type-name='int32_t' comment='rotated yearly at 15th of Timber'/>
             <int32_t name='unk49e' comment='in 0.23, hostility level - determined siege size, had a chance to reset to 1'/>
             <int32_t name='unk49f' comment='in 0.23, determined siege size'/>
-            <int32_t since='v0.40.01'/>
-            <int32_t since='v0.47.01'/>
-            <int32_t since='v0.47.01'/>
+            <int32_t name='unk_1' since='v0.40.01'/>
+            <int32_t name='unk_2' since='v0.47.01'/>
+            <int32_t name='unk_3' since='v0.47.01'/>
         </compound>
 
         <stl-vector name='armies' pointer-type='army' since='v0.40.01'/>
@@ -779,10 +779,10 @@
             <stl-vector name='weapon_proficiencies' type-name='job_skill'/>
 
             <pointer name='resource_allotment' type-name='resource_allotment_data' comment="Only for SiteGovernment, but not all"/>
-            <stl-vector since='v0.42.01' pointer-type='poetic_form'/>
-            <stl-vector since='v0.42.01' pointer-type='musical_form'/>
-            <stl-vector since='v0.42.01' pointer-type='dance_form'/>
-            <stl-vector since='v0.42.01' pointer-type='written_content'/>
+            <stl-vector name='unk_1' since='v0.42.01' pointer-type='poetic_form'/>
+            <stl-vector name='unk_2' since='v0.42.01' pointer-type='musical_form'/>
+            <stl-vector name='unk_3' since='v0.42.01' pointer-type='dance_form'/>
+            <stl-vector name='unk_4' since='v0.42.01' pointer-type='written_content'/>
             <int16_t name='unk12a' init-value='-1'/>
             <int16_t name='unk12b' comment='uninitialized'/>
             <bool name='unk13' comment='0'/>
@@ -813,9 +813,9 @@
             <int32_t name='unk_BC'/>
             <int32_t name='unk_C0'/>
 
-            <int32_t since='v0.47.01'/>?
-            <int32_t since='v0.47.01'/>?
-            <int32_t since='v0.47.01'/>?
+            <int32_t name='unk_5' since='v0.47.01'/>?
+            <int32_t name='unk_6' since='v0.47.01'/>?
+            <int32_t name='unk_7' since='v0.47.01'/>?
 
             <static-array name='unk26a' count='38' type-name='int32_t'/>
             <static-array name='unk26b' count='38' type-name='int32_t'/>
@@ -825,22 +825,22 @@
 
             <stl-vector name='unk28'>
                 <pointer>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
+                    <int32_t name='unk_1'/>
+                    <int32_t name='unk_2'/>
+                    <int32_t name='unk_3'/>
                 </pointer>
             </stl-vector>
-            <int32_t since='v0.47.01'/>?
+            <int32_t name='unk_8' since='v0.47.01'/>?
             <stl-vector name='unk29' since='v0.34.01'>
                 <pointer>
-                    <int32_t/>
-                    <stl-vector type-name='int32_t'/>
-                    <int32_t/>
+                    <int32_t name='unk_1'/>
+                    <stl-vector name='unk_2' type-name='int32_t'/>
+                    <int32_t name='unk_3'/>
                 </pointer>
             </stl-vector>
-            <int32_t since='v0.47.01'/>
-            <int32_t since='v0.47.01'/>
-            <int32_t since='v0.47.01'/>
+            <int32_t name='unk_9' since='v0.47.01'/>
+            <int32_t name='unk_10' since='v0.47.01'/>
+            <int32_t name='unk_11' since='v0.47.01'/>
         </compound>
     </struct-type>
 
@@ -852,7 +852,7 @@
 
         <stl-string name='name'/>
         <stl-vector name='preferred_shapings' type-name='int16_t'/>
-        <stl-vector type-name='int32_t' comment='maybe probability?'/>
+        <stl-vector name='unk_1' type-name='int32_t' comment='maybe probability?'/>
         <int32_t name='maintain_length_min'/>
         <int32_t name='maintain_length_max'/>
         <int32_t name='id'/>
@@ -937,7 +937,7 @@
         <int16_t name='land_holder'/>
         <int16_t name='requires_population'/>
 
-        <int16_t since='v0.34.01'/>
+        <int16_t name='unk_1' since='v0.34.01'/>
 
         <int32_t name='precedence' init-value='30001'/>
         <int32_t name='replaced_by' init-value='-1'/>
@@ -960,7 +960,7 @@
         <int32_t name='required_tomb'/>
         <int32_t name='mandate_max'/>
         <int32_t name='demand_max'/>
-        <int32_t init-value='30001' since='v0.47.01'/>
+        <int32_t name='unk_2' init-value='30001' since='v0.47.01'/>
     </struct-type>
 
     <struct-type type-name='entity_position_assignment' key-field='id'>
@@ -980,12 +980,12 @@
 
         <df-flagarray name='flags'/>
         <int32_t name='squad_id' ref-target='squad'/>
-        <int32_t init-value='-1'/>
-        <int32_t init-value='-1'/>
-        <int32_t init-value='-1' since='v0.40.01'/>
-        <int32_t init-value='-1' since='v0.40.01'/>
-        <stl-vector since='v0.40.01' comment='not saved'/>
-        <int32_t since='v0.47.01' comment='unknown size, not initialized or saved'/>
+        <int32_t name='unk_1' init-value='-1'/>
+        <int32_t name='unk_2' init-value='-1'/>
+        <int32_t name='unk_3' init-value='-1' since='v0.40.01'/>
+        <int32_t name='unk_4' init-value='-1' since='v0.40.01'/>
+        <stl-vector name='unk_5' since='v0.40.01' comment='not saved'/>
+        <int32_t name='unk_6' since='v0.47.01' comment='unknown size, not initialized or saved'/>
     </struct-type>
 
     <enum-type type-name='entity_material_category' base-type='int16_t'>
@@ -1110,7 +1110,7 @@
             <compound name='invasion'>
                 <int32_t name='entity_id' ref-target='historical_entity'/>
                 <int32_t name='site_id' ref-target='world_site'/>
-                <int32_t comment="can't find match. not defender hf/nemesis, for instance"/>
+                <int32_t name='unk_1' comment="can't find match. not defender hf/nemesis, for instance"/>
                 <int32_t name='attack_leader_hf' ref-target='historical_figure'/>
             </compound>
             <compound name='abduction'>
@@ -1120,14 +1120,14 @@
                 <int32_t name='event' ref-target='history_event'/>
             </compound>
             <compound name='incident'>
-                <int32_t/>
+                <int32_t name='unk_1'/>
                 <int32_t name='incident_id' ref-target='incident'/>
             </compound>
             <compound name='occupation'>
                 <int32_t name='site_id' ref-target='world_site'/>
                 <int32_t name='entity_id' ref-target='historical_entity'/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </compound>
             <compound name='beast'>
                 <int32_t name='histfig_id' ref-target='historical_figure'/>
@@ -1141,7 +1141,7 @@
             <compound name='harass'>
                 <int32_t name='entity_id' ref-target='historical_entity'/>
                 <int32_t name='site_id' ref-target='world_site'/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
             </compound>
             <compound name='flee'>
                 <int32_t name='refugee_entity_id' ref-target='historical_entity'/>
@@ -1164,19 +1164,19 @@
                 <int32_t name='entity_id' ref-target='historical_entity'/>
                 <int32_t name='site_id' ref-target='world_site'/>
                 <int32_t name='parent_entity_id' ref-target='historical_entity'/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
             </compound>
             <compound name='reclaiming'>
                 <int32_t name='entity_id' ref-target='historical_entity'/>
                 <int32_t name='site_id' ref-target='world_site'/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
                 <int32_t name='first_settler_hf' ref-target='historical_figure' comment="strangely enough not expedition leader (settler #2), nor listed as member of site government"/>
             </compound>
             <compound name='founding'>
                 <int32_t name='entity_id' ref-target='historical_entity'/>
                 <int32_t name='region_id' ref-target='world_region'/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </compound>
             <compound name='leave'>
                 <int32_t name='entity_id' ref-target='historical_entity'/>
@@ -1252,62 +1252,62 @@
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
                 <int32_t name='site_id' ref-target='world_site'/>
                 <int32_t name='structure_id' ref-target='abstract_building'/>
-                <int32_t comment="looks uninitialized"/>
+                <int32_t name='unk_1' comment="looks uninitialized"/>
             </compound>
             <compound name='artifact_in_subregion'>
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
                 <int32_t name='subregion_id' ref-target='world_region'/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </compound>
             <compound name='artifact_in_feature_layer'>
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
                 <int32_t name='feature_layer_id' ref-target='world_underground_region'/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </compound>
             <compound name='artifact_in_inventory'>
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
                 <int32_t name='hist_figure_id' ref-target='historical_figure'/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </compound>
             <compound name='artifact_not_in_site'>
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
                 <int32_t name='site_id' ref-target='world_site'/>
                 <int32_t name='structure_id' ref-target='abstract_building'/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
             </compound>
             <compound name='artifact_not_in_subregion'>
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
                 <int32_t name='subregion_id' ref-target='world_region'/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </compound>
             <compound name='artifact_not_in_feature_layer'>
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
                 <int32_t name='feature_layer_id' ref-target='world_underground_region'/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </compound>
             <compound name='artifact_not_in_inventory'>
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
                 <int32_t name='hist_figure_id' ref-target='historical_figure'/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </compound>
             <compound name='artifact_destroyed'>
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
             </compound>
         </compound>
         <int32_t name='unk_year' comment="often the same as the other year/tick. Start/stop time?"/>
         <int32_t name='unk_year_tick'/>
         <int32_t name="year"/>
         <int32_t name="year_tick"/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <enum name='type' type-name='entity_event_type'/>
     </struct-type>
 
@@ -1330,10 +1330,10 @@
         <int32_t name='id'/>
         <stl-vector type-name='int32_t' name='histfig_ids' ref-target='historical_figure'/>
         <stl-vector type-name='int32_t' name='entity_ids' ref-target='historical_entity'/>
-        <stl-vector>
+        <stl-vector name='unk_1'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
                 <int32_t name='year'/>
                 <int32_t name='tick'/>
             </pointer>
@@ -1420,11 +1420,11 @@
         <int32_t name='site' ref-target='world_site'/>
     </struct-type>
     <struct-type type-name='agreement_details_data_parley'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='party_id' ref-target='agreement_party'/>
     </struct-type>
     <struct-type type-name='agreement_details_data_position_corruption'>
-        <int32_t comment="247-249 seen"/>
+        <int32_t name='unk_1' comment="247-249 seen"/>
         <int32_t name='actor_index' comment="agreement.parties index"/>
         <int32_t name='influencer_index' init-value='-1' comment="agreement.parties index"/>
         <int32_t name='intermediary_index' init-value='-1' comment="agreement.parties index"/>
@@ -1489,7 +1489,7 @@
         <int32_t name='influencer_index' comment="agreement.parties index"/>
         <int32_t name='victim_id' ref-target='historical_figure'/>
         <int32_t name='fool_id' ref-target='historical_figure'/>
-        <int32_t ref-target='historical_figure' comment="only same as fool_id seen, and so may be swapped. Guess it would be sentencer if different from fooled hf, though"/>
+        <int32_t name='unk_1' ref-target='historical_figure' comment="only same as fool_id seen, and so may be swapped. Guess it would be sentencer if different from fooled hf, though"/>
     </struct-type>
     <struct-type type-name='agreement_details_data_plot_induce_war'>
         <int32_t name='actor_index' comment="agreement.parties index"/>

--- a/df.graphics.xml
+++ b/df.graphics.xml
@@ -137,8 +137,8 @@
         <bool name='fullscreen'/>
 
         <stl-deque name='overridden_grid_sizes'>
-            <int32_t/>
-            <int32_t/>
+            <int32_t name='x'/>
+            <int32_t name='y'/>
         </stl-deque>
 
         <pointer name='renderer' type-name='renderer'/>

--- a/df.history.xml
+++ b/df.history.xml
@@ -154,7 +154,7 @@
             <stl-vector name="spheres">
                 <enum base-type='int16_t' type-name='sphere_type'/>
             </stl-vector>
-            <stl-vector type-name='int32_t' since='v0.47.01'/>
+            <stl-vector name='unk_1' type-name='int32_t' since='v0.47.01'/>
         </pointer>
 
         <pointer name="skills">
@@ -169,8 +169,8 @@
 
             only a guess since most of figures have 102 (STANDARD); some have stuff like CLERK, SCOUT, BEAST_HUNTER, etc
             <enum base-type='int16_t' name='profession' type-name='profession'/>
-            <int32_t since='v0.44.01'/>
-            <int32_t name = "account_balance" comment = "Abstract tracker of this individual's wealth" since='v0.47.01'/>
+            <int32_t name='unk_1' since='v0.44.01'/>
+            <int32_t name="account_balance" comment = "Abstract tracker of this individual's wealth" since='v0.47.01'/>
             <pointer name='employment_held' since='v0.47.01'>
                 <stl-vector name='employment'>
                     <pointer>
@@ -193,7 +193,7 @@
 
         <pointer name='personality'>
             <compound name='personality' type-name='unit_personality'/>
-            <int16_t since='v0.44.01'/>
+            <int16_t name='unk_1' since='v0.44.01'/>
         </pointer>
 
         <pointer name="masterpieces">
@@ -210,8 +210,8 @@
             <int32_t name="region_id" ref-target='world_region'/>
             <int32_t name="underground_region_id" ref-target='world_underground_region'/>
             <int32_t name="army_id" ref-target='army'/>
-            <int32_t init-value='-1'/>
-            <int32_t init-value='-1'/>
+            <int32_t name='unk_1' init-value='-1'/>
+            <int32_t name='unk_2' init-value='-1'/>
             <int32_t init-value='-1' name='pos_x' comment='same coordinate system as army'/>
             <int32_t init-value='-1' name='pos_y'/>
             <bitfield name='flags'>
@@ -407,13 +407,13 @@
                     <int32_t name='unk_3' since='v0.47.01'/>
                 </pointer>
             </stl-vector>
-            <stl-vector> different from above - this might be wanted.unk
+            <stl-vector name='unk_1'> different from above - this might be wanted.unk
                 <pointer>
                     <int32_t name='entity_id' ref-target='historical_entity'/>
 
                     Constructor and save/load code handles the following 5 fields as if they were a compound, separate from the integer above
-                    <stl-vector type-name='int32_t'/>
-                    <stl-vector type-name='int32_t'/>
+                    <stl-vector name='unk_1' type-name='int32_t'/>
+                    <stl-vector name='unk_2' type-name='int32_t'/>
                     <int32_t name="discovered_year"/>
                     <int32_t name="discovered_time"/>
                     <int32_t name="unsolved_murders"/>
@@ -505,9 +505,9 @@
         <stl-vector name='hf_historical' since='v0.44.01'>
             <pointer>
                 <int32_t name='histfig_id' ref-target='historical_figure'/>
-                <stl-vector type-name='int32_t'/>
-                <stl-vector type-name='int32_t'/>
-                <stl-vector type-name='int32_t'/>
+                <stl-vector name='unk_1' type-name='int32_t'/>
+                <stl-vector name='unk_2' type-name='int32_t'/>
+                <stl-vector name='unk_3' type-name='int32_t'/>
                 <int32_t name='loyalty' comment="0 - 100" since='v0.47.01'/>
                 <int32_t name='respect' comment="-100 - 100" since='v0.47.01'/>
                 <int32_t name='fear' comment="-100 - 100" since='v0.47.01'/>
@@ -515,11 +515,11 @@
                 <int32_t name='trust' comment="-100 - 100" since='v0.47.01'/>
             </pointer>
         </stl-vector>
-        <stl-vector since='v0.44.01'>
+        <stl-vector name='unk_1' since='v0.44.01'>
             <pointer>
-                <int32_t/>
-                <stl-vector type-name='int32_t'/>
-                <stl-vector type-name='int32_t'/>
+                <int32_t name='unk_1'/>
+                <stl-vector name='unk_2' type-name='int32_t'/>
+                <stl-vector name='unk_3' type-name='int32_t'/>
                 guessing these are the same 5 fields as above, since they have the same version threshold
                 <int32_t name='loyalty' comment="0 - 100" since='v0.47.01'/>
                 <int32_t name='respect' comment="-100 - 100" since='v0.47.01'/>
@@ -532,13 +532,13 @@
         <stl-vector name='artifact_claims' since='v0.44.01'>
             <pointer>
                 <int32_t name='artifact_id' ref-target='artifact_record'/>
-                <int32_t comment="only 2 seen"/>
+                <int32_t name='unk_1' comment="only 2 seen"/>
                 <int32_t name='year'/>
                 <int32_t name='year_tick'/>
-                <int32_t init-value='-1'/>
+                <int32_t name='unk_2' init-value='-1'/>
             </pointer>
         </stl-vector>
-        <int32_t/>
+        <int32_t name='unk_2'/>
         <pointer name='intrigues'>
             <stl-vector name='potential_corrupt_skill'>
                 <comment>
@@ -646,20 +646,20 @@
             <stl-vector name='unk11' type-name='int32_t' comment="4 bytes allocated observed, which cant' host a pointer"/>
             <stl-vector name='unk12'>
                 <pointer>
-                    <int32_t/>
+                    <int32_t name='unk_1'/>
                     <int32_t name='unk_4'/>
-                    <int32_t/>
+                    <int32_t name='unk_2'/>
                     <compound name='unk_data' is-union='true'> based on unk_4
                         <pointer name='ptr_0'>
-                            <int32_t/>
-                            <int32_t/>
-                            <int32_t/>
-                            <int32_t/>
+                            <int32_t name='unk_1'/>
+                            <int32_t name='unk_2'/>
+                            <int32_t name='unk_3'/>
+                            <int32_t name='unk_4'/>
                         </pointer>
                         <pointer name='ptr_1'>
-                            <int32_t/>
-                            <int32_t/>
-                            <int32_t/>
+                            <int32_t name='unk_1'/>
+                            <int32_t name='unk_2'/>
+                            <int32_t name='unk_3'/>
                         </pointer>
                         <pointer name='ptr_2'>
                         </pointer>
@@ -1819,7 +1819,7 @@
         <int32_t name='defender_civ' ref-target='historical_entity'/>
         <int32_t name='site_civ' ref-target='historical_entity'/>
         <int32_t name='site' ref-target='world_site'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='history_event_created_sitest' inherits-from='history_event'>
@@ -2596,7 +2596,7 @@
         <int32_t name='teacher' ref-target='historical_figure'/>
         <int32_t name='artifact' ref-target='artifact_record'/>
         <int32_t name='interaction' ref-target='interaction'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <enum-type type-name='histfig_body_state' base-type='int8_t'>
@@ -3617,7 +3617,7 @@
         <stl-vector name='unk_histfig_3' pointer-type='historical_figure'/>
         <stl-vector name='unk_histfig_4' pointer-type='historical_figure'/>
         <stl-vector name='unk_histfig_5' pointer-type='historical_figure'/>
-        <stl-vector pointer-type='historical_figure' since='v0.47.01'/>
+        <stl-vector name='unk_1' pointer-type='historical_figure' since='v0.47.01'/>
 
         11 - necromancers
         <static-array name='unk_v40_1' since='v0.40.01' count='15'>

--- a/df.interaction.xml
+++ b/df.interaction.xml
@@ -88,36 +88,36 @@
     </class-type>
 
     <class-type type-name='interaction_effect_animatest' inherits-from='interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <stl-vector name='syndrome' pointer-type='syndrome'/>
     </class-type>
 
     <class-type type-name='interaction_effect_add_syndromest' inherits-from='interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <stl-vector name='syndrome' pointer-type='syndrome'/>
     </class-type>
 
     <class-type type-name='interaction_effect_resurrectst' inherits-from='interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <stl-vector name='syndrome' pointer-type='syndrome'/>
     </class-type>
 
     <class-type type-name='interaction_effect_cleanst' inherits-from='interaction_effect'>
         <int32_t name='grime_level' comment='IE_GRIME_LEVEL'/>
         <bitfield name='syndrome_tag' type-name='syndrome_flags' comment='IE_SYNDROME_TAG'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='interaction_effect_contactst' inherits-from='interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='interaction_effect_material_emissionst' inherits-from='interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='interaction_effect_hidest' inherits-from='interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='interaction_effect_change_item_qualityst' inherits-from='interaction_effect'>
@@ -126,12 +126,12 @@
     </class-type>
 
     <class-type type-name='interaction_effect_change_weatherst' inherits-from='interaction_effect'>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
     </class-type>
 
     <class-type type-name='interaction_effect_raise_ghostst' inherits-from='interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <stl-vector name='syndrome' pointer-type='syndrome' comment='assumed based on vmethod reference'/>
     </class-type>
 
@@ -145,15 +145,15 @@
         <int32_t name='quality_min' comment='IE_ITEM_QUALITY'/>
         <int32_t name='quality_max' comment='IE_ITEM_QUALITY'/>
         <int32_t name='create_artifact' comment='IE_ITEM_QUALITY:ARTIFACT'/>
-        <stl-string/>
-        <stl-string/>
-        <stl-string/>
-        <stl-string/>
-        <stl-string/>
+        <stl-string name='unk_1' comment='these five are probably item1:item2:mat1:mat2:mat3'/>
+        <stl-string name='unk_2'/>
+        <stl-string name='unk_3'/>
+        <stl-string name='unk_4'/>
+        <stl-string name='unk_5'/>
     </class-type>
 
     <class-type type-name='interaction_effect_propel_unitst' inherits-from='interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='propel_force' comment='IE_PROPEL_FORCE'/>
     </class-type>
 
@@ -161,14 +161,14 @@
         <int32_t name='make_pet' comment='IE_MAKE_PET_IF_POSSIBLE'/>
         <stl-string name='race_str' comment='CREATURE'/>
         <stl-string name='caste_str' comment='CREATURE'/>
-        <stl-vector type-name='int32_t' comment="seen 4 bytes allocated"/>
-        <stl-vector type-name='int16_t' comment="seen 2 bytes allocate"/>
+        <stl-vector name='unk_1' type-name='int32_t' comment="seen 4 bytes allocated"/>
+        <stl-vector name='unk_2' type-name='int16_t' comment="seen 2 bytes allocate"/>
         <stl-vector type-name='int32_t' name='required_creature_flags' comment='contains indexes of flags in creature_raw_flags, IE_CREATURE_FLAG'/>
         <stl-vector type-name='int32_t' name='forbidden_creature_flags' comment='contains indexes of flags in creature_raw_flags, IE_FORBIDDEN_CREATURE_FLAG'/>
         <stl-vector type-name='int32_t' name='required_caste_flags' comment='contains indexes of flags in caste_raw_flags, IE_CREATURE_CASTE_FLAG'/>
         <stl-vector type-name='int32_t' name='forbidden_caste_flags' comment='contains indexes of flags in caste_raw_flags, IE_FORBIDDEN_CREATURE_CASTE_FLAG'/>
-        <int32_t init-value='-1'/>
-        <int32_t init-value='-1'/>
+        <int32_t name='unk_3' init-value='-1'/>
+        <int32_t name='unk_4' init-value='-1'/>
         <int32_t name='time_range_min' comment='IE_TIME_RANGE'/>
         <int32_t name='time_range_max' comment='IE_TIME_RANGE'/>
     </class-type>
@@ -240,12 +240,12 @@
         <stl-vector name='goals' type-name='goal_type'/>
         <stl-string name='book_title_filename'/>
         <stl-string name='book_name_filename'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
     </class-type>
 
     <class-type type-name='interaction_source_disturbancest' inherits-from='interaction_source'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <enum-type type-name='interaction_source_usage_hint' base-type='int32_t'>
@@ -265,26 +265,26 @@
     </enum-type>
 
     <class-type type-name='interaction_source_deityst' inherits-from='interaction_source'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <stl-vector name='usage_hint' type-name='interaction_source_usage_hint' comment='IS_USAGE_HINT'/>
     </class-type>
 
     <class-type type-name='interaction_source_attackst' inherits-from='interaction_source'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='interaction_source_ingestionst' inherits-from='interaction_source'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='interaction_source_creature_actionst' inherits-from='interaction_source'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='interaction_source_underground_specialst' inherits-from='interaction_source'/>
 
     <class-type type-name='interaction_source_experimentst' inherits-from='interaction_source'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <enum-type type-name='interaction_target_type'>
@@ -399,7 +399,7 @@
     <struct-type type-name='interaction_instance' instance-vector='$global.world.interaction_instances.all' key-field='id'>
         <int32_t name='id'/>
         <int32_t name='interaction_id' ref-target='interaction'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='region_index'/>
         <stl-vector name='affected_units' type-name='int32_t' ref-target='unit' comment='IDs of units affected by the regional interaction'/>
     </struct-type>

--- a/df.itemimprovements.xml
+++ b/df.itemimprovements.xml
@@ -23,7 +23,7 @@
         <enum base-type='int16_t' name='quality' type-name='item_quality'/>
         <enum base-type='int16_t' name="skill_rating" type-name='skill_rating'
               comment='at the moment of creation'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </struct-type>
 
     <class-type type-name='itemimprovement' original-name='itemimprovementst'>
@@ -105,7 +105,7 @@
         <compound name='cloth'>
             <int32_t name='unit_id' ref-target='historical_figure'/>
             <int16_t name='quality'/>
-            <int16_t/>
+            <int16_t name='unk_1'/>
         </compound>
         <compound name='dye' type-name='dye_info'/>
     </class-type>
@@ -117,11 +117,11 @@
 
     <class-type type-name='itemimprovement_illustrationst' inherits-from='itemimprovement'>
         <compound name='image' type-name='art_image_ref'/>
-        <int32_t since='v0.34.01'/>
+        <int32_t name='unk_2' since='v0.34.01'/>
     </class-type>
 
     <class-type type-name='itemimprovement_instrument_piecest' inherits-from='itemimprovement'>
-        <stl-string/>
+        <stl-string name='unk_2'/>
     </class-type>
 
     <class-type type-name='itemimprovement_writingst' inherits-from='itemimprovement'>

--- a/df.items.xml
+++ b/df.items.xml
@@ -66,7 +66,7 @@
     <struct-type type-name='item_magicness'>
         <enum base-type='int16_t' name="type" type-name='item_magicness_type'/>
         <int16_t name='value' comment='boosts item value by 50*this'/>
-        <int16_t/>
+        <int16_t name='unk_1'/>
         <int32_t name='flags' comment='1=does not show up in item description or alter item value'/>
     </struct-type>
 
@@ -84,7 +84,7 @@
         <bitfield base-type='uint16_t' name='base_flags' since='v0.40.13'>
             <flag-bit name='evaporates' comment='does not contaminate tile when washed away'/>
         </bitfield>
-        <padding size='2' comment='needed for proper alignment of spatter on gcc'/>
+        <padding name='pad_1' size='2' comment='needed for proper alignment of spatter on gcc'/>
     </struct-type>
 
     <struct-type type-name='spatter' inherits-from='spatter_common'>
@@ -193,8 +193,8 @@
                     comment='only if the object is made of a "specific creature mat"'/>
             <vmethod ret-type='int16_t' name='getPlantID'
                     comment='only if the object is made of a plant material'/>
-            <vmethod ret-type='int32_t' comment='gets plant growth anon_1' since='v0.40.01'/>
-            <vmethod comment='sets plant growth anon_1' since='v0.40.01'><int32_t/></vmethod>
+            <vmethod ret-type='int32_t' name='getGrowthPrint' since='v0.40.01'/>
+            <vmethod name='setGrowthPrint' since='v0.40.01'><int32_t name='print'/></vmethod>
             <vmethod ret-type='int32_t' name='getDimension' since='v0.40.01'/>
 
             <vmethod ret-type='int32_t' name='getTotalDimension'/>
@@ -463,7 +463,7 @@
             <vmethod name='propagateUnitRefs'/> add to unit.owned_items/traded_items
             <vmethod ret-type='bool' name='isBag' comment='BOX made of cloth'/>
             <vmethod ret-type='bool' name='isSand'/>
-            <vmethod comment='returns item_actual.anon_1'/>
+            <vmethod comment='returns item_actual.unk_1'/>
 
             <vmethod ret-type='int32_t' name='getStackSize'/>
             <vmethod name='addStackSize'> <int32_t name='amount'/> </vmethod>
@@ -1057,7 +1057,7 @@
         <int16_t name='recipe_id'/>
         <stl-vector name='ingredients'>
             <pointer>
-                <int16_t/>
+                <int16_t name='unk_1'/>
                 <enum base-type='int16_t' name='item_type' type-name='item_type'/>
                 <int16_t name='unk_4' init-value='-1'/>
                 <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
@@ -1119,16 +1119,16 @@
         <int32_t name='hatchling_unit_unk_c0' init-value='-1'
                  comment='hatchlings will have this unit.unk_c0 value'/>
 
-        <int32_t since='v0.40.01'/> position uncertain
+        <int32_t name='unk_2' since='v0.40.01'/> position uncertain
 
         <pointer name='mothers_genes' type-name='unit_genes' comment='object owned by egg item'/>
         <int16_t name='mothers_caste' ref-target='caste_raw' aux-value='$$.race'/>
-        <int32_t since='v0.40.01'/>
+        <int32_t name='unk_3' since='v0.40.01'/>
 
         <pointer name='fathers_genes' type-name='unit_genes' comment='object owned by egg item'/>
         <int16_t name='fathers_caste' ref-target='caste_raw' aux-value='$$.race'
                  comment='-1 if no father genes'/>
-        <int32_t since='v0.40.01'/>
+        <int32_t name='unk_4' since='v0.40.01'/>
 
         <bitfield name='hatchling_flags1' type-name='unit_flags1'
                   comment='used primarily for bit_flag:tame'/>
@@ -1233,8 +1233,8 @@
         <int32_t name='sharpness'/>
         <compound name='stockpile' type-name='item_stockpile_ref'/>
         <int32_t name='vehicle_id' ref-target='vehicle' since='v0.34.08'/>
-        <int32_t since='v0.47.01' init-value='-1'/>
-        <int32_t since='v0.47.01' init-value='-1'/>
+        <int32_t name='unk_2' since='v0.47.01' init-value='-1'/>
+        <int32_t name='unk_3' since='v0.47.01' init-value='-1'/>
     </class-type>
 
     <struct-type type-name='item_stockpile_ref'>
@@ -1300,7 +1300,7 @@
 
     <class-type type-name='item_sheetst' inherits-from='item_constructed'>
         <int32_t name='dimension'/>
-        <int32_t/>
+        <int32_t name='unk_2'/>
     </class-type>
 </data-definition>
 

--- a/df.jobs.xml
+++ b/df.jobs.xml
@@ -453,7 +453,7 @@
             <enum-item name='Activated'/>
             <enum-item name='Completed'/>
         </enum>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </struct-type>
 
     <struct-type type-name='manager_order_template'>
@@ -466,7 +466,7 @@
         <bitfield name="item_category" type-name='stockpile_group_set'/>
         <int32_t name="hist_figure_id" ref-target='historical_figure'/>
         <bitfield name="material_category" type-name='job_material_category'/>
-        <int32_t init-value='1'/>
+        <int32_t name='unk_1' init-value='1'/>
     </struct-type>
 
     <enum-type type-name='guild_id' base-type='int16_t'>

--- a/df.language.xml
+++ b/df.language.xml
@@ -174,7 +174,7 @@
 
         <uint8_t name='adj_dist'/>
 
-        <padding size='7' comment='looks like garbage'/>
+        <padding size='7' name='pad_1' comment='looks like garbage'/>
 
         <bitfield name='flags' type-name='language_word_flags'/>
 

--- a/df.legends.xml
+++ b/df.legends.xml
@@ -16,29 +16,29 @@
             <flag-bit name='parley'/>
         </bitfield>
         <int16_t name='unk4b'/>
-        <int32_t since='v0.44.01'/>
-        <int32_t since='v0.44.01'/>
-        <int32_t since='v0.44.01'/>
-        <int32_t since='v0.44.01'/>
-        <int32_t since='v0.44.01'/>
+        <int32_t name='unk_1' since='v0.44.01'/>
+        <int32_t name='unk_2' since='v0.44.01'/>
+        <int32_t name='unk_3' since='v0.44.01'/>
+        <int32_t name='unk_4' since='v0.44.01'/>
+        <int32_t name='unk_5' since='v0.44.01'/>
     </struct-type>
 
     <struct-type type-name='entity_population_unk4'>
-        <stl-vector comment="all 3 vectors share a single index series, with the third being interleaved with at least the second one">
+        <stl-vector name='unk_1' comment="all 3 vectors share a single index series, with the third being interleaved with at least the second one">
             <pointer>
                 <int32_t name='idx'/>
                 <int32_t name='unk1'/>
                 <int32_t name='unk2'/>
             </pointer>
         </stl-vector>
-        <stl-vector>
+        <stl-vector name='unk_2'>
             <pointer>
                 <int32_t name='idx'/>
                 <int32_t name='unk1'/>
                 <int32_t name='unk2'/>
             </pointer>
         </stl-vector>
-        <stl-vector>
+        <stl-vector name='unk_3'>
             <pointer>
                 <int32_t name='idx'/>
                 <int32_t name='unk1'/>
@@ -127,10 +127,10 @@
         <int32_t name='abs_tile_x'/>
         <int32_t name='abs_tile_y'/>
         <int32_t name='abs_tile_z'/>
-        <int32_t since='v0.44.01'/>
+        <int32_t name='unk_1' since='v0.44.01'/>
         <int32_t name='site' ref-target='world_site'/>
         <int32_t name='structure_local' ref-target='abstract_building'/>
-        <int32_t init-value='-1' since='v0.47.01'/>
+        <int32_t name='unk_2' init-value='-1' since='v0.47.01'/>
         <int32_t name='subregion' ref-target='world_region'/>
         <int32_t name='feature_layer' ref-target='world_underground_region'/>
         <int32_t name='owner_hf' ref-target='historical_figure' comment="namer/creator does not seem to require a claim to be shown"/>
@@ -140,11 +140,11 @@
         <int32_t name='storage_site' ref-target='world_site' since='v0.44.01'/>
         <int32_t name='storage_structure_local' ref-target='abstract_building' since='v0.44.01'/>
         <int32_t name='loss_region' ref-target='world_region' since='v0.44.01'/>
-        <int32_t since='v0.44.01' init-value='-1'/>
+        <int32_t name='unk_3' since='v0.44.01' init-value='-1'/>
         <int32_t name='holder_hf' since='v0.44.01' ref-target='historical_figure' comment="doesn't seem to require a claim"/>
         <int32_t name='year' since='v0.44.01' init-value='-1' comment="seems to be current year or -1"/>
-        <int32_t since='v0.44.01' init-value='-1'/>
-        <int32_t  init-value='0' comment="Small set of non zero fairly small numbers seen?"/>
+        <int32_t name='unk_4' since='v0.44.01' init-value='-1'/>
+        <int32_t name='unk_5' init-value='0' comment="Small set of non zero fairly small numbers seen?"/>
     </struct-type>
 </data-definition>
 

--- a/df.map.xml
+++ b/df.map.xml
@@ -332,10 +332,10 @@
     <df-linked-list-type type-name='cave_column_link' item-type='cave_column'/>
 
     <class-type type-name='cave_column' df-list-link-type='cave_column_link' df-list-link-field='' original-name='cave_columnst'>
-        <int16_t/>
-        <int16_t/>
-        <int16_t init-value='30000'/>
-        <bitfield base-type='uint8_t'>
+        <int16_t name='unk_1'/>
+        <int16_t name='unk_2'/>
+        <int16_t name='unk_3' init-value='30000'/>
+        <bitfield name='unk_4' base-type='uint8_t'>
             <flag-bit/>
             <flag-bit/>
         </bitfield>
@@ -350,14 +350,14 @@
     </class-type>
 
     <class-type type-name='cave_column_rectangle' original-name='cave_column_rectanglest'>
-        <int32_t/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
+        <int32_t name='unk_1'/>
+        <int16_t name='unk_2'/>
+        <int16_t name='unk_3'/>
+        <int16_t name='unk_4'/>
+        <int16_t name='unk_5'/>
         <int16_t name='z_shift'/>
-        <compound type-name='coord_path'/>
-        <bitfield>
+        <compound name='unk_6' type-name='coord_path'/>
+        <bitfield name='unk_7'>
             <flag-bit/>
             <flag-bit/>
             <flag-bit/>
@@ -581,8 +581,8 @@
     <class-type type-name='feature' original-name='featurest'>
         <stl-vector name='population' pointer-type='world_population'/>
 
-        <int32_t/>
-        <int16_t/>
+        <int32_t name='unk_1'/>
+        <int16_t name='unk_2'/>
 
         <compound name='embark_pos' type-name='coord2d_path'/>
         <stl-vector name='min_map_z' type-name='int16_t'/>
@@ -762,8 +762,8 @@
     </class-type>
 
     <class-type type-name='feature_alteration_new_pop_maxst' inherits-from='feature_alteration'>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
     </class-type>
 
     <class-type type-name='feature_alteration_new_lava_fill_zst' inherits-from='feature_alteration'>
@@ -986,7 +986,7 @@
     </class-type>
 
     <class-type type-name='flow_guide_trailing_flowst' inherits-from='flow_guide'>
-        <static-array type-name='coord' count='15'/>
+        <static-array name='unk_1' type-name='coord' count='15'/>
     </class-type>
 
     <class-type type-name='flow_guide_item_cloudst' inherits-from='flow_guide'>
@@ -996,12 +996,12 @@
         <int32_t name='matindex'/>
         <int32_t name="unk_18"/>
         <int32_t name="unk_1c"/>
-        <static-array type-name='coord' count='15'/>
+        <static-array name='unk_1' type-name='coord' count='15'/>
     </class-type>
 
     <struct-type type-name='effect_info'>
         <int32_t name='id' comment='assigned during Save'/>
-        <pointer type-name='job'/>
+        <pointer name='job' type-name='job'/>
         <int16_t name='type' comment='2 = falling into chasm'/>
         <int16_t name='foreground'/>
         <int16_t name='background'/>
@@ -1028,7 +1028,7 @@
     </class-type>
 
     <class-type type-name='region_block_event_sphere_fieldst' inherits-from='region_block_eventst'>
-        <static-array type-name='int16_t' count='16'/>
+        <static-array name='unk_1' type-name='int16_t' count='16'/>
     </class-type>
 
 </data-definition>

--- a/df.meeting.xml
+++ b/df.meeting.xml
@@ -205,8 +205,8 @@
         <enum base-type='int16_t' type-name='meeting_event_type' name='type'/>
         <enum base-type='int16_t' type-name='meeting_topic' name='topic'/>
         <int16_t name='topic_parm'/>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int32_t'/>
+        <stl-vector name='unk_1' type-name='int32_t'/>
+        <stl-vector name='unk_2' type-name='int32_t'/>
         <int32_t name='quota_total'/>
         <int32_t name='quota_remaining'/>
         <int32_t name='year'/>
@@ -347,18 +347,18 @@
 
         <stl-vector name='unk_v42_1'>
             <pointer>
-                <int32_t/>
+                <int32_t name='unk_1'/>
                 <int32_t name='item_id' ref-target='item' comment='is artifact id for some activities ie. copy written'/>
-                <int32_t init-value='0'/>
+                <int32_t name='unk_2' init-value='0'/>
             </pointer>
         </stl-vector>
         <stl-vector name='unk_v42_2'>
             <pointer>
-                <int32_t/>
-                <int32_t init-value='-1'/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2' init-value='-1'/>
                 <int32_t name='item_id' ref-target='item'
                          comment='is unit ID for writing jobs and reading'/>
-                <int32_t init-value='0'/>
+                <int32_t name='unk_3' init-value='0'/>
             </pointer>
         </stl-vector>
 
@@ -485,34 +485,34 @@
     </class-type>
 
     <class-type type-name='activity_event_harassmentst' inherits-from='activity_event'>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector>
+        <stl-vector name='unk_1' type-name='int32_t'/>
+        <stl-vector name='unk_2'>
             <pointer>
-                <int32_t/>
-                <static-array type-name='int32_t' count='3'/>
+                <int32_t name='unk_1'/>
+                <static-array name='unk_2' type-name='int32_t' count='3'/>
 
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
 
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_7'/>
+                <int32_t name='unk_8'/>
+                <int32_t name='unk_9'/>
+                <int32_t name='unk_10'/>
 
-                <stl-vector type-name='int32_t'/>
+                <stl-vector name='unk_11' type-name='int32_t'/>
 
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_12'/>
+                <int32_t name='unk_13'/>
             </pointer>
         </stl-vector>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
     </class-type>
 
     <enum-type type-name='conversation_menu'>
@@ -606,28 +606,28 @@
         </stl-vector>
         <enum name='menu' type-name='conversation_menu'/>
         <compound name='unk1' type-name='entity_event'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
         <int32_t name='unk_v42_3' since='v0.42.01'/>
         <stl-vector type-name='int32_t' name='unk_v42_4' since='v0.42.01'/>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector>
+        <stl-vector name='unk_5' type-name='int32_t'/>
+        <stl-vector name='unk_6'>
             <pointer>
-                <int32_t/>
-                <int16_t/>
-                <int16_t/>
-                <int16_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int16_t name='unk_2'/>
+                <int16_t name='unk_3'/>
+                <int16_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
+                <int32_t name='unk_7'/>
+                <int32_t name='unk_8'/>
+                <int32_t name='unk_9'/>
             </pointer>
         </stl-vector>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int32_t'/>
+        <stl-vector name='unk_7' type-name='int32_t'/>
+        <stl-vector name='unk_8' type-name='int32_t'/>
         <compound name='unk_b4'>
             <int32_t name='unk_1'/>
             <int32_t name='unk_2'/>
@@ -651,11 +651,11 @@
                 <int32_t name='year'/>
                 <int32_t name='ticks'/>
 
-                copies of anon_2 through anon_5 in this turn's talk_choice:
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t name='unk_v4014_1' since='v0.40.14' comment='uninit'/>
+                copies of unk_1 thru unk_4 in this turn's talk_choice:
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_34014_1' since='v0.40.14' comment='uninit'/>
             </pointer>
         </stl-vector>
         <int32_t name='floor_holder' ref-target='unit' comment="-1 = no one's turn"/>
@@ -666,35 +666,35 @@
             <flag-bit name='shouting'/>
         </bitfield>
         <compound name='unk2'>
-            <stl-vector pointer-type='incident'/>
-            <int32_t/>
-            <int32_t/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
+            <stl-vector name='unk_1' pointer-type='incident'/>
+            <int32_t name='unk_2'/>
+            <int32_t name='unk_3'/>
+            <stl-vector name='unk_4' type-name='int32_t'/>
+            <stl-vector name='unk_5' type-name='int32_t'/>
+            <stl-vector name='unk_6' type-name='int32_t'/>
+            <stl-vector name='unk_7' type-name='int32_t'/>
+            <stl-vector name='unk_8' type-name='int32_t'/>
+            <stl-vector name='unk_9' type-name='int32_t'/>
+            <stl-vector name='unk_10' type-name='int32_t'/>
+            <stl-vector name='unk_11' type-name='int32_t'/>
+            <stl-vector name='unk_12' type-name='int32_t'/>
+            <stl-vector name='unk_13' type-name='int32_t'/>
+            <stl-vector name='unk_14' type-name='int32_t'/>
+            <stl-vector name='unk_15' type-name='int32_t'/>
+            <stl-vector name='unk_16' type-name='int32_t'/>
+            <stl-vector name='unk_17' type-name='int32_t'/>
+            <int32_t name='unk_18'/>
+            <int32_t name='unk_19'/>
+            <int32_t name='unk_20'/>
+            <int32_t name='unk_21'/>
+            <int32_t name='unk_22'/>
+            <int32_t name='unk_23'/>
+            <int32_t name='unk_24'/>
+            <int32_t name='unk_25'/>
+            <int32_t name='unk_26'/>
+            <int32_t name='unk_27'/>
+            <int32_t name='unk_28'/>
+            <int32_t name='unk_29'/>
         </compound>
         <stl-vector name='choices' pointer-type='talk_choice'/>
         <enum name='unk3' type-name='conversation_menu' init-value='None'/>
@@ -702,7 +702,7 @@
         <static-array type-name='int32_t' count='11' name='unk4' comment='uninitialized'/>
         <!-- array was previously:
             <compound type-name='entity_event' comment='copy of unk1'/>
-            <int32_t comment='copy of anon_1'/>
+            <int32_t comment='copy of anon1'/>
             but was consistently uninitialized
         -->
     </class-type>
@@ -719,30 +719,30 @@
                         <enum name='conflict_level' type-name='conflict_level'/>
                     </pointer>
                 </stl-vector>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </pointer>
         </stl-vector>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
         <int32_t name='unk_v42_3' since='v0.42.01'/>
     </class-type>
 
     <class-type type-name='activity_event_guardst' inherits-from='activity_event'>
-        <stl-vector type-name='int32_t'/>
-        <compound type-name='coord'/>
-        <int32_t/>
+        <stl-vector name='unk_1' type-name='int32_t'/>
+        <compound name='unk_2' type-name='coord'/>
+        <int32_t name='unk_3'/>
     </class-type>
 
     <class-type type-name='activity_event_reunionst' inherits-from='activity_event'>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int32_t'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <stl-vector name='unk_1' type-name='int32_t'/>
+        <stl-vector name='unk_2' type-name='int32_t'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
     </class-type>
 
     <class-type type-name='activity_event_prayerst' inherits-from='activity_event'>
@@ -760,7 +760,7 @@
         <int32_t name='site_id' ref-target='world_site'/>
         <int32_t name='location_id' ref-target='abstract_building' aux-value='$$.site_id'/>
         <int32_t name='building_id'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='activity_event_worshipst' inherits-from='activity_event'>
@@ -768,7 +768,7 @@
         <int32_t name='site_id' ref-target='world_site'/>
         <int32_t name='location_id' ref-target='abstract_building' aux-value='$$.site_id'/>
         <int32_t name='building_id'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <enum-type type-name='performance_event_type'>
@@ -847,16 +847,16 @@
     </class-type>
 
     <class-type type-name='performance_play_orderst'>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <stl-vector name='unk_4'>
             <pointer>
-                <static-array type-name='int16_t' count='28'/>
-                <static-array type-name='int16_t' count='28'/>
+                <static-array name='unk_1' type-name='int16_t' count='28'/>
+                <static-array name='unk_2' type-name='int16_t' count='28'/>
             </pointer>
         </stl-vector>
-        <int32_t/>
+        <int32_t name='unk_5'/>
         <virtual-methods>
             <vmethod name='write_file'> <pointer name='file' type-name='file_compressorst'/> </vmethod>
             <vmethod name='read_file'>
@@ -878,7 +878,7 @@
         <int32_t name='site_id' ref-target='world_site'/>
         <int32_t name='location_id' ref-target='abstract_building' aux-value='$$.site_id'/>
         <int32_t name='building_id'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <compound name='knowledge' type-name='knowledge_scholar_category_flag'/>
         <int32_t name='timer'/>
     </class-type>
@@ -889,11 +889,11 @@
         <int32_t name='location_id' ref-target='abstract_building' aux-value='$$.site_id'/>
         <int32_t name='building_id'/>
 
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <compound name='knowledge' type-name='knowledge_scholar_category_flag'/>
         <int32_t name='timer'/>
-        <int32_t/>
-        <int32_t ref-target='historical_figure'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3' ref-target='historical_figure'/>
     </class-type>
 
     <class-type type-name='activity_event_readst' inherits-from='activity_event'>
@@ -909,7 +909,7 @@
         <int32_t name='histfig_id' ref-target='historical_figure'/>
         <int32_t name='unit_id' ref-target='unit'/>
         <int32_t name='occupation_id' ref-target='occupation'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='activity_event_writest' inherits-from='activity_event'>
@@ -917,14 +917,14 @@
         <int32_t name='building_id'/>
         <int32_t name='site_id'/>
         <int32_t name='location_id'/>
-        <bitfield>
+        <bitfield name='unk_1'>
             <flag-bit/>
             <flag-bit/>
             <flag-bit/>
         </bitfield>
         <int32_t name='timer'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
         <enum name='mode'>
             <enum-item name='WriteAboutKnowledge'/>
         </enum>
@@ -950,102 +950,102 @@
             <flag-bit/>
             <flag-bit/>
         </bitfield>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='timer'/>
     </class-type>
 
     <class-type type-name='activity_event_teach_topicst' inherits-from='activity_event'>
         <compound name='participants' type-name='activity_event_participants'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
     </class-type>
 
     <class-type type-name='activity_event_playst' inherits-from='activity_event'>
         <compound name='participants' type-name='activity_event_participants'/>
-        <int32_t/>
-        <static-array type-name='int8_t' count='49'/>
-        <compound type-name='coord'/>
+        <int32_t name='unk_1'/>
+        <static-array name='unk_2' type-name='int8_t' count='49'/>
+        <compound name='unk_3' type-name='coord'/>
     </class-type>
 
     <class-type type-name='activity_event_make_believest' inherits-from='activity_event'>
         <compound name='participants' type-name='activity_event_participants'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <static-array type-name='int8_t' count='49'/>
-        <compound type-name='coord'/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <static-array name='unk_4' type-name='int8_t' count='49'/>
+        <compound name='unk_5' type-name='coord'/>
     </class-type>
 
     <class-type type-name='activity_event_play_with_toyst' inherits-from='activity_event'>
         <compound name='participants' type-name='activity_event_participants'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
         <compound name='unk'>
-            <static-array type-name='int8_t' count='49'/>
-            <compound type-name='coord'/>
+            <static-array name='unk_1' type-name='int8_t' count='49'/>
+            <compound name='unk_2' type-name='coord'/>
         </compound>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
     </class-type>
 
     <class-type type-name='activity_event_encounterst' inherits-from='activity_event'>
-        <stl-vector>
+        <stl-vector name='unk_1'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
+                <int32_t name='unk_7'/>
+                <int32_t name='unk_8'/>
+                <int32_t name='unk_9'/>
+                <int32_t name='unk_10'/>
             </pointer>
         </stl-vector>
-        <stl-vector>
+        <stl-vector name='unk_2'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
+                <int32_t name='unk_7'/>
+                <int32_t name='unk_8'/>
             </pointer>
         </stl-vector>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int32_t'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <stl-vector name='unk_3' type-name='int32_t'/>
+        <stl-vector name='unk_4' type-name='int32_t'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
     </class-type>
 
     <class-type type-name='activity_event_store_objectst' inherits-from='activity_event'>
-        <int32_t/>
-        <compound type-name='coord'/>
+        <int32_t name='unk_1'/>
+        <compound name='unk_2' type-name='coord'/>
         <int32_t name='building_id' ref-target='building'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <struct-type type-name='schedule_info' key-field='id' instance-vector='$global.world.schedules.all'>
         <int32_t name='id'/>
-        <int16_t/>
+        <int16_t name='unk_1'/>
         <stl-vector name='slots' pointer-type='schedule_slot'/>
     </struct-type>
 
@@ -1053,7 +1053,7 @@
         <int16_t name='type' comment='0:Eat, 1:Sleep, 2-4:???'/>
         <int16_t name='start_time'/>
         <int16_t name='end_time'/>
-        <int16_t/>
+        <int16_t name='unk_1'/>
         <int8_t name='processed'/>
     </struct-type>
 </data-definition>

--- a/df.military.xml
+++ b/df.military.xml
@@ -107,14 +107,14 @@
         <int32_t name="backpack" ref-target='item'/>
         <int32_t name="flask" ref-target='item'/>
 
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <static-array name='activities' count='3' index-enum='squad_event_type'
                       type-name='int32_t' ref-target='activity_entry'/>
         <static-array name='events' count='3' index-enum='squad_event_type'
                       type-name='int32_t' ref-target='activity_event'
                       aux-value='$._global.activities[$._key]'/>
 
-        <int32_t/>
+        <int32_t name='unk_2'/>
     </struct-type>
 
     <struct-type type-name='squad_schedule_order'>
@@ -199,7 +199,7 @@
                  refers-to='(find-by-id $$._global.entity_id.ref-target.positions.own $id $)'/>
         <int32_t name="leader_assignment" since='v0.40.01'
                  refers-to='(find-by-id $$._global.entity_id.ref-target.positions.assignments $id $)'/>
-        <int32_t since='v0.44.01'/>
+        <int32_t name='unk_1' since='v0.44.01'/>
     </struct-type>
 
     <enum-type type-name='squad_order_type'>
@@ -313,9 +313,9 @@
     <class-type type-name='squad_order_trainst' inherits-from='squad_order'/>
 
     <class-type type-name='squad_order_drive_entity_off_sitest' inherits-from='squad_order'>
-        <int32_t/>
-        <int32_t/>
-        <stl-string/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <stl-string name='unk_4'/>
     </class-type>
 
     <class-type type-name='squad_order_cause_trouble_for_entityst' inherits-from='squad_order'>
@@ -329,24 +329,24 @@
     </class-type>
 
     <class-type type-name='squad_order_drive_armies_from_sitest' inherits-from='squad_order'>
-        <int32_t/>
-        <int32_t/>
-        <stl-string/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <stl-string name='unk_4'/>
     </class-type>
 
     <class-type type-name='squad_order_retrieve_artifactst' inherits-from='squad_order'>
         <int32_t name='artifact_id' ref-target='artifact_record'/>
-        <compound type-name='coord'/>
+        <compound name='unk_2' type-name='coord'/>
     </class-type>
 
     <class-type type-name='squad_order_raid_sitest' inherits-from='squad_order'>
-        <int32_t/>
-        <compound type-name='coord'/>
+        <int32_t name='unk_2'/>
+        <compound name='unk_3' type-name='coord'/>
     </class-type>
 
     <class-type type-name='squad_order_rescue_hfst' inherits-from='squad_order'>
-        <int32_t/>
-        <compound type-name='coord'/>
+        <int32_t name='unk_2'/>
+        <compound name='unk_3' type-name='coord'/>
     </class-type>
 
     Some army_controller research notes:
@@ -447,9 +447,9 @@
     </struct-type>
 
     <struct-type type-name='army_controller_sub1'>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
     </struct-type>
 
     <struct-type type-name='army_controller_invasion_order'>
@@ -457,7 +457,7 @@
         <int32_t name='unk_2'/>
         <int32_t name='unk_3'/>
         <int32_t name='unk_4'/>
-        <stl-vector>
+        <stl-vector name='unk_4a'>
             <pointer>
                 <int32_t name='army_id' ref-target='army' comment="no longer available when an attack has started"/>
                 <int32_t name='pos_x_a' comment="In map_blocks, i.e. in 3 * 16 * world tiles"/>
@@ -493,15 +493,15 @@
     </struct-type>
 
     <struct-type type-name='army_controller_sub6'>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
     </struct-type>
 
     <struct-type type-name='army_controller_sub7'>
@@ -509,12 +509,12 @@
         <int32_t name='unk_2' init-value='-1'/>
         <stl-vector name='unk_3'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
             </pointer>
         </stl-vector>
         <int32_t name='unk_4' comment="0 seen"/>
@@ -529,8 +529,8 @@
     <struct-type type-name='army_controller_sub11'>
         <int32_t name='unk_1' init-value='-1'/>
         <int32_t name='unk_2' init-value='-1'/>
-        <stl-vector>
-            <pointer name='unk_3' comment="probably the same type as the corresponding one of army_controller_invasion_order">
+        <stl-vector name='unk_3'>
+            <pointer comment="probably the same type as the corresponding one of army_controller_invasion_order">
                 <int32_t name='army_id' ref-target='army'/>
                 <int32_t name='pos_x_a' comment="map_block coordinates"/>
                 <int32_t name='pos_y_a'/>
@@ -547,12 +547,12 @@
         <int32_t name='unk_3' init-value='0' comment="2 seen on exiled character"/>
         <stl-vector name='unk_4'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
             </pointer>
         </stl-vector>
         <int32_t name='unk_5' init-value='-1'/>
@@ -562,64 +562,64 @@
     </struct-type>
 
     <struct-type type-name='army_controller_sub13'>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <stl-vector name='unk_4'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
             </pointer>
         </stl-vector>
     </struct-type>
 
     <struct-type type-name='army_controller_sub14'>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <stl-vector name='unk_4'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
             </pointer>
         </stl-vector>
     </struct-type>
 
     <struct-type type-name='army_controller_sub15'>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <stl-vector name='unk_3'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
             </pointer>
         </stl-vector>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
+        <int32_t name='unk_10'/>
+        <int32_t name='unk_11'/>
+        <int32_t name='unk_12'/>
+        <int32_t name='unk_13'/>
     </struct-type>
 
     <struct-type type-name='army_controller_sub16'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </struct-type>
 
     <struct-type type-name='army_controller_quest'>
@@ -630,8 +630,8 @@
     </struct-type>
 
     <struct-type type-name='army_controller_sub18'>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
     </struct-type>
 
     <struct-type type-name='army_controller_villainous_visit'>

--- a/df.raws.xml
+++ b/df.raws.xml
@@ -135,9 +135,9 @@
             <stl-vector name='colors' pointer-type='descriptor_color'/>
             <stl-vector name='shapes' pointer-type='descriptor_shape'/>
             <stl-vector name='patterns' pointer-type='descriptor_pattern'/>
-            <stl-vector type-name='int32_t' since='v0.47.01'/>
-            <stl-vector type-name='int32_t' since='v0.47.01'/>
-            <stl-vector type-name='int32_t' since='v0.47.01'/>
+            <stl-vector name='unk_1' type-name='int32_t' since='v0.47.01'/>
+            <stl-vector name='unk_2' type-name='int32_t' since='v0.47.01'/>
+            <stl-vector name='unk_3' type-name='int32_t' since='v0.47.01'/>
         </compound>
 
         -- Reaction RAWs

--- a/df.reaction-raws.xml
+++ b/df.reaction-raws.xml
@@ -41,7 +41,7 @@
         <stl-vector name="descriptions" pointer-type='reaction_description' since='v0.42.01'/>
         <int32_t name='quality_adj1' since='v0.47.02' init-value='11'/>
         <int32_t name='quality_adj2' since='v0.47.02' init-value='5'/>
-        <int32_t since='v0.47.02' init-value='10'/>
+        <int32_t name='unk_1' since='v0.47.02' init-value='10'/>
         <int32_t name='exp_gain' since='v0.47.02' init-value='30'/>
     </struct-type>
 
@@ -54,9 +54,9 @@
     </struct-type>
 
     <struct-type type-name='reaction_description'>
-        <stl-string/>
+        <stl-string name='unk_1'/>
         <enum type-name='item_type' name='item_type'/>
-        <stl-string/>
+        <stl-string name='unk_2'/>
     </struct-type>
 
     <enum-type type-name='reaction_reagent_type'>

--- a/df.refs.xml
+++ b/df.refs.xml
@@ -204,9 +204,9 @@
     </class-type>
 
     <class-type type-name='general_ref_locationst' inherits-from='general_ref'>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
     </class-type>
 
     <class-type type-name='general_ref_interactionst' inherits-from='general_ref'>
@@ -246,17 +246,17 @@
     </class-type>
 
     <class-type type-name='general_ref_entity_popst' inherits-from='general_ref'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='race' ref-target='creature_raw'/>
-        <int32_t/>
+        <int32_t name='unk_2'/>
         <bitfield name='flags' type-name='undead_flags'/>
     </class-type>
 
     <class-type type-name='general_ref_creaturest' inherits-from='general_ref'>
         <int32_t name='race' ref-target='creature_raw'/>
         <int32_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
         <bitfield name='flags' type-name='undead_flags'/>
     </class-type>
 
@@ -275,7 +275,7 @@
     </class-type>
 
     <class-type type-name='general_ref_languagest' inherits-from='general_ref'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='general_ref_written_contentst' inherits-from='general_ref'>
@@ -420,7 +420,7 @@
             <pointer name='histfig' type-name='historical_figure'/>
             <pointer name='entity' type-name='historical_entity'/>
             <compound name='wrestle'>
-                <pointer/>
+                <pointer name='unk_1'/>
                 <pointer name='item' type-name='unit_item_wrestle'/>
             </compound>
         </compound>
@@ -550,7 +550,7 @@
     </class-type>
 
     <class-type type-name='histfig_site_link_occupationst' inherits-from='histfig_site_link'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
     <class-type type-name='histfig_site_link_seat_of_powerst' inherits-from='histfig_site_link'/>
     <class-type type-name='histfig_site_link_hangoutst' inherits-from='histfig_site_link'/>
@@ -612,8 +612,8 @@
     <class-type type-name='histfig_hf_link_masterst' inherits-from='histfig_hf_link'/>
     <class-type type-name='histfig_hf_link_apprenticest' inherits-from='histfig_hf_link'/>
     <class-type type-name='histfig_hf_link_companionst' inherits-from='histfig_hf_link'>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
     </class-type>
     <class-type type-name='histfig_hf_link_former_apprenticest' inherits-from='histfig_hf_link'/>
     <class-type type-name='histfig_hf_link_former_masterst' inherits-from='histfig_hf_link'/>

--- a/df.resource.xml
+++ b/df.resource.xml
@@ -70,35 +70,35 @@
 
     <class-type type-name='resource_allotment_specifier_cropst' inherits-from='resource_allotment_specifier'>
         <int32_t name='mat_type' ref-target='plant_raw' aux-value='$$.mat_index' comment='index to world.raws.plant.all' />
-        <int32_t/>
+        <int32_t name='unk_4'/>
         <int32_t name='unk_v40_01' since='v0.40.01'/>
-        <static-array count='5' type-name='int32_t'/>
+        <static-array name='unk_5' count='5' type-name='int32_t'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_stonest' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
-        <int32_t/>
-        <static-array count='5' type-name='int32_t'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <static-array name='unk_6' count='5' type-name='int32_t'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_metalst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
-        <static-array count='12' type-name='int32_t'/>
+        <int32_t name='unk_4'/>
+        <static-array name='unk_5' count='12' type-name='int32_t'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_woodst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_armor_bodyst' inherits-from='resource_allotment_specifier'>
@@ -179,32 +179,32 @@
     <class-type type-name='resource_allotment_specifier_threadst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_clothst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_leatherst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
+        <int32_t name='unk_10'/>
+        <int32_t name='unk_11'/>
+        <int32_t name='unk_12'/>
+        <int32_t name='unk_13'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_quiverst' inherits-from='resource_allotment_specifier'>
@@ -265,19 +265,19 @@
     <class-type type-name='resource_allotment_specifier_bonest' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_hornst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_shellst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_tallowst' inherits-from='resource_allotment_specifier'>
@@ -288,7 +288,7 @@
     <class-type type-name='resource_allotment_specifier_toothst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_pearlst' inherits-from='resource_allotment_specifier'>
@@ -304,10 +304,10 @@
     <class-type type-name='resource_allotment_specifier_extractst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
         <int16_t name='mat_type2' ref-target='material' aux-value='$$.mat_index2'/>
         <int32_t name='mat_index2'/>
-        <int32_t comment='uninitialized'/>
+        <int32_t name='unk_5' comment='uninitialized'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_cheesest' inherits-from='resource_allotment_specifier'>
@@ -320,13 +320,13 @@
         <int32_t name='mat_index'/>
         <int16_t name='mat_type2' ref-target='material' aux-value='$$.mat_index2'/>
         <int32_t name='mat_index2'/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <class-type type-name='resource_allotment_specifier_powderst' inherits-from='resource_allotment_specifier'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <struct-type type-name='resource_allotment_data'

--- a/df.syndrome.xml
+++ b/df.syndrome.xml
@@ -295,7 +295,7 @@
         <stl-string name='name'/>
         <stl-string name='name_plural'/>
         <stl-string name='name_adj'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_body_appearance_modifierst'
@@ -322,8 +322,8 @@
         <stl-vector type-name='int32_t' name='forbidden_creature_flags' comment='contains indexes of flags in creature_raw_flags'/>
         <stl-vector type-name='int32_t' name='required_caste_flags' comment='contains indexes of flags in caste_raw_flags'/>
         <stl-vector type-name='int32_t' name='forbidden_caste_flags' comment='contains indexes of flags in caste_raw_flags'/>
-        <int32_t init-value='-1'/>
-        <int32_t init-value='-1'/>
+        <int32_t name='unk_1' init-value='-1'/>
+        <int32_t name='unk_2' init-value='-1'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_skill_roll_adjustst'
@@ -431,91 +431,91 @@
     </class-type>
 
     <class-type type-name='creature_interaction_effect_close_open_woundsst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_cure_infectionsst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_heal_nervesst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_heal_tissuesst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_dizzinessst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_feverst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_nauseast' inherits-from='creature_interaction_effect'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_painst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_paralysisst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_swellingst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_regrow_partsst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_special_attack_interactionst' inherits-from='creature_interaction_effect'>
-        <stl-vector type-name='int16_t'/>
-        <stl-vector pointer-type='stl-string'/>
-        <stl-string/>
+        <stl-vector name='unk_1' type-name='int16_t'/>
+        <stl-vector name='unk_2' pointer-type='stl-string'/>
+        <stl-string name='unk_3'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_stop_bleedingst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_cure_infectionst' inherits-from='creature_interaction_effect'>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <int32_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <stl-vector name='unk_4'/>
     </class-type>
 
     <bitfield-type type-name='syndrome_flags' base-type='uint32_t'>

--- a/df.ui-menus.xml
+++ b/df.ui-menus.xml
@@ -124,7 +124,7 @@
     <class-type type-name='interface_button' original-name='interface_buttonst'>
         <enum name='hotkey_id' type-name='interface_key' base-type='int32_t'/>
         <bool name="is_hidden"/>
-        <int32_t since='v0.40.23'/>
+        <int32_t name='unk_1' since='v0.40.23'/>
 
         <virtual-methods>
             <vmethod name='printSlabStatus' comment='ghost, buried, memorialized'>
@@ -246,7 +246,7 @@
             <int32_t name="mat_index"/>
             <bitfield name='material_category' type-name='job_material_category'/>
 
-            <stl-string since='v0.42.01'/>
+            <stl-string name='unk_1' since='v0.42.01'/>
             <stl-vector name='use_tooltip_lines' pointer-type='stl-string' since='v0.42.01'/>
         </compound>
 
@@ -260,7 +260,7 @@
 
         <compound name='zone'>
             <bool name='remove'/>
-            <padding size='1'/>
+            <padding name='pad_1' size='1'/>
             <enum name='mode' base-type='int16_t'>
                 <enum-item name='Rectangle'/>
                 <enum-item name='Flow'/>
@@ -273,7 +273,7 @@
         <compound name='unit'>
             <stl-vector name='inv_items' pointer-type='unit_inventory_item'/>
             <stl-vector name='inv_spatters' pointer-type='spatter'/>
-            <stl-vector since='v0.42.01'/>
+            <stl-vector name='unk_1' since='v0.42.01'/>
 
             <bool name="in_new_squad" since='v0.34.08'/>
             <int32_t name="cursor_uniform" since='v0.34.08'/>
@@ -285,9 +285,9 @@
             <stl-bit-vector name='squad_unk1' since='v0.34.08'/>
             <stl-vector name='squad_unk2' since='v0.34.08'/>
 
-            <pointer type-name='entity_position'/>
-            <pointer type-name='entity_position_assignment'/>
-            <pointer type-name='entity_position'/>
+            <pointer name='unk_2a' type-name='entity_position'/>
+            <pointer name='unk_2b' type-name='entity_position_assignment'/>
+            <pointer name='unk_2c' type-name='entity_position'/>
             <bool name='unk3'/>
             <bool name='unk4'/>
             <bool name='squad_list_opened'/>
@@ -404,8 +404,8 @@
             <int32_t name="position_squad_cursor"/>
         </compound>
 
-        <stl-vector since='v0.42.01'/>
-        <pointer since='v0.42.01'/>
+        <stl-vector name='unk_1' since='v0.42.01'/>
+        <pointer name='unk_2' since='v0.42.01'/>
 
         <compound name='minimap'>
             -- Abstract representation of contents; updated by need_scan
@@ -487,9 +487,9 @@
                     </compound>
                     TODO: Floor, Campfire, BuildingItem, Fire, Spoor
                 </compound>
-                <int16_t/>
-                <int16_t/>
-                <int16_t/>
+                <int16_t name='unk_1'/>
+                <int16_t name='unk_2'/>
+                <int16_t name='unk_3'/>
             </pointer>
         </stl-vector>
     </struct-type>

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -416,7 +416,7 @@
                 </pointer>
             </stl-vector>
             <int16_t name='sym_selector'/>
-            <int16_t/>
+            <int16_t name='unk_1'/>
             <int32_t name='cur_point_index'/>
             <bool name='in_edit_name_mode'/>
             <bool name='in_edit_text_mode'/>
@@ -545,45 +545,45 @@
 
         <stl-vector name='unk_8' since='v0.47.01' comment='related to (job_type)0xf1'>
             <pointer>
-                <int32_t ref-target='item'/>
-                <int32_t ref-target='historical_figure'/>
-                <int32_t comment='refers to historical_figure_info::T_relationships::T_intrigues::T_plots::id'/>
-                <int32_t ref-target='historical_figure'/>
-                <int32_t ref-target='unit'/>
-                <int32_t ref-target='historical_figure'/>
-                <int32_t ref-target='unit'/>
-                <int32_t ref-target='agreement'/>
-                <int32_t init-value='0'/>
-                <compound type-name='coord' comment='guess; only x is initialized'/>
-                <static-array count='16'>
+                <int32_t name='unk_1' ref-target='item'/>
+                <int32_t name='unk_2' ref-target='historical_figure'/>
+                <int32_t name='unk_3' comment='refers to historical_figure_info::T_relationships::T_intrigues::T_plots::id'/>
+                <int32_t name='unk_4' ref-target='historical_figure'/>
+                <int32_t name='unk_5' ref-target='unit'/>
+                <int32_t name='unk_6' ref-target='historical_figure'/>
+                <int32_t name='unk_7' ref-target='unit'/>
+                <int32_t name='unk_8' ref-target='agreement'/>
+                <int32_t name='unk_9' init-value='0'/>
+                <compound name='unk_10' type-name='coord' comment='guess; only x is initialized'/>
+                <static-array name='unk_11' count='16'>
                     <int32_t init-value='-1'/>
                 </static-array>
-                <static-array count='16'>
+                <static-array name='unk_12' count='16'>
                     <int32_t/>
                 </static-array>
-                <static-array count='16'>
+                <static-array name='unk_13' count='16'>
                     <int32_t/>
                 </static-array>
-                <static-array count='16'>
+                <static-array name='unk_14' count='16'>
                     <int32_t/>
                 </static-array>
-                <static-array count='16'>
+                <static-array name='unk_15' count='16'>
                     <int32_t/>
                 </static-array>
-                <static-array count='16'>
+                <static-array name='unk_16' count='16'>
                     <int32_t/>
                 </static-array>
-                <static-array count='16'>
+                <static-array name='unk_17' count='16'>
                     <int32_t/>
                 </static-array>
-                <static-array count='16'>
+                <static-array name='unk_18' count='16'>
                     <int32_t/>
                 </static-array>
-                <int32_t init-value='0'/>
-                <int32_t init-value='-1'/>
-                <int32_t init-value='-1'/>
-                <int32_t init-value='-1'/>
-                <int32_t init-value='-1'/>
+                <int32_t name='unk_19' init-value='0'/>
+                <int32_t name='unk_20' init-value='-1'/>
+                <int32_t name='unk_21' init-value='-1'/>
+                <int32_t name='unk_22' init-value='-1'/>
+                <int32_t name='unk_23' init-value='-1'/>
             </pointer>
         </stl-vector>
 
@@ -626,7 +626,7 @@
             <int32_t name='unk6df4'/>
 
             <bool name='unk_44_12a'/>
-            <padding size='3' comment='workaround for strange IDA 7.0 bug'/>
+            <padding name='pad_1' size='3' comment='workaround for strange IDA 7.0 bug'/>
 
             <compound name='unk_44_12b' type-name='nemesis_offload'/>
             <bool name='unk_44_12c' since='v0.44.12'/>
@@ -697,10 +697,10 @@
         <enum base-type='int8_t' type-name='season' name='season'/>
         <int16_t name='season_ticks' comment='1 tick = 10 frames'/>
         <pointer name='entity' type-name='historical_entity'/>
-        <int16_t/>
-        <int32_t/>
-        <int16_t/>
-        <int16_t/>
+        <int16_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int16_t name='unk_3'/>
+        <int16_t name='unk_4'/>
     </struct-type>
 
     <struct-type type-name='map_viewport'>
@@ -736,13 +736,13 @@
         <int32_t name='cur_tick_count' comment='GetTickCount'/>
         <int16_t name='tick_phase' comment='cur_year_tick%10080'/>
         <int8_t name='dim_colors'/>
-        <int8_t/>
-        <static-array count='500' type-name='int32_t'/>
-        <static-array count='500' type-name='int8_t'/>
-        <static-array count='500'><int32_t name='x'/><int32_t name='y'/></static-array>
-        <static-array count='500' type-name='int32_t'/>
-        <int32_t/>
-        <int32_t/>
+        <int8_t name='unk_1'/>
+        <static-array name='unk_2' count='500' type-name='int32_t'/>
+        <static-array name='unk_3' count='500' type-name='int8_t'/>
+        <static-array name='unk_4' count='500'><int32_t name='x'/><int32_t name='y'/></static-array>
+        <static-array name='unk_5' count='500' type-name='int32_t'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
     </struct-type>
 </data-definition>
 

--- a/df.units.xml
+++ b/df.units.xml
@@ -637,7 +637,7 @@
             </enum>
             <int32_t name='target_entity' ref-target='historical_entity'/>
             <enum name='target_role' type-name='entity_position_responsibility' base-type='int16_t'/>
-            <padding size='2'/>
+            <padding name="pad_1" size='2'/>
         </compound>
 
         <int16_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
@@ -981,23 +981,23 @@
             <stl-vector name='unk_138' pointer-type='unit_unk_138' since='v0.44.01'/>
             <stl-vector name='requests' pointer-type='unit_request'/>
             <stl-vector name='coin_debts' pointer-type='unit_coin_debt'/>
-            <stl-vector since='v0.47.01'>
+            <stl-vector name='unk_1' since='v0.47.01'>
                 <pointer>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
+                    <int32_t name='unk_1'/>
+                    <int32_t name='unk_2'/>
+                    <int32_t name='unk_3'/>
                     following field not saved:
-                    <int32_t/>
+                    <int32_t name='unk_4'/>
                     following 3 fields saved if first field is 0
-                    <int16_t/>
-                    <int16_t/>
-                    <int16_t/>
+                    <int16_t name='unk_5'/>
+                    <int16_t name='unk_6'/>
+                    <int16_t name='unk_7'/>
                 </pointer>
             </stl-vector>
-            <int32_t since='v0.47.01'/>
-            <int32_t since='v0.47.01'/>
-            <static-array type-name='int32_t' count='5' index-enum='gait_type' since='v0.47.01' comment='initialized together with enemy.gait_index'/>
-            <int32_t since='v0.47.01'/>
+            <int32_t name='unk_2' since='v0.47.01'/>
+            <int32_t name='unk_3' since='v0.47.01'/>
+            <static-array name='unk_4' type-name='int32_t' count='5' index-enum='gait_type' since='v0.47.01' comment='initialized together with enemy.gait_index'/>
+            <int32_t name='unk_5' since='v0.47.01'/>
 
             <int16_t name='adv_sleep_timer'/>
 
@@ -1097,35 +1097,35 @@
             <static-array name='unk_unit_id_2' type-name='int32_t' ref-target='unit' count='200' since='v0.40.01' comment="Seen own side, enemy side, not involved (witnesses?). Unused fields not cleared"/>
             <int32_t name='unk_unit_id_2_count' since='v0.40.01'/>
             <pointer name='unk_448' since='v0.40.01'>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
                 <compound name='unk'>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t comment='not saved'/>
+                    <int32_t name='unk_1'/>
+                    <int32_t name='unk_2'/>
+                    <int32_t name='unk_3'/>
+                    <int32_t name='unk_4'/>
+                    <int32_t name='unk_5'/>
+                    <int32_t name='unk_6'/>
+                    <int32_t name='unk_7'/>
+                    <int32_t name='unk_8'/>
+                    <int32_t name='unk_9'/>
+                    <int32_t name='unk_10' comment='not saved'/>
                 </compound>
             </pointer>
             <pointer name='unk_44c' since='v0.40.01'>
-                <int32_t/>
-                <int32_t/>
-                <int16_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <static-array type-name='int32_t' count='20'/>
-                <static-array type-name='int32_t' count='20'/>
-                <int16_t/>
-                <int16_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int16_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
+                <static-array name='unk_7' type-name='int32_t' count='20'/>
+                <static-array name='unk_8' type-name='int32_t' count='20'/>
+                <int16_t name='unk_9'/>
+                <int16_t name='unk_10'/>
+                <int32_t name='unk_11'/>
+                <int32_t name='unk_12'/>
             </pointer>
             <int32_t name='unk_450' since='v0.40.01'/>
             <int32_t name='unk_454' since='v0.40.01'/>
@@ -1816,11 +1816,11 @@
         <int32_t name='unk3'/>
         <int32_t name='unk4'/>
 
-        <int32_t since='v0.34.01'/>
-        <int32_t since='v0.34.01'/>
-        <int32_t since='v0.34.01'/>
-        <int32_t since='v0.34.01'/>
-        <int32_t since='v0.40.01'/>
+        <int32_t name='unk_1' since='v0.34.01'/>
+        <int32_t name='unk_2' since='v0.34.01'/>
+        <int32_t name='unk_3' since='v0.34.01'/>
+        <int32_t name='unk_4' since='v0.34.01'/>
+        <int32_t name='unk_5' since='v0.40.01'/>
 
         <static-array type-name='unit_attribute' name='mental_attrs' count='13' index-enum='mental_attribute_type'/>
 
@@ -1872,7 +1872,7 @@
         <enum name='thought' base-type='int32_t' type-name='unit_thought_type'/>
         <int32_t name='subthought' comment='for certain thoughts'/>
         <int32_t name='severity'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='year'/>
         <int32_t name='year_tick'/>
     </struct-type>
@@ -1979,11 +1979,11 @@
                 <pointer>
                     <compound name='memory' type-name='unit_emotion_memory'/>
                     <enum name='changed_facet' base-type='int32_t' type-name='personality_facet_type' init-value='NONE'/>
-                    <int32_t/>
-                    <int32_t/>
+                    <int32_t name='unk_1'/>
+                    <int32_t name='unk_2'/>
                     <enum name='changed_value' base-type='int32_t' type-name='value_type' init-value='NONE'/>
-                    <int32_t/>
-                    <int32_t/>
+                    <int32_t name='unk_3'/>
+                    <int32_t name='unk_4'/>
                 </pointer>
             </stl-vector>
         </pointer>
@@ -2448,9 +2448,9 @@
     </struct-type>
 
     <struct-type type-name='unit_unk_138'>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
         <bitfield name='flags'>
             <flag-bit/>
             <flag-bit name='returning_treasure'/>

--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -168,11 +168,11 @@
     </class-type>
 
     <struct-type type-name='widget_menu'>
-        <padding size='24' comment='lines, std::map'/>
+        <padding name='pad_1' size='24' comment='lines, std::map'/>
         <int32_t name='selection'/>
         <int32_t name='last_displayheight'/>
         <bool name='bleached'/>
-        <padding size='24' comment='colors, std::map'/>
+        <padding name='pad_2' size='24' comment='colors, std::map'/>
     </struct-type>
 
     <struct-type type-name='widget_textbox'>
@@ -207,8 +207,8 @@
 
     <struct-type type-name='world_dat_summary'>
         <compound type-name='language_name' name='name'/>
-        <stl-string/>
-        <static-array count='15' type-name='int8_t' comment='same as the one at the top of world_data'/>
+        <stl-string name='unk_1'/>
+        <static-array name='unk_2' count='15' type-name='int8_t' comment='same as the one at the top of world_data'/>
         <compound name='last_id' comment='when loading, DF sets *_next_id to these fields plus 1'>
             <int32_t name='unit'/>
             <int32_t name='soul'/>
@@ -248,7 +248,7 @@
             <int32_t name='image_set' since='v0.47.01'/>
             <int32_t name='divination_set' since='v0.47.01'/>
         </compound>
-        <stl-string/>
+        <stl-string name='unk_3'/>
     </struct-type>
 
     <class-type type-name='viewscreen_adopt_regionst' inherits-from='viewscreen'>
@@ -314,7 +314,7 @@
         </enum>
         <int8_t name="map_islocalview"/>
         <int8_t name="map_hidden"/>
-        <int8_t since='v0.47.02'/>
+        <int8_t name='unk_1' since='v0.47.02'/>
         <compound type-name='coord2d' name='player_region'/>
         <compound type-name='coord2d' name='player_local'/>
         <compound type-name='coord2d' name='min_discovered'/>
@@ -338,8 +338,8 @@
             <enum-item name="Regions"/>
             <enum-item name="Bestiary"/>
         </enum>
-        <int16_t since='v0.47.02'/>
-        <int16_t since='v0.47.02'/>
+        <int16_t name='unk_2' since='v0.47.02'/>
+        <int16_t name='unk_3' since='v0.47.02'/>
 
         <int32_t name='unk_v40_1a'/>
         <int32_t name='unk_v40_1b'/>
@@ -347,64 +347,64 @@
         <int32_t name='unk_v40_1d'/>
         <int32_t name='unk_v40_1e'/>
         <int32_t name='unk_v40_1f'/>
-        <int32_t/>
-        <int8_t since='v0.47.02'/>
-        <pointer since='v0.47.02'/>
+        <int32_t name='unk_4'/>
+        <int8_t name='unk_5' since='v0.47.02'/>
+        <pointer name='unk_6' since='v0.47.02'/>
 
         <stl-string name='filter_str'/>
         <int8_t name='in_filter'/>
-        <int8_t since='v0.47.02'/>
+        <int8_t name='unk_7' since='v0.47.02'/>
 
         <static-array name='items' count='9'>
             <stl-vector pointer-type='adventure_log_item'/>
         </static-array>
-        <int8_t since='v0.47.02'/>
-        <int8_t since='v0.47.02'/>
-        <int8_t since='v0.47.02'/>
-        <int32_t since='v0.47.02'/>
-        <int32_t since='v0.47.02'/>
+        <int8_t name='unk_8' since='v0.47.02'/>
+        <int8_t name='unk_9' since='v0.47.02'/>
+        <int8_t name='unk_10' since='v0.47.02'/>
+        <int32_t name='unk_11' since='v0.47.02'/>
+        <int32_t name='unk_12' since='v0.47.02'/>
 
         <static-array name='filtered_items' count='9'>
             <stl-vector pointer-type='adventure_log_item'/>
         </static-array>
 
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
+        <stl-vector name='unk_13' since='v0.47.02'/>
+        <stl-vector name='unk_14' since='v0.47.02'/>
+        <stl-vector name='unk_15' since='v0.47.02'/>
+        <stl-vector name='unk_16' since='v0.47.02'/>
+        <stl-vector name='unk_17' since='v0.47.02'/>
+        <stl-vector name='unk_18' since='v0.47.02'/>
+        <stl-vector name='unk_19' since='v0.47.02'/>
+        <stl-vector name='unk_21' since='v0.47.02'/>
+        <stl-vector name='unk_22' since='v0.47.02'/>
+        <stl-vector name='unk_23' since='v0.47.02'/>
+        <stl-vector name='unk_24' since='v0.47.02'/>
+        <stl-vector name='unk_25' since='v0.47.02'/>
+        <stl-vector name='unk_26' since='v0.47.02'/>
+        <stl-vector name='unk_27' since='v0.47.02'/>
+        <stl-vector name='unk_28' since='v0.47.02'/>
     </class-type>
 
     <struct-type type-name='adventure_log_item'>
-        <int32_t comment='possibly enum' init-value='-1'/>
-        <pointer/>
+        <int32_t name='unk_1' comment='possibly enum' init-value='-1'/>
+        <pointer name='unk_2'/>
         <pointer type-name='incident' name='incident'/>
-        <pointer/>
+        <pointer name='unk_3'/>
         <int32_t name='year'/>
         <int32_t name='time'/>
         <stl-string name='str1'/>
         <stl-string name='str2' comment='simplify_string(str1)'/>
         <stl-string name='str3'/>
         <stl-vector pointer-type='stl-string' name='info'/>
-        <stl-string/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
+        <stl-string name='unk_4'/>
+        <pointer name='unk_5'/>
+        <pointer name='unk_6'/>
+        <pointer name='unk_7'/>
         <int32_t name='pos_x' init-value='-1'/>
         <int32_t name='pos_y' init-value='-1'/>
-        <int32_t/>
-        <int16_t/>
-        <int8_t/>
+        <int32_t name='unk_8'/>
+        <int16_t name='unk_9'/>
+        <int8_t name='unk_10'/>
     </struct-type>
 
     <class-type type-name='viewscreen_announcelistst' inherits-from='viewscreen'>
@@ -439,32 +439,32 @@
     </class-type>
 
     <class-type type-name='viewscreen_barterst' inherits-from='viewscreen'>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <int8_t/>
-        <int8_t/>
-        <int8_t/>
-        <static-array count='2'><stl-vector/></static-array>
-        <static-array count='2'><stl-vector/></static-array>
-        <static-array count='2'><stl-vector/></static-array>
-        <stl-vector/>
-        <stl-vector/>
-        <static-array count='2' type-name='int32_t'/>
-        <int8_t/>
-        <int16_t/>
-        <int8_t/>
+        <pointer name='unk_1'/>
+        <pointer name='unk_2'/>
+        <pointer name='unk_3'/>
+        <pointer name='unk_4'/>
+        <int8_t name='unk_5'/>
+        <int8_t name='unk_6'/>
+        <int8_t name='unk_7'/>
+        <static-array name='unk_8' count='2'><stl-vector/></static-array>
+        <static-array name='unk_9' count='2'><stl-vector/></static-array>
+        <static-array name='unk_10' count='2'><stl-vector/></static-array>
+        <stl-vector name='unk_11'/>
+        <stl-vector name='unk_12'/>
+        <static-array name='unk_13' count='2' type-name='int32_t'/>
+        <int8_t name='unk_14'/>
+        <int16_t name='unk_15'/>
+        <int8_t name='unk_16'/>
         <int32_t name='max_ask'/>
         <int32_t name='max_offer'/>
         <int32_t name='cur_ask'/>
         <int32_t name='cur_offer'/>
-        <int8_t/>
-        <int8_t/>
-        <int8_t/>
-        <stl-string/>
-        <stl-vector/>
-        <int32_t/>
+        <int8_t name='unk_17'/>
+        <int8_t name='unk_18'/>
+        <int8_t name='unk_19'/>
+        <stl-string name='unk_20'/>
+        <stl-vector name='unk_21'/>
+        <int32_t name='unk_22'/>
     </class-type>
 
     <class-type type-name='viewscreen_buildingst' inherits-from='viewscreen'>
@@ -622,19 +622,19 @@
         <int32_t name='army_controller2' ref-target='army_controller'/>
         <int32_t name='histfig' ref-target='historical_figure'/>
         <int32_t name='unk_14'/> -1
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_16'/>
+        <int32_t name='unk_17'/>
+        <int32_t name='unk_18'/>
+        <int32_t name='unk_19'/>
+        <int32_t name='unk_20'/>
+        <int32_t name='unk_21'/>
         <int32_t name='unk_15'/>
-        <int32_t/>
+        <int32_t name='unk_22'/>
         <stl-vector name='squads' type-name='int32_t' ref-target='squad'/>
         <stl-vector name='messengers' type-name='int32_t' ref-target='occupation'/>
 
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_23'/>
+        <int32_t name='unk_24'/>
 
         <compound name='details' is-union='true'>
             <pointer name='raid'>
@@ -649,26 +649,26 @@
                 </enum>
                 <int32_t name='unk_2'/>
 
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
+                <int32_t name='unk_7'/>
+                <int32_t name='unk_8'/>
+                <int32_t name='unk_9'/>
+                <int32_t name='unk_10'/>
+                <int32_t name='unk_11'/>
+                <int32_t name='unk_12'/>
+                <int32_t name='unk_13'/>
+                <int32_t name='unk_14'/>
+                <int32_t name='unk_15'/>
+                <int32_t name='unk_16'/>
+                <int32_t name='unk_17'/>
+                <int32_t name='unk_18'/>
+                <int32_t name='unk_19'/>
+                <int32_t name='unk_20'/>
+                <int32_t name='unk_21'/>
+                <int32_t name='unk_22'/>
+                <int32_t name='unk_23'/>
+                <int32_t name='unk_24'/>
                 <bitfield base-type='uint32_t' name='raid_flags'>
                     <flag-bit name='Unknown1'/>
                     <flag-bit name='OneTimeTribute'/>
@@ -683,13 +683,13 @@
                 </bitfield>
                 <int32_t name='unk_3'/>
                 <int32_t name='unk_4'/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_25'/>
+                <int32_t name='unk_26'/>
+                <int32_t name='unk_27'/>
+                <int32_t name='unk_28'/>
+                <int32_t name='unk_29'/>
+                <int32_t name='unk_30'/>
+                <int32_t name='unk_31'/>
             </pointer>
             <pointer name='recovery'>
                 <int32_t name='artifact' ref-target='artifact_record'/>
@@ -714,7 +714,7 @@
             <enum-item name='RescuePerson' value='18'/>
             <enum-item name='RequestWorkers' value='19'/>
         </enum>
-        <int32_t/>
+        <int32_t name='unk_25'/>
     </struct-type>
 
     <class-type type-name='viewscreen_civlistst' inherits-from='viewscreen'>
@@ -830,7 +830,7 @@
                 <int32_t name='count'/>
             </compound>
             <compound name='tmp2'>
-                <static-array count='4001' type-name='int64_t'/>
+                <static-array name='unk_1' count='4001' type-name='int64_t'/>
             </compound>
         </compound>
 
@@ -840,22 +840,22 @@
     </class-type>
 
     <class-type type-name='viewscreen_counterintelligencest' inherits-from='viewscreen'>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <int32_t/>
-        <int32_t/>
-        <stl-string/>
-        <int8_t/>
-        <int8_t/>
-        <pointer/>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <stl-vector name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <stl-string name='unk_6'/>
+        <int8_t name='unk_7'/>
+        <int8_t name='unk_8'/>
+        <pointer name='unk_9'/>
+        <int32_t name='unk_10'/>
+        <stl-vector name='unk_11'/>
+        <stl-vector name='unk_12'/>
+        <stl-vector name='unk_13'/>
+        <stl-vector name='unk_14'/>
+        <stl-vector name='unk_15'/>
+        <stl-vector name='unk_16'/>
     </class-type>
 
     <class-type type-name='viewscreen_createquotast' inherits-from='viewscreen'>
@@ -892,10 +892,10 @@
 
         <bool name="view_skills"/>
 
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='length'/>
         <int32_t name='scroll_pos'/>
-        <int8_t/>
+        <int8_t name='unk_2'/>
         <stl-vector name="inventory" pointer-type="unit_inventory_item"/>
         <stl-vector name="spatters" pointer-type="spatter"/>
     </class-type>
@@ -903,35 +903,35 @@
     <class-type type-name='viewscreen_dungeon_wrestlest' inherits-from='viewscreen'>
         <pointer name="player" type-name='unit'/>
         <pointer name="target" type-name='unit'/>
-        <int8_t/>
-        <int32_t/>
-        <stl-vector/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int32_t'/>
+        <int8_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <stl-vector name='unk_3'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <stl-vector name='unk_6' type-name='int32_t'/>
+        <stl-vector name='unk_7' type-name='int32_t'/>
         <compound name='unk1'>
-            <pointer type-name='unit'/>
-            <int8_t/>
-            <int8_t/>
+            <pointer name='unk_1' type-name='unit'/>
+            <int8_t name='unk_2'/>
+            <int8_t name='unk_3'/>
             <stl-vector name='weapons' pointer-type='item'/>
-            <stl-vector type-name='int16_t'/>
-            <stl-vector/>
-            <stl-vector type-name='int16_t'/>
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector type-name='int16_t'/>
-            <stl-vector type-name='int16_t'/>
-            <stl-vector type-name='int16_t'/>
-            <stl-vector type-name='int16_t'/>
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector/>
+            <stl-vector name='unk_4' type-name='int16_t'/>
+            <stl-vector name='unk_5'/>
+            <stl-vector name='unk_6' type-name='int16_t'/>
+            <stl-vector name='unk_7'/>
+            <stl-vector name='unk_8'/>
+            <stl-vector name='unk_9'/>
+            <stl-vector name='unk_10'/>
+            <stl-vector name='unk_11' type-name='int16_t'/>
+            <stl-vector name='unk_12' type-name='int16_t'/>
+            <stl-vector name='unk_13' type-name='int16_t'/>
+            <stl-vector name='unk_14' type-name='int16_t'/>
+            <stl-vector name='unk_15'/>
+            <stl-vector name='unk_16'/>
+            <stl-vector name='unk_17'/>
         </compound>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
     </class-type>
 
     <class-type type-name='viewscreen_dungeonmodest' inherits-from='viewscreen'>
@@ -969,8 +969,8 @@
 
     <class-type type-name='viewscreen_entityst' inherits-from='viewscreen'>
         <pointer name='entity' type-name='historical_entity'/>
-        <stl-vector/>
-        <int32_t/>?
+        <stl-vector name='unk_1'/>
+        <int32_t name='unk_2'/>?
         <stl-vector pointer-type='nemesis_record' name='important_leader_nemesis'/>
         <stl-vector type-name='int32_t' name='important_leader_precedence'/>
         <int32_t name='start_idx'/>
@@ -1005,9 +1005,9 @@
     <class-type type-name='viewscreen_export_graphical_mapst' inherits-from='viewscreen'>
         <bool name='in_select' comment='false = in export'/>
         <enum name='sel_type' type-name='export_map_type' />
-        <int32_t comment='if sel_type is negative, this number is appended to the filename'/>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector/>
+        <int32_t name='unk_1' comment='if sel_type is negative, this number is appended to the filename'/>
+        <stl-vector name='unk_2' type-name='int32_t'/>
+        <stl-vector name='unk_3'/>
         <int16_t name='x0'/>
         <int16_t name='y0'/>
         <int16_t name='x1'/>
@@ -1168,14 +1168,14 @@
         </stl-vector>
         <stl-vector name='artifacts'>
             <pointer>
-                <pointer type-name='artifact_record'/>
+                <pointer name='artifact' type-name='artifact_record'/>
                 <stl-string name='name'/>
                 <stl-string name='trans_name'/>
             </pointer>
         </stl-vector>
         <stl-vector name='histfigs'>
             <pointer>
-                <pointer type-name='historical_figure'/>
+                <pointer name='histfig' type-name='historical_figure'/>
                 <stl-string name='name'/>
                 <stl-string name='trans_name'/>
             </pointer>
@@ -1405,21 +1405,21 @@
             <enum base-type='int32_t' type-name='part_of_speech'/>
         </stl-vector>
         <stl-string name='selector'/>
-        <pointer since='v0.47.02'/>
-        <pointer since='v0.47.02'/>
+        <pointer name='unk_1' since='v0.47.02'/>
+        <pointer name='unk_2' since='v0.47.02'/>
     </class-type>
 
     <class-type type-name='viewscreen_layer_currencyst' inherits-from='viewscreen_layer'>
-        <stl-vector/>
-        <int32_t/>
-        <stl-vector/>
+        <stl-vector name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <stl-vector name='unk_3'/>
     </class-type>
 
     <class-type type-name='viewscreen_layer_export_play_mapst' inherits-from='viewscreen_layer'>
-        <stl-vector type-name='int8_t'/>
-        <stl-vector type-name='int16_t'/>
-        <stl-vector type-name='int16_t'/>
-        <stl-vector type-name='int16_t'/>
+        <stl-vector name='unk_1' type-name='int8_t'/>
+        <stl-vector name='unk_2' type-name='int16_t'/>
+        <stl-vector name='unk_3' type-name='int16_t'/>
+        <stl-vector name='unk_4' type-name='int16_t'/>
     </class-type>
 
     <class-type type-name='viewscreen_layer_militaryst' inherits-from='viewscreen_layer'>
@@ -1432,7 +1432,7 @@
 
         <compound name='positions'>
             <stl-vector name="assigned" pointer-type='unit'/>
-            <stl-vector type-name='int32_t' since='v0.44.01'/>
+            <stl-vector name='unk_1' type-name='int32_t' since='v0.44.01'/>
             <stl-vector name="skill">
                 <enum base-type='int16_t' type-name='job_skill'/>
             </stl-vector>
@@ -1727,7 +1727,7 @@
 
     <class-type type-name='viewscreen_layer_overall_healthst'
                 inherits-from='viewscreen_layer'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
 
         <stl-vector name="unit" pointer-type='unit'/>
         <stl-vector name="bits1">
@@ -1743,10 +1743,10 @@
     </class-type>
 
     <class-type type-name='viewscreen_layer_reactionst' inherits-from='viewscreen_layer'>
-        <pointer/>
-        <int32_t/>
-        <stl-bit-vector/>
-        <int8_t/>
+        <pointer name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <stl-bit-vector name='unk_3'/>
+        <int8_t name='unk_4'/>
     </class-type>
 
     <class-type type-name='viewscreen_layer_squad_schedulest' inherits-from='viewscreen_layer'>
@@ -1758,7 +1758,7 @@
         <bool name='in_give_order'/>
         <bool name='in_edit_order'/>
         <pointer name='order_list' type-name='squad_schedule_entry'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='order_month'/>
         <int32_t name='order_type'/>
         <stl-bit-vector name='burrows'/>
@@ -1796,8 +1796,8 @@
             <stl-vector pointer-type='bool'/>
         </static-array>
         <int32_t name='type_tab'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
         <stl-vector name='use_name' pointer-type='stl-string'/>
         <stl-vector name='use_id' type-name='int32_t' ref-target='reaction'/>
     </class-type>
@@ -1806,7 +1806,7 @@
         <pointer name='unit' type-name='unit'/>
         <stl-vector name='held_items' pointer-type='item'/>
         <stl-vector name='reactions' pointer-type='reaction'/>
-        <stl-vector/>
+        <stl-vector name='unk_1'/>
         <stl-string name='group_name'/>
         <stl-vector name='choice_items' pointer-type='item'/>
         <stl-vector name='sel_items' pointer-type='item'/>
@@ -1814,27 +1814,27 @@
         <pointer name='cur_reaction' type-name='reaction'/>
         <int32_t name='reagent' refers-to='$$.cur_reaction.reagents[$]'/>
         <int32_t name='reagent_amnt_left'/>
-        <stl-vector pointer-type='stl-string'/>
-        <int32_t comment='index into previous field'/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <stl-vector name='unk_2' pointer-type='stl-string'/>
+        <int32_t name='unk_3' comment='index into previous field'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <stl-vector name='unk_6'/>
+        <stl-vector name='unk_7'/>
+        <stl-vector name='unk_8'/>
+        <stl-vector name='unk_9'/>
+        <stl-vector name='unk_10'/>
+        <stl-vector name='unk_11'/>
+        <stl-vector name='unk_12'/>
+        <stl-vector name='unk_13'/>
+        <stl-vector name='unk_14'/>
+        <stl-vector name='unk_15'/>
+        <stl-vector name='unk_16'/>
+        <stl-vector name='unk_17'/>
         <int32_t name='unk_20'/>
         <pointer name='unk_21'/>
-        <stl-vector/>
-        <stl-vector/>
-        <stl-vector/>
+        <stl-vector name='unk_22'/>
+        <stl-vector name='unk_23'/>
+        <stl-vector name='unk_24'/>
     </class-type>
 
     <class-type type-name='viewscreen_layer_unit_healthst' inherits-from='viewscreen_layer'>
@@ -1846,10 +1846,10 @@
         <static-array name='text_fg' count='4'><stl-vector type-name='int16_t'/></static-array>
         <static-array name='text_bg' count='4'><stl-vector type-name='int16_t'/></static-array>
         <static-array name='text_bold' count='4'><stl-vector type-name='int16_t'/></static-array>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <class-type type-name='viewscreen_layer_unit_relationshipst' inherits-from='viewscreen_layer'>
@@ -1863,8 +1863,8 @@
         </stl-vector>
         <stl-vector pointer-type='unit' name='relation_unit'/>0 for deity and other non-units
         <stl-vector pointer-type='historical_figure' name='relation_hf'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
+        <stl-vector name='unk_1' since='v0.47.02'/>
+        <stl-vector name='unk_2' since='v0.47.02'/>
         <stl-vector type-name='int32_t' name='level'/>5000 for deity, 330 for friend, 30 for acquaintance
     </class-type>
 
@@ -1887,7 +1887,7 @@
     </class-type>
 
     <class-type type-name='world_gen_param_seedst' inherits-from='world_gen_param_basest'>
-        <pointer type-name='stl-string'/>
+        <pointer name='value' type-name='stl-string'/>
     </class-type>
 
     <class-type type-name='world_gen_param_valuest' inherits-from='world_gen_param_basest'>
@@ -1914,31 +1914,31 @@
 
     <class-type type-name='viewscreen_layer_world_gen_paramst' inherits-from='viewscreen_layer'>
         <pointer type-name='worldgen_parms' name='parms'/>
-        <stl-string/>
+        <stl-string name='unk_1'/>
         <stl-vector pointer-type='world_gen_param_basest' name='controls'/>
         <compound type-name='worldgen_parms_ps' name='ps'/>
     </class-type>
 
     <class-type type-name='viewscreen_layer_world_gen_param_presetst' inherits-from='viewscreen_layer'>
-        <pointer/>
-        <int32_t/>
-        <int32_t/>
-        <stl-string/>
-        <static-array type-name='int16_t' count='24'/>
-        <static-array type-name='int8_t' count='24'/>
-        <int32_t/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
+        <pointer name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <stl-string name='unk_4'/>
+        <static-array name='unk_5' type-name='int16_t' count='24'/>
+        <static-array name='unk_6' type-name='int8_t' count='24'/>
+        <int32_t name='unk_7'/>
+        <int16_t name='unk_8'/>
+        <int16_t name='unk_9'/>
+        <int16_t name='unk_10'/>
+        <int16_t name='unk_11'/>
     </class-type>
 
     <class-type type-name='viewscreen_legendsst' inherits-from='viewscreen'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='init_step'/>
         <int32_t name='init_era'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
         <int32_t name='init_progress'/>
         <stl-vector type-name='int32_t' name='histfigs' ref-target='historical_figure'/>
         <stl-vector type-name='int32_t' name='sites' ref-target='world_site'/>
@@ -1949,13 +1949,13 @@
         <stl-vector type-name='int32_t' name='entities' ref-target='historical_entity'/>
         <stl-vector type-name='int32_t' name='structure_sites' ref-target='world_site'/>
         <stl-vector type-name='int32_t' name='structures_indices'/> index into world_site.buildings
-        <stl-vector/>
+        <stl-vector name='unk_4'/>
 
         <stl-vector name='header_text' pointer-type='stl-string'/> text at the top above event list
 
         the following four vectors have the same size and contain info about displayed events
         <stl-vector name='event_collections' type-name='int32_t' ref-target='history_event_collection'/> contains ids for collections, -1 for events
-        <stl-bit-vector/>
+        <stl-bit-vector name='unk_5'/>
         <stl-vector name='events' type-name='int32_t' ref-target='history_event'/> contains ids for events, -1 for collections
         <stl-vector name='events_text' pointer-type='stl-string'/>
 
@@ -1980,7 +1980,7 @@
             <enum-item name='UndergroundRegions'/>
             <enum-item name='Populations'/>
         </enum>
-        <int32_t/>
+        <int32_t name='unk_6'/>
         <int32_t name='main_cursor'/>
         <stl-vector type-name='int16_t' name='main_row_type'/>
         <stl-vector type-name='int32_t' name='main_row_arg1'/>
@@ -1988,21 +1988,21 @@
         <stl-vector type-name='int32_t' name='main_row_arg3'/>
         <int32_t name='sub_cursor'/>
         <int8_t name='important_events_only'/>
-        <stl-vector>
+        <stl-vector name='unk_7'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <pointer>
-                    <pointer/>
-                    <pointer/>
-                    <pointer/>
-                    <pointer/>
-                    <pointer/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <pointer name='unk_3'>
+                    <pointer name='unk_1'/>
+                    <pointer name='unk_2'/>
+                    <pointer name='unk_3'/>
+                    <pointer name='unk_4'/>
+                    <pointer name='unk_5'/>
                 </pointer>
-                <int16_t/>
-                <int16_t/>
-                <int32_t/>
-                <stl-vector type-name='int32_t'/>
+                <int16_t name='unk_4'/>
+                <int16_t name='unk_5'/>
+                <int32_t name='unk_6'/>
+                <stl-vector name='unk_7' type-name='int32_t'/>
             </pointer>
         </stl-vector>
         <int16_t name='map_x'/>
@@ -2018,7 +2018,7 @@
         <stl-vector name='codices_filtered' type-name='int32_t'  comment='index into codices'/>
         <stl-vector name='regions_filtered' type-name='int32_t' comment='index into regions'/>
         <stl-vector name='layers_filtered' type-name='int32_t' comment='index into layers'/>
-        <stl-vector type-name='int32_t'/>
+        <stl-vector name='unk_8' type-name='int32_t'/>
         <stl-vector name='entities_filtered' type-name='int32_t' comment='index into entities'/>
         <stl-vector name='structures_filtered' type-name='int32_t' comment='index into structures'/>
         <int32_t name='total_codices'/>
@@ -2029,13 +2029,13 @@
         <stl-vector name='locations' pointer-type='abstract_building'/>
         <stl-vector name='dance_floor_x' type-name='int32_t'/>
         <stl-vector name='dance_floor_y' type-name='int32_t'/>
-        <stl-vector type-name='int32_t'/>
+        <stl-vector name='unk_1' type-name='int32_t'/>
         <int32_t name='location_idx'/>
 
         <stl-vector name='occupations' pointer-type='occupation'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
+        <stl-vector name='unk_2' since='v0.47.02'/>
+        <stl-vector name='unk_3' since='v0.47.02'/>
+        <stl-vector name='unk_4' since='v0.47.02'/>
         <int32_t name='occupation_idx'/>
 
         <stl-vector name='units' pointer-type='unit'/>
@@ -2067,22 +2067,22 @@
     <struct-type type-name='matgloss_list'>
         <stl-vector name='unk_0'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
+                <int32_t name='unk_7'/>
+                <int32_t name='unk_8'/>
+                <int32_t name='unk_9'/>
+                <int32_t name='unk_10'/>
+                <int32_t name='unk_11'/>
+                <int32_t name='unk_12'/>
+                <int32_t name='unk_13'/>
+                <int32_t name='unk_14'/>
+                <int32_t name='unk_15'/>
+                <int32_t name='unk_16'/>
             </pointer>
         </stl-vector>
         <stl-vector name='generated_inorganics'>
@@ -2353,7 +2353,7 @@
         <int32_t name='all_caves_visible'/>
         <int32_t name='show_embark_tunnel'/>
         <int32_t name='pole'/>
-        <bool/>
+        <bool name='unk_1'/>
     </struct-type>
 
     <struct-type type-name='worldgen_parms_ps'>
@@ -2523,7 +2523,7 @@
         <stl-vector name='last_id' type-name='int32_t' ref-target='report'/>
         <stl-vector name='mission_reports' type-name='int32_t' ref-target='mission_report'/>
         <stl-vector name='spoils_reports' type-name='int32_t' ref-target='spoils_report'/>
-        <stl-vector since='v0.47.02'/>
+        <stl-vector name='unk_1' since='v0.47.02'/>
         <int32_t name='cursor'/>
         <pointer name='mission_report' type-name='mission_report'/>
         <int32_t name='map_cursor_x'/>
@@ -2544,9 +2544,9 @@
         <pointer name='spoils_report_title' type-name='stl-string'/>
         <int32_t name='spoils_report_scroll'/>
 
-        <pointer since='v0.47.02'/>
-        <stl-vector since='v0.47.02'/>
-        <int32_t since='v0.47.02'/>
+        <pointer name='unk_2' since='v0.47.02'/>
+        <stl-vector name='unk_3' since='v0.47.02'/>
+        <int32_t name='unk_4' since='v0.47.02'/>
     </class-type>
 
     <class-type type-name='viewscreen_requestagreementst' inherits-from='viewscreen'>
@@ -2568,7 +2568,7 @@
     </struct-type>
 
     <class-type type-name='viewscreen_savegamest' inherits-from='viewscreen'>
-        <stl-string/>
+        <stl-string name='unk_1'/>
         <enum name='cur_step' base-type='int32_t'>
             <enum-item name='Initializing'/>
             <enum-item name='CheckingDirectoryStructure'/>
@@ -2635,12 +2635,12 @@
         <pointer name='p_matindex' type-name='int32_t'/>
         <pointer name='choice' type-name='embark_item_choice'/>
         <pointer name='screen' type-name='viewscreen_setupdwarfgamest'/>
-        <pointer since='v0.47.02'/>
+        <pointer name='unk_1' since='v0.47.02'/>
         <static-array name='page_base' count='107' index-enum='entity_sell_category'>
             <stl-vector type-name='int32_t'/>
         </static-array>
         <static-string name='title' size='256'/>
-        <static-string size='256'/>
+        <static-string name='unk_2' size='256'/>
         <static-string name='filter' size='256'/>
         <int32_t name='right_pos'/>
         <int32_t name='right_page_base'/>
@@ -2691,7 +2691,7 @@
         </enum>
 
         <int32_t name='home_site_id' ref-target='world_site' since='v0.47.01'/>
-        <int32_t since='v0.47.01'/>
+        <int32_t name='unk_1' since='v0.47.01'/>
         <int16_t name='civilian_occupation' since='v0.47.01'/>
         <static-array name='civilian_skill' type-name='int32_t' count='147' index-enum='job_skill' since='v0.47.01'/>
 
@@ -2857,7 +2857,7 @@
         <stl-vector name='unk_v47_138'/>
         <stl-vector name='unk_v47_139'/>
         <stl-vector name='unk_v47_140'/>
-        <padding size='340'/>
+        <padding name='pad_1' size='340'/>
         <int32_t name='equip_points_remaining'/>
         <stl-vector name='unk_v47_142'/>
         <int32_t name='unk_v47_143'/>
@@ -2868,7 +2868,7 @@
                     <int16_t name='item_subtype'/>
                     <int16_t name='mat_type'/>
                     <int32_t name='mat_index'/>
-                    <bool/>
+                    <bool name='unk_1'/>
                 </pointer>
             </stl-vector>
         </static-array>
@@ -2929,7 +2929,7 @@
             <pointer>
                 <int32_t name='race' ref-target='creature_raw'/>
                 <int32_t name='entity_id' ref-target='historical_entity'/>
-                <int32_t/> could be above here
+                <int32_t name='unk_1'/> could be above here
                 <bool name='playable'/> will be included in wild_creature_ids
             </pointer>
         </stl-vector>
@@ -2983,9 +2983,9 @@
         <stl-vector name='skill_dwarf_idx' type-name='int16_t'/>
         <stl-vector name='skill_level' type-name='int16_t'/>
 
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int16_t'/>
+        <stl-vector name='unk_1' type-name='int32_t'/>
+        <stl-vector name='unk_2' type-name='int32_t'/>
+        <stl-vector name='unk_3' type-name='int16_t'/>
 
         <stl-vector name='item_type' type-name='int16_t'/>
         <stl-vector name='item_subtype' type-name='int16_t'/>
@@ -3173,8 +3173,8 @@
             </pointer>
         </stl-vector>
         <stl-vector pointer-type="stl-string" name="arena_savegames"/>
-        <stl-vector pointer-type='stl-string' since='v0.47.01'/>
-        <stl-vector pointer-type='stl-string' since='v0.47.01'/>
+        <stl-vector pointer-type='stl-string' name='unk_1' since='v0.47.01'/>
+        <stl-vector pointer-type='stl-string' name='unk_2' since='v0.47.01'/>
         <stl-string name="str_slaves"/>
         <stl-string name="str_chapter"/>
         <stl-string name="str_copyright"/>
@@ -3227,7 +3227,7 @@
     <class-type type-name='viewscreen_tradeagreementst' inherits-from='viewscreen'>
         <pointer type-name='entity_sell_prices' name='requests'/>
         <int32_t ref-target='historical_entity' name='civ_id'/>
-        <stl-vector type-name='int16_t'/>
+        <stl-vector name='unk_1' type-name='int16_t'/>
         <int32_t name='type_idx'/>
         <int32_t name='good_idx'/>
         <static-string size='256' name='title'/>
@@ -3278,14 +3278,14 @@
           <enum-item name='WelcomeAnnoyed'/>
           <enum-item name='RefusedAnnoyed'/>
         </enum>
-        <int16_t/>
-        <int32_t/>
+        <int16_t name='unk_1'/>
+        <int32_t name='unk_2'/>
         <int8_t name="has_offer"/>
         <stl-vector name="counteroffer" pointer-type='item'/>
         <int8_t name="in_edit_count"/>
         <stl-string name="edit_count"/>
-        <stl-vector pointer-type="stl-string"/>
-        <int32_t/>
+        <stl-vector name='unk_3' pointer-type="stl-string"/>
+        <int32_t name='unk_4'/>
     </class-type>
 
     <class-type type-name='viewscreen_tradelistst' inherits-from='viewscreen'>
@@ -3362,17 +3362,17 @@
                 <stl-string name='item_desc' comment='e.g. FAT'/>
                 <stl-string name='product_desc' comment='e.g. BAG_ITEM (-producing)'/>
                 <int32_t name='mat_index'/>
-                <int32_t/>?
-                <int32_t/>?
-                <int32_t/>?
+                <int32_t name='unk_1'/>?
+                <int32_t name='unk_2'/>?
+                <int32_t name='unk_3'/>?
                 <stl-string name='name'/>
                 ...?
             </pointer>
         </stl-vector>
         <stl-vector name='traits_visible' type-name='int32_t'/>
-        <int8_t/>
-        <stl-vector/>
-        <int32_t/>?
+        <int8_t name='unk_1'/>
+        <stl-vector name='unk_2'/>
+        <int32_t name='unk_3'/>?
         <bool name='item_count_edit'/>
         <stl-string name='item_count_entry'/>
     </class-type>

--- a/df.world-data.xml
+++ b/df.world-data.xml
@@ -446,10 +446,10 @@
 
         <compound name='pos' type-name='coord2d'/>
         <int16_t name='unk12e8'/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
+        <int16_t name='unk_1'/>
+        <int16_t name='unk_2'/>
+        <int16_t name='unk_3'/>
+        <int16_t name='unk_4'/>
 
         -- Rivers crossing embark tile edges
         <compound name='rivers_vertical'>
@@ -770,10 +770,10 @@
             <int32_t name='world_width2'/>
             <int32_t name='world_height2'/>
 
-            <pointer type-name='uint32_t' is-array='true' comment='align(width,4)*height'/>
-            <pointer type-name='uint32_t' is-array='true' comment='align(width,4)*height'/>
-            <pointer type-name='uint32_t' is-array='true' comment='width*height'/>
-            <pointer type-name='uint8_t' is-array='true' comment='align(width,4)*height'/>
+            <pointer name='unk_1' type-name='uint32_t' is-array='true' comment='align(width,4)*height'/>
+            <pointer name='unk_2' type-name='uint32_t' is-array='true' comment='align(width,4)*height'/>
+            <pointer name='unk_3' type-name='uint32_t' is-array='true' comment='width*height'/>
+            <pointer name='unk_4' type-name='uint8_t' is-array='true' comment='align(width,4)*height'/>
         </compound>
 
         <stl-vector name='region_details' pointer-type='world_region_details'/>
@@ -863,25 +863,25 @@
             </pointer>
         </pointer>
 
-        <int32_t since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <pointer since='v0.40.01'/>
-        <padding size='294920'/>
-        <int8_t since='v0.40.01'/>
-        <int8_t since='v0.40.01'/>
+        <int32_t name='unk_1' since='v0.40.01'/>
+        <pointer name='unk_2' since='v0.40.01'/>
+        <pointer name='unk_3' since='v0.40.01'/>
+        <pointer name='unk_4' since='v0.40.01'/>
+        <pointer name='unk_5' since='v0.40.01'/>
+        <pointer name='unk_6' since='v0.40.01'/>
+        <pointer name='unk_7' since='v0.40.01'/>
+        <pointer name='unk_8' since='v0.40.01'/>
+        <pointer name='unk_9' since='v0.40.01'/>
+        <pointer name='unk_10' since='v0.40.01'/>
+        <pointer name='unk_11' since='v0.40.01'/>
+        <pointer name='unk_12' since='v0.40.01'/>
+        <pointer name='unk_13' since='v0.40.01'/>
+        <pointer name='unk_14' since='v0.40.01'/>
+        <pointer name='unk_15' since='v0.40.01'/>
+        <pointer name='unk_16' since='v0.40.01'/>
+        <padding name='pad_1' size='294920'/>
+        <int8_t name='unk_17' since='v0.40.01'/>
+        <int8_t name='unk_18' since='v0.40.01'/>
 
         <stl-vector name="active_site" pointer-type='world_site'/>
 
@@ -961,14 +961,14 @@
         </stl-vector>
 
         <compound name='unk_482f8' since='v0.40.01'>
-            <static-array type-name='int32_t' count='320000'/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
+            <static-array name='unk_1' type-name='int32_t' count='320000'/>
+            <int32_t name='unk_2'/>
+            <int32_t name='unk_3'/>
+            <int32_t name='unk_4'/>
+            <int32_t name='unk_5'/>
+            <int32_t name='unk_6'/>
+            <int32_t name='unk_7'/>
+            <int32_t name='unk_8'/>
         </compound>
     </struct-type>
 

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -1,22 +1,22 @@
 <data-definition>
     <struct-type type-name='scribejob'>
         <int32_t name='idmaybe'/>
-        <int32_t comment='not locationid'/>
+        <int32_t name='unk_1' comment='not locationid'/>
         <int32_t name='item_id'/>
         <int32_t name='written_content_id'/>
         <int32_t name='unit_id'/>
         <int32_t name='activity_entry_id'/>
-        <int32_t/>
+        <int32_t name='unk_2'/>
     </struct-type>
 
     <struct-type type-name='site_reputation_report'>
         <int32_t name='site_id'/>
         <int32_t name='location_id'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
         <int32_t name='year'/>
         <int32_t name='tickmaybe'/>
-        <static-array type-name='int32_t' count='8'/>
+        <static-array name='unk_3' type-name='int32_t' count='8'/>
     </struct-type>
 
     <struct-type type-name='site_reputation_info'>
@@ -27,11 +27,11 @@
         <stl-vector name='scribejobs' pointer-type='scribejob'/>
         <int32_t name='nextidmaybe'/>
         <int32_t name='year'/>
-        <uint16_t/>
-        <int16_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <uint16_t name='unk_1'/>
+        <int16_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
     </struct-type>
 
     <enum-type type-name='abstract_building_type'>
@@ -109,14 +109,14 @@
 
         <stl-vector name='inhabitants'>
             <pointer>
-                <int16_t/>
+                <int16_t name='unk_1'/>
                 <int32_t name='histfig_id' ref-target='historical_figure'/>
             </pointer>
         </stl-vector>
         <df-flagarray name='flags' index-enum='abstract_building_flags'/>
         <pointer name='unk1' comment='in temples; hfig is the god'>
             <stl-vector name='hfig' ref-target='historical_figure' type-name='int32_t'/>
-            <int32_t/>
+            <int32_t name='unk_1'/>
             <stl-vector name='architectural_elements' comment='used by temples' type-name='architectural_element'/>
 
             <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index' comment='just a guess'/>
@@ -215,11 +215,11 @@
             <enum-item name='SEWERS'/>
             <enum-item name='CATACOMBS'/>
         </enum>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <compound name='entombed' type-name='abstract_building_entombed'/>
-        <int32_t/>
-        <int32_t comment='not saved'/>
-        <int32_t comment='not saved'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3' comment='not saved'/>
+        <int32_t name='unk_4' comment='not saved'/>
     </class-type>
 
     <class-type type-name='abstract_building_underworld_spirest' inherits-from='abstract_building'>
@@ -233,7 +233,7 @@
         <stl-vector name='room_info'>
             <pointer>
                 <int32_t name='id'/>
-                <stl-string/>
+                <stl-string name='unk_1'/>
                 <int32_t name='world_x'/>
                 <int32_t name='world_y'/>
                 <int32_t name='world_z'/>
@@ -245,10 +245,10 @@
     <class-type type-name='abstract_building_libraryst' inherits-from='abstract_building'>
         <compound name='name' type-name='language_name'/>
         <stl-vector name='copied_artifacts' type-name='int32_t' ref-target='artifact_record'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
         <compound name='contents' type-name='abstract_building_contents'/>
     </class-type>
 
@@ -263,7 +263,7 @@
 
     <class-type type-name='abstract_building_towerst' inherits-from='abstract_building'>
         <compound name='name' type-name='language_name'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
     </class-type>
 
     <enum-type type-name='world_site_type' base-type='int16_t'>
@@ -320,7 +320,7 @@
     <struct-type type-name='property_ownership'>
         <int32_t name="index"/>
         <bool name="is_concrete_property" comment="true if house [property_index = 4 only one seen], or index into buildings"/>
-        <padding size='3'/>
+        <padding name='pad_1' size='3'/>
         <int32_t name='property_index' comment="index into buildings when is_concrete_property is false. Only seen 4 = house with is_concrete_property = true"/>
         <int32_t name="unk_hfid" ref-target='historical_figure' comment="Always same as owner_hfid when set, but not always set when that field is."/>
         <int32_t name="owner_entity_id" ref-target='historical_entity' comment='Mutually exclusive with owner_hfid. All seen were merchant companies.'/>
@@ -364,7 +364,7 @@
             <stl-vector name="unk_d4" type-name='int32_t'/>
 
             <stl-vector name="unk_v40_1a" since='v0.40.01' pointer-type='historical_figure'/> during worldgen only
-            <padding size='4'/>
+            <padding name='pad_1' size='4'/>
             <stl-vector name="unk_v40_1b" since='v0.40.01' pointer-type='nemesis_record'/> this and below: at the end of worldgen only
             <stl-vector name="unk_v40_1c" since='v0.40.01' pointer-type='nemesis_record'/>
             <stl-vector name="unk_v40_1d" since='v0.40.01' pointer-type='nemesis_record'/>
@@ -395,18 +395,18 @@
         <int32_t name="unk_110"/>
         <int32_t name="unk_114"/>
         <pointer name="unk_118">
-            <stl-vector type-name='int16_t'/>
-            <stl-vector type-name='int16_t'/>
-            <stl-vector type-name='int16_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
+            <stl-vector name='unk_1' type-name='int16_t'/>
+            <stl-vector name='unk_2' type-name='int16_t'/>
+            <stl-vector name='unk_3' type-name='int16_t'/>
+            <stl-vector name='unk_4' type-name='int32_t'/>
+            <stl-vector name='unk_5' type-name='int32_t'/>
+            <stl-vector name='unk_6' type-name='int32_t'/>
         </pointer>
         <int32_t name="unk_11c" comment='Caves have non zero numbers. No others.'/>
         <int32_t name="unk_120" comment='Subset of caves can have non zero.'/>
         <int32_t name="unk_124" comment='Monument 0, LairShrine 5, Camp 20, others varying'/>
         <int32_t name="unk_128" comment=' "site_level" is in here somewhere. Same as for unk_124, but varying ones always less/equal'/>
-        <static-array type-name='int32_t' count='8' comment="Has all zero for Fortress, Camp, PlayerFortress, Monument, and LairShrine. Cave can have value, while DarkFortress, MountainHalls, ForestRetreat and Town all have at least one non zero value"/>
+        <static-array name='unk_2' type-name='int32_t' count='8' comment="Has all zero for Fortress, Camp, PlayerFortress, Monument, and LairShrine. Cave can have value, while DarkFortress, MountainHalls, ForestRetreat and Town all have at least one non zero value"/>
 
         <stl-vector name="unk_13c" comment='MountainHall, Town, DarkFortress, but not all'>
             <pointer>
@@ -506,35 +506,35 @@
         </stl-vector>
         <stl-vector name="unk_v40_4b" since='v0.40.01'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
             </pointer>
         </stl-vector>
         <stl-vector name="unk_v40_4c" since='v0.40.01'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <stl-vector type-name='int32_t'/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <stl-vector name='unk_3' type-name='int32_t'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
             </pointer>
         </stl-vector>
         <stl-vector name="unk_v40_4d" since='v0.40.01' comment="only seen once, 13 long, corresponding to 13 attacks from the same entity_id resulting in site taken over in 'might bey year'">
             <pointer>
                 <int32_t name='id'/>
-                <stl-vector>
+                <stl-vector name='unk_1'>
                     <pointer>
-                        <int32_t/>
-                        <int32_t comment="might be race"/>
-                        <int32_t/>
-                        <int32_t/>
-                        <int32_t comment="might be year"/>
-                        <int32_t comment="might be year"/>
-                        <int32_t/>
-                        <int32_t/>
+                        <int32_t name='unk_1'/>
+                        <int32_t name='unk_2' comment="might be race"/>
+                        <int32_t name='unk_3'/>
+                        <int32_t name='unk_4'/>
+                        <int32_t name='unk_5' comment="might be year"/>
+                        <int32_t name='unk_6' comment="might be year"/>
+                        <int32_t name='unk_7'/>
+                        <int32_t name='unk_8'/>
                     </pointer>
                 </stl-vector>
-                <stl-vector type-name='int32_t'/>
+                <stl-vector name='unk_2' type-name='int32_t'/>
                 <int32_t name='entity_id' ref-target='historical_entity' comment="single attacking site civ is only one seen"/>
             </pointer>
         </stl-vector>
@@ -542,23 +542,23 @@
         <int32_t name='unk_v40_4d_next_id' init-value='0' since='v0.43.01' comment="only single non zero entry, matching vector above. Might guess 'since' is scrambled"/>
         <stl-vector name='unk_v43_2' since='v0.43.01'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array> not initialized OR saved
-                <static-array count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <static-array name='unk_4' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_5' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_6' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_7' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_8' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_9' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_10' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_11' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_12' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_13' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_14' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_15' count='16'><static-array count='16' type-name='int32_t'/></static-array>
+                <static-array name='unk_16' count='16'><static-array count='16' type-name='int32_t'/></static-array> not initialized OR saved
+                <static-array name='unk_17' count='16'><static-array count='16' type-name='int32_t'/></static-array>
             </pointer>
         </stl-vector>
         <int32_t name='unk_v43_3' comment='constant 0?' since='v0.43.01'/>
@@ -595,31 +595,31 @@
         <stl-vector name="unk_v42_1" since='v0.42.01' pointer-type='occupation'/> during worldgen only
 
         <int32_t name='unk_v43_4' since='v0.43.01' comment='uninitialized'/>
-        <stl-vector since='v0.44.01'/>
+        <stl-vector name='unk_3' since='v0.44.01'/>
 
-        <pointer type-name='historical_figure' has-bad-pointers='true'/>
-        <pointer type-name='historical_figure' has-bad-pointers='true'/>
-        <pointer type-name='historical_figure' has-bad-pointers='true'/>
-        <pointer type-name='historical_figure' has-bad-pointers='true'/>
-        <pointer type-name='historical_figure' has-bad-pointers='true'/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <pointer/>
-        <int32_t/>
-        <pointer>
-            <stl-vector/>
+        <pointer name='unk_4' type-name='historical_figure' has-bad-pointers='true'/>
+        <pointer name='unk_5' type-name='historical_figure' has-bad-pointers='true'/>
+        <pointer name='unk_6' type-name='historical_figure' has-bad-pointers='true'/>
+        <pointer name='unk_7' type-name='historical_figure' has-bad-pointers='true'/>
+        <pointer name='unk_8' type-name='historical_figure' has-bad-pointers='true'/>
+        <pointer name='unk_9'/>
+        <pointer name='unk_10'/>
+        <pointer name='unk_11'/>
+        <pointer name='unk_12'/>
+        <pointer name='unk_13'/>
+        <pointer name='unk_14'/>
+        <pointer name='unk_15'/>
+        <pointer name='unk_16'/>
+        <pointer name='unk_17'/>
+        <pointer name='unk_18'/>
+        <pointer name='unk_19'/>
+        <pointer name='unk_20'/>
+        <pointer name='unk_21'/>
+        <pointer name='unk_22'/>
+        <pointer name='unk_23'/>
+        <int32_t name='unk_24'/>
+        <pointer name='unk_25'>
+            <stl-vector name='unk_1'/>
         </pointer>
     </struct-type>
 
@@ -658,20 +658,20 @@
         <int32_t name='unk_ec' init-value='-1'/>
         <int32_t name='unk_f0' init-value='-1'/>
         <int32_t name='unk_f4' comment='0 or 800000'/>
-        <stl-vector>
+        <stl-vector name='unk_1'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
             </pointer>
         </stl-vector>
-        <stl-vector>
+        <stl-vector name='unk_2'>
             <pointer>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
             </pointer>
         </stl-vector>
         <int32_t name="unk_f8"/>
@@ -753,7 +753,7 @@
                         <int32_t name="unk_1c"/>
                     </pointer>
                 </stl-vector>
-                <stl-vector since='v0.44.01'/>
+                <stl-vector name='unk_1' since='v0.44.01'/>
                 <int32_t name="unk_55f0" init-value='-30000'/>
                 <int32_t name="unk_55f4" init-value='-30000'/>
                 <int16_t name="unk_55f8"/>
@@ -828,61 +828,61 @@
             </pointer>
         </stl-vector>
 
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name="army_controller_pos_x"/>
         <int32_t name="army_controller_pos_y"/>
         <static-array name='unk_193bc' count='500'>
             <int32_t name='nemesis_id' ref-target='nemesis_record'/>
-            <int32_t/>
+            <int32_t name='unk_1'/>
             <compound name='unk_8'>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+                <int32_t name='unk_1'/>
+                <int32_t name='unk_2'/>
+                <int32_t name='unk_3'/>
+                <int32_t name='unk_4'/>
+                <int32_t name='unk_5'/>
+                <int32_t name='unk_6'/>
+                <int32_t name='unk_7'/>
+                <int32_t name='unk_8'/>
+                <int32_t name='unk_9'/>
             </compound>
-            <int32_t/>
+            <int32_t name='unk_2'/>
             <int32_t name='building_id' ref-target='site_realization_building'/>
             <compound type-name='coord' name='pos'/>
-            <int16_t/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
-            <static-array type-name='int32_t' count='20'/>
-            <static-array type-name='int32_t' count='20'/>
-            <int16_t/>
-            <int16_t/>
-            <int32_t/>
-            <int32_t/>
+            <int16_t name='unk_3'/>
+            <int32_t name='unk_4'/>
+            <int32_t name='unk_5'/>
+            <int32_t name='unk_6'/>
+            <static-array name='unk_7' type-name='int32_t' count='20'/>
+            <static-array name='unk_9' type-name='int32_t' count='20'/>
+            <int16_t name='unk_10'/>
+            <int16_t name='unk_11'/>
+            <int32_t name='unk_12'/>
+            <int32_t name='unk_13'/>
         </static-array>
         <int32_t name='num_unk_193bc'/>
-        <int32_t/>
-        <int32_t/>
-        <static-array count='2' since='v0.47.01'>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <static-array name='unk_4' count='2' since='v0.47.01'>
             <static-array type-name='int32_t' count='300'/>
         </static-array>
-        <int32_t since='v0.47.01'/>
+        <int32_t name='unk_5' since='v0.47.01'/>
 
-        <static-array type-name='pointer' count='20'/>
-        <int32_t/>
-        <static-array type-name='pointer' count='20'/>
-        <int32_t/>
-        <static-array type-name='pointer' count='20'/>
-        <int32_t/>
-        <static-array type-name='pointer' count='20'/>
-        <int32_t/>
-        <static-array type-name='pointer' count='20'/>
-        <int32_t/>
-        <static-array type-name='pointer' count='20'/>
-        <int32_t/>
-        <static-array type-name='pointer' count='20'/>
-        <int32_t/>
-        <static-array type-name='pointer' count='20'/>
-        <int32_t/>
+        <static-array name='unk_6' type-name='pointer' count='20'/>
+        <int32_t name='unk_7'/>
+        <static-array name='unk_8' type-name='pointer' count='20'/>
+        <int32_t name='unk_9'/>
+        <static-array name='unk_10' type-name='pointer' count='20'/>
+        <int32_t name='unk_11'/>
+        <static-array name='unk_12' type-name='pointer' count='20'/>
+        <int32_t name='unk_13'/>
+        <static-array name='unk_15' type-name='pointer' count='20'/>
+        <int32_t name='unk_16'/>
+        <static-array name='unk_17' type-name='pointer' count='20'/>
+        <int32_t name='unk_18'/>
+        <static-array name='unk_19' type-name='pointer' count='20'/>
+        <int32_t name='unk_20'/>
+        <static-array name='unk_21' type-name='pointer' count='20'/>
+        <int32_t name='unk_22'/>
 
         <static-array name='building_well' pointer-type='site_realization_building' count='20'/>
         <int32_t name='num_building_well'/>
@@ -893,8 +893,8 @@
         <static-array name='building_type21' pointer-type='site_realization_building' count='20'/>
         <int32_t name='num_building_type21'/>
 
-        <static-array type-name='pointer' count='16'/>
-        <int32_t/>
+        <static-array name='unk_23' type-name='pointer' count='16'/>
+        <int32_t name='unk_24'/>
 
         <stl-vector name="unk_wsr_vector"/>
     </struct-type>
@@ -925,14 +925,14 @@
         <int8_t name="unk_348"/>
         <int8_t name="unk_349"/>
         <int32_t name='unk_34c'/>
-        <int8_t/>
-        <int8_t/>
-        <int8_t/>
-        <int8_t/>
-        <int8_t/>
-        <int8_t/>
-        <int32_t since='v0.47.01'/>
-        <int32_t since='v0.47.01'/>
+        <int8_t name='unk_1'/>
+        <int8_t name='unk_2'/>
+        <int8_t name='unk_3'/>
+        <int8_t name='unk_4'/>
+        <int8_t name='unk_5'/>
+        <int8_t name='unk_6'/>
+        <int32_t name='unk_7' since='v0.47.01'/>
+        <int32_t name='unk_8' since='v0.47.01'/>
         <static-array name='unk_370' count='48' type-name='int16_t'/>
         <static-array name='unk_3d0' count='48' type-name='int16_t'/>
     </struct-type>
@@ -1156,8 +1156,8 @@
 
     <class-type type-name='site_realization_building_info_shrinest'
                 inherits-from='site_realization_building_infost'>
-        <int32_t init-value='-1'/>
-        <int32_t init-value='-1'/>
+        <int32_t name='unk_1' init-value='-1'/>
+        <int32_t name='unk_2' init-value='-1'/>
     </class-type>
 
     <enum-type type-name='creation_zone_pwg_alteration_type'>
@@ -1184,35 +1184,35 @@
 
     <class-type type-name='creation_zone_pwg_alteration_location_deathst' inherits-from='creation_zone_pwg_alterationst'>
         <compound name='unk_1'>
-            <stl-vector>
+            <stl-vector name='unk_1a'>
                 <pointer>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
+                    <int32_t name='unk_1'/>
+                    <int32_t name='unk_2'/>
+                    <int32_t name='unk_3'/>
+                    <int32_t name='unk_4'/>
+                    <int32_t name='unk_5'/>
+                    <int32_t name='unk_6'/>
+                    <int32_t name='unk_7'/>
+                    <int32_t name='unk_8'/>
                 </pointer>
             </stl-vector>
-            <stl-vector type-name='int32_t'/>
+            <stl-vector name='unk_2a' type-name='int32_t'/>
         </compound>
         <int32_t name='unk_2'/>
     </class-type>
 
     <class-type type-name='creation_zone_pwg_alteration_campst' inherits-from='creation_zone_pwg_alterationst'>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <int32_t name='x1'/>
         <int32_t name='y1'/>
         <int32_t name='x2'/>
         <int32_t name='y2'/>
-        <int32_t/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
-        <int32_t/>
+        <int32_t name='unk_2'/>
+        <int16_t name='unk_3'/>
+        <int16_t name='unk_4'/>
+        <int16_t name='unk_5'/>
+        <int16_t name='unk_6'/>
+        <int32_t name='unk_7'/>
     </class-type>
 
     <class-type type-name='creation_zone_pwg_alteration_srb_ruinedst' inherits-from='creation_zone_pwg_alterationst'>
@@ -1221,8 +1221,8 @@
     </class-type>
 
     <class-type type-name='creation_zone_pwg_alteration_srp_ruinedst' inherits-from='creation_zone_pwg_alterationst'>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
     </class-type>
 
 

--- a/df.world.xml
+++ b/df.world.xml
@@ -147,8 +147,8 @@
             <pointer>
                 <enum name='performance_event' base-type='int32_t' type-name='performance_event_type' comment='can e.g. be music for a dance musician'/>
                 <int32_t name='role_index' comment='index into the instruments vector for music, with corresponding roles for other forms, possibly a dance_form_sub1 entry for dances'/>
-                <compound type-name='incident_hfid'/>
-                <int32_t/>
+                <compound name='unk_1' type-name='incident_hfid'/>
+                <int32_t name='unk_2'/>
             </pointer>
         </stl-vector>
         <int32_t name='reference_id' comment='history_event id/poetic_form id/musical_form id/dance_form_id or -1'/>
@@ -192,18 +192,18 @@
             <enum-item name='Given'/>
         </enum>
         <int32_t name='content_id' ref-target='written_content'/>
-        <compound type-name='incident_hfid'/>
-        <compound type-name='incident_hfid'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector type-name='int32_t'/>
-        <int32_t/>
+        <compound name='unk_1' type-name='incident_hfid'/>
+        <compound name='unk_2' type-name='incident_hfid'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <stl-vector name='unk_7' type-name='int32_t'/>
+        <int32_t name='unk_8'/>
     </struct-type>
 
     <struct-type type-name='incident_data_identity'>
-        <stl-vector pointer-type='incident_hfid'/>
+        <stl-vector name='unk_1' pointer-type='incident_hfid'/>
     </struct-type>
 
 
@@ -426,8 +426,8 @@
         <stl-vector type-name='int32_t' name='coffin_skeletons' ref-target='item'/>
         <int32_t name='disturbance' ref-target='interaction'/>
         <stl-vector type-name='int32_t' name='treasures' ref-target='item'/>
-        <int32_t comment='reference to something, not an interaction or syndrome'/>
-        <int32_t/>
+        <int32_t name='unk_1' comment='reference to something, not an interaction or syndrome'/>
+        <int32_t name='unk_2'/>
         <stl-vector name='trigger_regions' comment='normally just one, 3x3 around the coffin'>
             <pointer>
                 <int32_t name='x_min'/>
@@ -508,14 +508,14 @@
 
     <struct-type type-name='glowing_barrier'>
         <bool name='triggered' comment='set when the glowing barrier vanishes, preventing later HFS events'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <stl-vector name='buildings' type-name='int32_t' ref-target='building' comment='when building is deconstructed, causes glowing barrier at pos to vanish and (in fort mode) spawns HFS one z-level below if it has not been set off already'/>
         <compound name='pos' type-name='coord' comment='coordinates of a GlowingBarrier or GlowingFloor tiletype'/>
     </struct-type>
 
     <struct-type type-name='deep_vein_hollow'>
         <bool name='triggered' comment='set when the underworld spire is breached, preventing subsequent HFS events'/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
         <compound name='tiles' type-name='coord_path' comment='tile coordinates correspond to open spaces within an underworld spire; revealing one of these tiles triggers the HFS demon wave'/>
         <compound name='pos' type-name='coord' comment='seemingly unused'/>
     </struct-type>
@@ -579,16 +579,16 @@
                 <bitfield name='flags' base-type='int32_t'>
                     <flag-bit name='dead'/>
                 </bitfield>
-                <int32_t comment='not saved'/>
+                <int32_t name='unk_1' comment='not saved'/>
             </pointer>
         </stl-vector>
 
-        <static-array count='2000'>
-            <pointer type-name='unit' comment="List seems to be processed index 0 first and then removal swaps last to first"/>
-            <int32_t comment="Seems to have very few bits set in lower half, (not copied with the pointer?)"/>
-            <int32_t comment="Seems to have many bits set in lower half, (not copied with the pointer?)"/>
+        <static-array name='unk_1' count='2000'>
+            <pointer name='unk_1' type-name='unit' comment="List seems to be processed index 0 first and then removal swaps last to first"/>
+            <int32_t name='unk_2' comment="Seems to have very few bits set in lower half, (not copied with the pointer?)"/>
+            <int32_t name='unk_3' comment="Seems to have many bits set in lower half, (not copied with the pointer?)"/>
         </static-array>
-        <int32_t comment='next slot'/>
+        <int32_t name='unk_2' comment='next slot'/>
 
         <virtual-methods>
             <vmethod name='cancel_job'><pointer type-name='job'/></vmethod>
@@ -635,12 +635,12 @@
     <struct-type type-name='mental_picture'>
         <compound name='unk'>
             <stl-vector name='elements' pointer-type='mental_picture_elementst'/>
-            <int32_t/>
+            <int32_t name='unk_1'/>
             <stl-vector name='properties' pointer-type='mental_picture_propertyst'/>
-            <int32_t/>
+            <int32_t name='unk_2'/>
         </compound>
-        <int32_t init-value='-1'/>
-        <int32_t init-value='-1'/>
+        <int32_t name='unk_1' init-value='-1'/>
+        <int32_t name='unk_2' init-value='-1'/>
     </struct-type>
 
     32bit size is 4 bytes more than should be
@@ -649,82 +649,82 @@
 
         <stl-vector name='mental_pictures'>
             <pointer>
-                <stl-vector pointer-type='mental_picture'/>
+                <stl-vector name='unk_1' pointer-type='mental_picture'/>
             </pointer>
         </stl-vector>
         <stl-vector name='deities' type-name='int32_t' ref-target="historical_figure" comment="historical figure ID of gods the belief system is concerned with"/>
         <stl-vector name='worship_levels' type-name='int32_t' comment="worship level for each god referenced in the deities field"/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_1'/>
+        <int32_t name='unk_2'/>
+        <int32_t name='unk_3'/>
+        <int32_t name='unk_4'/>
+        <int32_t name='unk_5'/>
+        <int32_t name='unk_6'/>
+        <int32_t name='unk_7'/>
+        <int32_t name='unk_8'/>
+        <int32_t name='unk_9'/>
+        <int32_t name='unk_10'/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_11'/>
+        <int32_t name='unk_12'/>
+        <int32_t name='unk_13'/>
+        <int32_t name='unk_14'/>
+        <int32_t name='unk_15'/>
+        <int32_t name='unk_16'/>
+        <int32_t name='unk_17'/>
+        <int32_t name='unk_18'/>
+        <int32_t name='unk_19'/>
+        <int32_t name='unk_20'/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_21'/>
+        <int32_t name='unk_22'/>
+        <int32_t name='unk_23'/>
+        <int32_t name='unk_24'/>
+        <int32_t name='unk_25'/>
+        <int32_t name='unk_26'/>
+        <int32_t name='unk_27'/>
+        <int32_t name='unk_28'/>
+        <int32_t name='unk_29'/>
+        <int32_t name='unk_30'/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_31'/>
+        <int32_t name='unk_32'/>
+        <int32_t name='unk_33'/>
+        <int32_t name='unk_34'/>
+        <int32_t name='unk_35'/>
+        <int32_t name='unk_36'/>
+        <int32_t name='unk_37'/>
+        <int32_t name='unk_38'/>
+        <int32_t name='unk_39'/>
+        <int32_t name='unk_40'/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_41'/>
+        <int32_t name='unk_42'/>
+        <int32_t name='unk_43'/>
+        <int32_t name='unk_44'/>
+        <int32_t name='unk_45'/>
+        <int32_t name='unk_46'/>
+        <int32_t name='unk_47'/>
+        <int32_t name='unk_48'/>
+        <int32_t name='unk_49'/>
+        <int32_t name='unk_50'/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_51'/>
+        <int32_t name='unk_52'/>
+        <int32_t name='unk_53'/>
+        <int32_t name='unk_54'/>
+        <int32_t name='unk_55'/>
+        <int32_t name='unk_56'/>
+        <int32_t name='unk_57'/>
+        <int32_t name='unk_58'/>
+        <int32_t name='unk_59'/>
+        <int32_t name='unk_60'/>
 
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='unk_61'/>
+        <int32_t name='unk_62'/>
+        <int32_t name='unk_63'/>
+        <int32_t name='unk_64'/>
     </struct-type>
 
     <struct-type type-name='divination_set_roll'>
@@ -901,10 +901,10 @@
             -- Pointers used as tokens; data never accessed by the look of it:
 
             <compound name='simple1'>
-                <int8_t/>
+                <int8_t name='unk_1'/>
                 <int8_t name='food'/>
-                <int8_t/>
-                <int8_t/>
+                <int8_t name='unk_2'/>
+                <int8_t name='unk_3'/>
             </compound>
             <stl-vector name='seeds' type-name='int8_t'
                         index-refers-to='(find-plant-raw $)'/>
@@ -953,9 +953,9 @@
                 <int8_t name='tanned_skins'/>
 
                 <int8_t name='thread_cloth'/>
-                <int8_t/>
-                <int8_t/>
-                <int8_t/>
+                <int8_t name='unk_1'/>
+                <int8_t name='unk_2'/>
+                <int8_t name='unk_3'/>
             </compound>
         </compound>
 
@@ -1029,7 +1029,7 @@
                 <flag-bit name='sparring'/>
             </bitfield>
 
-            <static-array type-name='int32_t' count='9' since='v0.40.01'/>
+            <static-array name='unk_1' type-name='int32_t' count='9' since='v0.40.01'/>
             <stl-vector name='mission_reports' pointer-type='mission_report'/>
             <stl-vector name='spoils_reports' pointer-type='spoils_report' since='v0.44.06'/>
             <stl-vector name='interrogation_reports' pointer-type='interrogation_report' since='v0.47.01'/>
@@ -1260,35 +1260,35 @@
                 <enum-item name='Done'/>
             </enum>
             <int32_t name='num_rejects'/>
-            <static-array count='53' type-name='int32_t'/>
-            <static-array count='53' type-name='int32_t'/>
+            <static-array name='unk_1' count='53' type-name='int32_t'/>
+            <static-array name='unk_2' count='53' type-name='int32_t'/>
             <int16_t name='rejection_reason'/>
             <int32_t name='lakes_total'/>
-            <int32_t/>
-            <int16_t/>
+            <int32_t name='unk_3'/>
+            <int16_t name='unk_4'/>
             <int32_t name='lakes_cur'/>
-            <int32_t/>
-            <int32_t/>
+            <int32_t name='unk_5'/>
+            <int32_t name='unk_6'/>
             <static-array name='geo_layers' count='100' pointer-type='world_geo_layer'/>
-            <static-array count='100' type-name='int8_t'/>
-            <static-array count='100' type-name='int16_t'/>
-            <int32_t/>
+            <static-array name='unk_7' count='100' type-name='int8_t'/>
+            <static-array name='unk_8' count='100' type-name='int16_t'/>
+            <int32_t name='unk_9'/>
             <int32_t name='finalized_civ_mats'/>
             <int32_t name='finalized_art'/>
             <int32_t name='finalized_uniforms'/>
             <int32_t name='finalized_sites'/>
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
+            <int32_t name='unk_10'/>
+            <int32_t name='unk_11'/>
+            <int32_t name='unk_12'/>
             <stl-vector name='entities' pointer-type='historical_entity'/>
             <stl-vector name='sites' pointer-type='world_site'/>
             <int32_t name='cursor_x'/>
             <int32_t name='cursor_y'/>
-            <stl-vector type-name='pointer'/>
-            <stl-vector type-name='pointer'/>
+            <stl-vector name='unk_13' type-name='pointer'/>
+            <stl-vector name='unk_14' type-name='pointer'/>
             <int32_t name='rivers_total'/>
             <int32_t name='rivers_cur'/>
-            <int8_t/>
+            <int8_t name='unk_15'/>
             <stl-string name='last_param_set'/>
             <stl-string name='last_seed'/>
             <stl-string name='last_name_seed'/>
@@ -1304,13 +1304,13 @@
             <bool name='finished_prehistory'/>
             <stl-vector name='sites2' pointer-type='world_site'/>
             <stl-vector name='sites3' pointer-type='world_site'/>
-            <int32_t/>
-            <int8_t/>
-            <int8_t/>
-            <int8_t/>
-            <int8_t/>
+            <int32_t name='unk_16'/>
+            <int8_t name='unk_17'/>
+            <int8_t name='unk_18'/>
+            <int8_t name='unk_19'/>
+            <int8_t name='unk_20'/>
             <stl-vector name='entity_raws' pointer-type='entity_raw'/>
-            <stl-vector type-name='int16_t'/>
+            <stl-vector name='unk_21' type-name='int16_t'/>
             <int32_t name='civ_count'/>  --  Only valid during civ placement phase
             <int32_t name='civs_left_to_place'/>  --  Ditto
             <static-array name='regions1' count='10'>
@@ -1322,22 +1322,22 @@
             <static-array name='regions3' count='10'>
                 <stl-vector pointer-type='world_region'/>
             </static-array>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <stl-vector type-name='int32_t'/>
-            <int32_t/>
-            <int32_t/>
+            <stl-vector name='unk_22' type-name='int32_t'/>
+            <stl-vector name='unk_23' type-name='int32_t'/>
+            <stl-vector name='unk_24' type-name='int32_t'/>
+            <stl-vector name='unk_25' type-name='int32_t'/>
+            <stl-vector name='unk_26' type-name='int32_t'/>
+            <stl-vector name='unk_27' type-name='int32_t'/>
+            <int32_t name='unk_28'/>
+            <int32_t name='unk_29'/>
             <stl-vector name='unk_10d298' type-name='int16_t' since='v0.40.01'/>
             <stl-vector name='unk_10d2a4' type-name='int16_t' since='v0.40.01'/>
             <stl-vector name='libraries' pointer-type='abstract_building' since='v0.42.01'/>
-            <int32_t since='v0.42.01'/>
+            <int32_t name='unk_30' since='v0.42.01'/>
             <stl-vector name='temples' pointer-type='abstract_building' since='v0.44.01'/>
             <stl-vector name='some_artifacts' pointer-type='artifact_record' since='v0.44.01'/>
-            <stl-vector since='v0.47.01'/>
-            <stl-vector type-name='int32_t' since='v0.47.01'/>
+            <stl-vector name='unk_31' since='v0.47.01'/>
+            <stl-vector name='unk_32' type-name='int32_t' since='v0.47.01'/>
         </compound>
 
         <compound name='orphaned_flow_pool' type-name='flow_reuse_pool'/>
@@ -1503,7 +1503,7 @@
             <int16_t name='next_walkable_id'/>
 
             <int16_t name='plant_update_step'/>
-            <bool/>
+            <bool name='unk_1'/>
         </compound>
 
         <int32_t name='save_version'/>
@@ -1595,21 +1595,21 @@
             <stl-vector type-name='int16_t' name='feature_y'/>
             <stl-vector type-name='int16_t' name='feature_local_idx' comment='same as map_block.local_feature'/>
             <stl-vector type-name='int32_t' name='feature_global_idx' ref-target='world_underground_region'/>
-            <stl-vector pointer-type='feature_init' comment='from unk_9C'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.region.x'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.region.y'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.embark.x'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.embark.y'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.local_feature_idx'/>
-            <stl-vector type-name='int32_t' comment='unk_9C.global_feature_idx'/>
-            <stl-vector type-name='int32_t' comment='unk_9C.unk10'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.unk14'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.local.x'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.local.y'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.z_min'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.z_min; yes, seemingly duplicate'/>
-            <stl-vector type-name='int16_t' comment='unk_9C.z_max'/>
-            <stl-bit-vector since='v0.40.11'/>
+            <stl-vector pointer-type='feature_init' name='unk_1' comment='from unk_9C'/>
+            <stl-vector type-name='int16_t' name='unk_2' comment='unk_9C.region.x'/>
+            <stl-vector type-name='int16_t' name='unk_3' comment='unk_9C.region.y'/>
+            <stl-vector type-name='int16_t' name='unk_4' comment='unk_9C.embark.x'/>
+            <stl-vector type-name='int16_t' name='unk_5' comment='unk_9C.embark.y'/>
+            <stl-vector type-name='int16_t' name='unk_6' comment='unk_9C.local_feature_idx'/>
+            <stl-vector type-name='int32_t' name='unk_7' comment='unk_9C.global_feature_idx'/>
+            <stl-vector type-name='int32_t' name='unk_8' comment='unk_9C.unk10'/>
+            <stl-vector type-name='int16_t' name='unk_9' comment='unk_9C.unk14'/>
+            <stl-vector type-name='int16_t' name='unk_10' comment='unk_9C.local.x'/>
+            <stl-vector type-name='int16_t' name='unk_11' comment='unk_9C.local.y'/>
+            <stl-vector type-name='int16_t' name='unk_12' comment='unk_9C.z_min'/>
+            <stl-vector type-name='int16_t' name='unk_13' comment='unk_9C.z_min; yes, seemingly duplicate'/>
+            <stl-vector type-name='int16_t' name='unk_14' comment='unk_9C.z_max'/>
+            <stl-bit-vector name='unk_15' since='v0.40.11'/>
         </compound>
 
         <bool name='allow_announcements' comment='announcements will not be processed at all if false'/>
@@ -1633,7 +1633,7 @@
                         <int16_t name='mattype' ref-target='material' aux-value='$$.matindex'/>
                         <int32_t name='matindex'/>
 
-                        <bool/>
+                        <bool name='unk_1'/>
                     </pointer>
                 </stl-vector>
             </static-array>
@@ -1691,64 +1691,64 @@
         <int8_t name='unk_26b5b9'/>
 
         <compound name='unk_26c678' since='v0.47.01'>
-            <stl-vector/>
-            <stl-vector/>
+            <stl-vector name='unk_1'/>
+            <stl-vector name='unk_2'/>
 
-            <int32_t/>
+            <int32_t name='unk_3'/>
             <compound name='unk_38' type-name='world_unk26c678_unk38'/>
 
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector/>
-            <stl-vector/>
+            <stl-vector name='unk_4'/>
+            <stl-vector name='unk_5'/>
+            <stl-vector name='unk_6'/>
+            <stl-vector name='unk_7'/>
+            <stl-vector name='unk_8'/>
+            <stl-vector name='unk_9'/>
+            <stl-vector name='unk_10'/>
+            <stl-vector name='unk_11'/>
         </compound>
 
         <compound name='unk_19325c'>
-            <stl-vector>
+            <stl-vector name='unk_1'>
                 <pointer>
-                    <pointer/>
-                    <int32_t/>
-                    <int16_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
+                    <pointer name='unk_1'/>
+                    <int32_t name='unk_2'/>
+                    <int16_t name='unk_3'/>
+                    <int32_t name='unk_4'/>
+                    <int32_t name='unk_5'/>
+                    <int32_t name='unk_6'/>
                 </pointer>
             </stl-vector>
-            <stl-vector>
+            <stl-vector name='unk_2'>
                 <pointer>
-                    <pointer/>
-                    <int32_t/>
-                    <int32_t/>
+                    <pointer name='unk_1'/>
+                    <int32_t name='unk_2'/>
+                    <int32_t name='unk_3'/>
                 </pointer>
             </stl-vector>
-            <stl-vector>
+            <stl-vector name='unk_3'>
                 <pointer>
-                    <int16_t/>
-                    <int32_t/>
-                    <int32_t/>
-                    <int32_t/>
+                    <int16_t name='unk_1'/>
+                    <int32_t name='unk_2'/>
+                    <int32_t name='unk_3'/>
+                    <int32_t name='unk_4'/>
                 </pointer>
             </stl-vector>
 
-            <int32_t/>
-            <int32_t/>
-            <int32_t/>
+            <int32_t name='unk_4'/>
+            <int32_t name='unk_5'/>
+            <int32_t name='unk_6'/>
         </compound>
 
         <int32_t name='unk_26b618' since='v0.40.01'/>
     </struct-type>
 
     <struct-type type-name='world_unk26c678_unk38'>
-        <static-array count='107'>
+        <static-array name='unk_1' count='107'>
             <stl-vector/> contains 16-byte records on Win64
         </static-array>
-        <stl-vector type-name='int32_t'/>
-        <stl-vector type-name='int16_t'/>
-        <stl-vector type-name='int16_t'/>
+        <stl-vector name='unk_2' type-name='int32_t'/>
+        <stl-vector name='unk_3' type-name='int16_t'/>
+        <stl-vector name='unk_4' type-name='int16_t'/>
     </struct-type>
 
     <enum-type type-name='world_cavein_flags'>


### PR DESCRIPTION
DFHack/dfhack#2219

Because otherwise people will use them in scripts, which is bad because removing/renaming one anon field renames ALL OTHER anon fields in the same structure.

Next step: update codegen to forbid unnamed fields so this never has to be done ever again.