### PR TITLE
Update more globals from g_src

### DIFF
--- a/df.globals.xml
+++ b/df.globals.xml
@@ -156,7 +156,7 @@
 
     <global-object name='init' type-name='init'/>
 
-    <global-object name='texture' type-name='texture_handler'/>
+    <global-object name='texture' type-name='texture_handlerst'/>
 
     <global-object name='timed_events'>
         <stl-vector pointer-type='timed_event'/>

--- a/df.graphics.xml
+++ b/df.graphics.xml
@@ -5041,12 +5041,13 @@
 
         <compound name='textures'>
             <stl-vector type-name='pointer' name='raws'/>
+            <int32_t name='init_texture_size'/>
             <bool name='uploaded'/>
             <uint32_t name='gl_catalog'/>
             <pointer name='gl_texpos'/>
         </compound>
 
-        <padding size='16'/> GLsync rendering barrier
+        <pointer name='sync' comment='rendering barrier'/>
 
         <compound name='simticks'>
             <pointer name='sem'/>
@@ -5077,6 +5078,40 @@
         <enum-item name='justify_cont'/>
         <enum-item name='not_truetype'/>
     </enum-type>
+
+    -- texture_handler.h
+    <struct-type type-name='tile_pagest' key-field='token'>
+        <stl-string name='token'/>
+        <stl-string name='graphics_dir'/>
+        <stl-string name='filename'/>
+
+        <int16_t name='tile_dim_x'/>
+        <int16_t name='tile_dim_y'/>
+        <int16_t name='page_dim_x'/>
+        <int16_t name='page_dim_y'/>
+
+        <stl-vector name='texpos' type-name='long'/>
+        <stl-vector name='datapos' type-name='long'/>
+        <stl-vector name='texpos_gs' type-name='long'/>
+        <stl-vector name='datapos_gs' type-name='long'/>
+
+        <bool name='loaded'/>
+    </struct-type>
+
+    <struct-type type-name='palette_pagest' key-field='token'>
+        <stl-string name='token'/>
+        <stl-string name='graphics_dir'/>
+        <stl-string name='filename'/>
+
+        <int32_t name='default_row'/>
+        <stl-vector name='color_token' pointer-type='stl-string'/>
+        <stl-vector name='color_row' type-name='int32_t'/>
+    </struct-type>
+
+    <struct-type type-name='texture_handlerst'>
+        <stl-vector name='page' pointer-type='tile_pagest'/>
+        <stl-vector name='palette' pointer-type='palette_pagest'/>
+    </struct-type>
 </data-definition>
 
 <!--

--- a/df.init.xml
+++ b/df.init.xml
@@ -17,6 +17,7 @@
         <enum-item name='SHADER'/>
         <enum-item name='NOT_RESIZABLE'/>
         <enum-item name='ARB_SYNC'/>
+        <enum-item name='INTERFACE_SCALING_TO_DESIRED_HEIGHT_WIDTH'/>
     </enum-type>
 
     <struct-type type-name='init_display'>
@@ -33,22 +34,24 @@
 
         <int32_t name='desired_fullscreen_width'/>
         <int32_t name='desired_fullscreen_height'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='actual_fullscreen_width'/>
+        <int32_t name='actual_fullscreen_height'/>
         <int32_t name='desired_windowed_width'/>
         <int32_t name='desired_windowed_height'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='actual_windowed_width'/>
+        <int32_t name='actual_windowed_height'/>
 
-        <int32_t name='maximum_interface_pixel_width'/>
-        <int32_t name='interface_scaling_desired_grid_width'/>
-        <int32_t name='interface_scaling_desired_grid_height'/>
+        <int32_t name='max_interface_percentage'/>
+        <int32_t name='interface_scaling_desired_width'/>
+        <int32_t name='interface_scaling_desired_height'/>
         <int32_t name='interface_scaling_percentage'/>
+
+        <int8_t name='partial_print_count'/>
     </struct-type>
 
     <enum-type type-name='init_media_flags'>
         <enum-item name='SOUND_OFF'/>
-        <enum-item name='INTRO_OFF'/>
+        <enum-item name='UNUSED_01_02'/>
         <enum-item name='COMPRESS_SAVES'/>
     </enum-type>
 
@@ -58,6 +61,7 @@
         <int32_t name='volume_music'/>
         <int32_t name='volume_ambience'/>
         <int32_t name='volume_sfx'/>
+        <int32_t name='time_between_songs'/>
     </struct-type>
 
     <enum-type type-name='init_input_flags'>
@@ -83,12 +87,12 @@
         <static-array name='basic_font_datapos' type-name='long' count='256'/>
         <static-array name='small_font_datapos' type-name='long' count='256'/>
         <static-array name='large_font_datapos' type-name='long' count='256'/>
