### PR TITLE
Fixed the globbing in codegen.pl to support paths with spaces.

### DIFF
--- a/codegen.pl
+++ b/codegen.pl
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use File::Glob 'bsd_glob';
 
 BEGIN {
     our $script_root = '.';
@@ -37,7 +38,7 @@ my @transforms =
     ('lower-1.xslt', 'lower-2.xslt');
 my @documents;
 
-for my $fn (sort { $a cmp $b } glob "$input_dir/df.*.xml") {
+for my $fn (sort { $a cmp $b } bsd_glob "$input_dir/df.*.xml") {
     local $filename = $fn;
     my $doc = $parser->parse_file($filename);
     $doc = $_->transform($doc) for @transforms;
@@ -154,10 +155,10 @@ mkdir $output_dir;
 {
     my %files;
     # Get a list of all the existing files
-    for my $name (glob "$output_dir/*.h") {
+    for my $name (bsd_glob "$output_dir/*.h") {
         $files{$name} = 1;
     }
-    for my $name (glob "$output_dir/static*.inc") {
+    for my $name (bsd_glob "$output_dir/static*.inc") {
         $files{$name} = 1;
     }
     $files{"$output_dir/codegen.out.xml"} = 1;


### PR DESCRIPTION
As discussed on the DFHack Discord, this should fix some issues in regards to building DFHack when the path to it has spaces, as `glob` interprets the spaces as separating different patterns to glob. One could fix this by simply wrapping the string in more quotes, but I believe a more robust approach would be to use `bsd_glob` instead, which does not use spaces as separators (and the intent of the code, as far as I can tell, is to only glob with one pattern anyway).