-        <static-array type-name='long' count='256'/>
-        <static-array type-name='long' count='256'/>
-        <static-array type-name='long' count='256'/>
-        <static-array type-name='long' count='256'/>
-        <static-array type-name='long' count='256'/>
-        <static-array type-name='long' count='256'/>
+        <static-array name='basic_font_texpos_top' type-name='long' count='256'/>
+        <static-array name='small_font_texpos_top' type-name='long' count='256'/>
+        <static-array name='large_font_texpos_top' type-name='long' count='256'/>
+        <static-array name='basic_font_texpos_bot' type-name='long' count='256'/>
+        <static-array name='small_font_texpos_bot' type-name='long' count='256'/>
+        <static-array name='large_font_texpos_bot' type-name='long' count='256'/>
         <s-float name='basic_font_adjx'/>
         <s-float name='basic_font_adjy'/>
         <s-float name='small_font_adjx'/>
@@ -104,7 +108,6 @@
     </struct-type>
 
     <enum-type type-name='init_window_flags'>
-        <enum-item name='TOPMOST'/>
         <enum-item name='VSYNC_ON'/>
         <enum-item name='VSYNC_OFF'/>
         <enum-item name='TEXTURE_LINEAR'/>
@@ -112,36 +115,6 @@
 
     <struct-type type-name='init_window'>
         <df-flagarray name='flag' index-enum='init_window_flags'/>
-        <long name='fps_cap'/>
-        <long name='g_fps_cap'/>
-        <static-array name='loadbar_texpos' type-name='long' count='6'/>
-
-        <static-array name='intro_button_texpos' count='3'><static-array type-name='long' count='39'/></static-array>
-        <static-array name='intro_button_texpos_flipped' count='39'><static-array type-name='long' count='3'/></static-array>
-
-        <static-array name='border_texpos' count='3'><static-array type-name='long' count='7'/></static-array>
-        <static-array name='border_texpos_frame' count='3'><static-array type-name='long' count='3'/></static-array>
-        <static-array name='border_texpos_edge_t' type-name='long' count='4'/>
-        <long name='border_texpos_cross'/>
-        <static-array name='border_texpos_internal_t' type-name='long' count='4'/>
-        <long name='border_texpos_v'/>
-        <long name='border_texpos_h'/>
-
-        <static-array name='scrollbar_texpos' count='4'><static-array type-name='long' count='12'/></static-array>
-        <static-array name='scrollbar_texpos_1' count='2'><static-array type-name='long' count='3'/></static-array>
-        <static-array name='scrollbar_texpos_2' count='2'><static-array type-name='long' count='4'/></static-array>
-        <static-array name='scrollbar_texpos_3' count='2'><static-array type-name='long' count='2'/></static-array>
-        <static-array name='scrollbar_texpos_4' count='2'><static-array type-name='long' count='2'/></static-array>
-        <static-array name='scrollbar_texpos_5' count='4'><static-array type-name='long' count='4'/></static-array>
-        <static-array name='scrollbar_texpos_6' count='4'><static-array type-name='long' count='2'/></static-array>
-
-        <static-array name='filter_texpos' count='3'><static-array type-name='long' count='10'/></static-array>
-        <static-array name='filter_texpos_flipped' count='10'><static-array type-name='long' count='3'/></static-array>
-
-        <static-array name='tabs_texpos' count='3'><static-array type-name='long' count='10'/></static-array>
-        <static-array name='tabs_texpos_flipped' count='10'><static-array type-name='long' count='2'/></static-array>
-
-        <static-array name='other' type-name='long' count='239'/>
     </struct-type>
 
     <struct-type type-name='init'>
@@ -150,30 +123,135 @@
         <compound name='input' type-name='init_input'/>
         <compound name='font' type-name='init_font'/>
         <compound name='window' type-name='init_window'/>
-    </struct-type>
 
-    -- texture_handler.h
+        <int32_t name='fps_cap'/>
+        <int32_t name='gfps_cap'/>
 
-    <struct-type type-name='tile_page' key-field='token'>
-        <stl-string name='token'/>
-        <stl-string name='filename'/>
+        <static-array name='load_bar_texpos' type-name='long' count='6'/>
 
-        <int16_t name='tile_dim_x'/>
-        <int16_t name='tile_dim_y'/>
-        <int16_t name='page_dim_x'/>
-        <int16_t name='page_dim_y'/>
+        <static-array name='intro_button_texpos' type-name='long' count='117'/>
+        <static-array name='texpos_neutral_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_confirm_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_cancel_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_selected_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_unselected_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_open_list_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_increase_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_decrease_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_nullify_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_left_arrow_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_right_arrow_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_up_arrow_button' type-name='int32_t' count='9'/>
+        <static-array name='texpos_down_arrow_button' type-name='int32_t' count='9'/>
 
-        <stl-vector name='texpos' type-name='int32_t'/>
-        <stl-vector name='datapos' type-name='int32_t'/>
-        <stl-vector name='texpos_gs' type-name='int32_t'/>
-        <stl-vector name='datapos_gs' type-name='int32_t'/>
+        <static-array name='border_texpos' type-name='long' count='21'/>
+        <int32_t name='texpos_border_nw'/>
+        <int32_t name='texpos_border_n'/>
+        <int32_t name='texpos_border_ne'/>
+        <int32_t name='texpos_border_w'/>
+        <int32_t name='texpos_border_interior'/>
+        <int32_t name='texpos_border_e'/>
+        <int32_t name='texpos_border_sw'/>
+        <int32_t name='texpos_border_s'/>
+        <int32_t name='texpos_border_se'/>
+        <int32_t name='texpos_border_join_n'/>
+        <int32_t name='texpos_border_join_s'/>
+        <int32_t name='texpos_border_join_w'/>
+        <int32_t name='texpos_border_join_e'/>
+        <int32_t name='texpos_border_inside_nswe'/>
+        <int32_t name='texpos_border_inside_nsw'/>
+        <int32_t name='texpos_border_inside_nse'/>
+        <int32_t name='texpos_border_inside_nwe'/>
+        <int32_t name='texpos_border_inside_swe'/>
+        <int32_t name='texpos_border_inside_ns'/>
+        <int32_t name='texpos_border_inside_we'/>
 
-        <bool name='loaded'/>
-    </struct-type>
+        <static-array name='scrollbar_texpos' type-name='long' count='48'/>
+        <static-array name='texpos_scrollbar' count='2'><static-array type-name='int32_t' count='3'/></static-array>
+        <static-array name='texpos_scrollbar_up_hover' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_up_pressed' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_down_hover' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_down_pressed' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_small_scroller' count='2'><static-array type-name='int32_t' count='2'/></static-array>
+        <static-array name='texpos_scrollbar_small_scroller_hover' count='2'><static-array type-name='int32_t' count='2'/></static-array>
+        <static-array name='texpos_scrollbar_top_scroller' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_top_scroller_hover' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_bottom_scroller' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_bottom_scroller_hover' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_blank_scroller' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_blank_scroller_hover' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_center_scroller' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_center_scroller_hover' type-name='int32_t' count='2'/>
+        <static-array name='texpos_scrollbar_offcenter_scroller' count='2'><static-array type-name='int32_t' count='2'/></static-array>
+        <static-array name='texpos_scrollbar_offcenter_scroller_hover' count='2'><static-array type-name='int32_t' count='2'/></static-array>
 
-    <struct-type type-name='texture_handler'>
-        <stl-vector name='page' pointer-type='tile_page'/>
-        <stl-vector name='texpos' type-name='int32_t'/>
+        <static-array name='filter_texpos' type-name='long' count='30'/>
+        <static-array name='texpos_button_filter' count='6'><static-array type-name='int32_t' count='3'/></static-array>
+        <static-array name='texpos_button_filter_name' count='4'><static-array type-name='int32_t' count='3'/></static-array>
+
+        <static-array name='tabs_texpos' type-name='long' count='30'/>
+        <static-array name='texpos_tab_unselected' count='5'><static-array type-name='int32_t' count='2'/></static-array>
+        <static-array name='texpos_tab_selected' count='5'><static-array type-name='int32_t' count='2'/></static-array>
+
+        <static-array name='classic_load_bar_texpos' type-name='long' count='6'/>
+        <static-array name='classic_texpos_neutral_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_confirm_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_cancel_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_selected_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_unselected_intro_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_open_list_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_increase_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_decrease_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_nullify_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_left_arrow_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_right_arrow_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_up_arrow_button' type-name='int32_t' count='9'/>
+        <static-array name='classic_texpos_down_arrow_button' type-name='int32_t' count='9'/>
+
+        <int32_t name='classic_texpos_border_nw'/>
+        <int32_t name='classic_texpos_border_n'/>
+        <int32_t name='classic_texpos_border_ne'/>
+        <int32_t name='classic_texpos_border_w'/>
+        <int32_t name='classic_texpos_border_interior'/>
+        <int32_t name='classic_texpos_border_e'/>
+        <int32_t name='classic_texpos_border_sw'/>
+        <int32_t name='classic_texpos_border_s'/>
+        <int32_t name='classic_texpos_border_se'/>
+        <int32_t name='classic_texpos_border_join_n'/>
+        <int32_t name='classic_texpos_border_join_s'/>
+        <int32_t name='classic_texpos_border_join_w'/>
+        <int32_t name='classic_texpos_border_join_e'/>
+        <int32_t name='classic_texpos_border_inside_nswe'/>
+        <int32_t name='classic_texpos_border_inside_nsw'/>
+        <int32_t name='classic_texpos_border_inside_nse'/>
+        <int32_t name='classic_texpos_border_inside_nwe'/>
+        <int32_t name='classic_texpos_border_inside_swe'/>
+        <int32_t name='classic_texpos_border_inside_ns'/>
+        <int32_t name='classic_texpos_border_inside_we'/>
+
+        <static-array name='classic_texpos_scrollbar' count='2'><static-array type-name='int32_t' count='3'/></static-array>
+        <static-array name='classic_texpos_scrollbar_up_hover' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_up_pressed' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_down_hover' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_down_pressed' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_small_scroller' count='2'><static-array type-name='int32_t' count='2'/></static-array>
+        <static-array name='classic_texpos_scrollbar_small_scroller_hover' count='2'><static-array type-name='int32_t' count='2'/></static-array>
+        <static-array name='classic_texpos_scrollbar_top_scroller' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_top_scroller_hover' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_bottom_scroller' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_bottom_scroller_hover' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_blank_scroller' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_blank_scroller_hover' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_center_scroller' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_center_scroller_hover' type-name='int32_t' count='2'/>
+        <static-array name='classic_texpos_scrollbar_offcenter_scroller' count='2'><static-array type-name='int32_t' count='2'/></static-array>
+        <static-array name='classic_texpos_scrollbar_offcenter_scroller_hover' count='2'><static-array type-name='int32_t' count='2'/></static-array>
+
+        <static-array name='classic_texpos_button_filter' count='6'><static-array type-name='int32_t' count='3'/></static-array>
+        <static-array name='classic_texpos_button_filter_name' count='4'><static-array type-name='int32_t' count='3'/></static-array>
+
+        <static-array name='classic_texpos_tab_unselected' count='5'><static-array type-name='int32_t' count='2'/></static-array>
+        <static-array name='classic_texpos_tab_selected' count='5'><static-array type-name='int32_t' count='2'/></static-array>
     </struct-type>
 </data-definition>
 

--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -43,8 +43,8 @@
             </vmethod>
             <vmethod name='logic'/>
             <vmethod name='render'/>
-            <vmethod/>
-            <vmethod/>
+            <vmethod name='resize'><int32_t name='w'/><int32_t name='h'/></vmethod>
+            <vmethod name='set_port_flags'/>
             <vmethod is-destructor='true'/>
         </virtual-methods>
 
@@ -62,6 +62,7 @@
         <int32_t name='shutdown_interface_for_ms'/>
     </struct-type>
 
+<!--
     <class-type type-name='layer_object' original-name='layer_objectst'>
         <bool name='enabled'/>
         <bool name='active'/>
@@ -136,34 +137,20 @@
         <int8_t name='handle_mouselbtndown'/>
         <int8_t name='handle_mouserbtndown'/>
     </class-type>
+-->
 
     <struct-type type-name='widget_menu'>
-        <padding name='pad_1' size='24' comment='lines, std::map'/>
+        <padding name='lines' size='24' comment='std::map, int to string+T'/>
         <int32_t name='selection'/>
         <int32_t name='last_displayheight'/>
         <bool name='bleached'/>
-        <padding name='pad_2' size='24' comment='colors, std::map'/>
+        <padding name='colors' size='24' comment='std::map, int to int+int'/>
     </struct-type>
 
     <struct-type type-name='widget_textbox'>
         <stl-string name='text'/>
         <bool name='keep'/>
     </struct-type>
-
-    <class-type type-name='KeybindingScreen' inherits-from='viewscreen'>
-        <enum base-type='int32_t' name='mode'>
-            <enum-item name='Main'/>
-            <enum-item name='KeyL'/>
-            <enum-item name='KeyR'/>
-            <enum-item name='Macro'/>
-            <enum-item name='Register'/>
-        </enum>
-        <compound name='main' type-name='widget_menu'/>
-        <compound name='keyL' type-name='widget_menu'/>
-        <compound name='keyR' type-name='widget_menu'/>
-        <compound name='macro' type-name='widget_menu'/>
-        <compound name='keyRegister' type-name='widget_menu'/>
-    </class-type>
 
     <class-type type-name='MacroScreenLoad' inherits-from='viewscreen'>
         <compound name='menu' type-name='widget_menu'/>


### PR DESCRIPTION
* Fix enabler.textures and enabler.sync
* Update texture_handler+tile_page, rename to restore "st" suffix, and move into df.graphics.xml
* Sync init and sub-structures
* Identify new viewscreen vmethods
* Removed layer_object and KeybindingScreen, neither of which exist anymore

NOTE: some of these changes will require additional DFHack updates