### PR TITLE
rename a handful of globals to match toady names

### DIFF
--- a/df.advmode.xml
+++ b/df.advmode.xml
@@ -382,7 +382,7 @@
         <int32_t name='unk_4' init-value='-1'/>
     </struct-type>
 
-    <struct-type type-name='ui_advmode'>
+    <struct-type type-name='adventurest'>
         <enum base-type='int16_t' name='menu' type-name='ui_advmode_menu'/>
 
         <int8_t name='site_level_zoom' comment='when set, the travel map is zoomed in to show site details'/>

--- a/df.globals.xml
+++ b/df.globals.xml
@@ -163,9 +163,9 @@
     </global-object>
 
     <!-- To find: create squad, enter the 's' menu, trace pointers to squad -->
-    <global-object name='ui' type-name='ui'/>
+    <global-object name='plotinfo' type-name='plotinfost'/>
 
-    <global-object name='ui_advmode' type-name='ui_advmode'/>
+    <global-object name='adventure' type-name='adventurest'/>
 
     <!-- To find: start creating a building, trace the build material item pointers -->
     <global-object name='ui_build_selector' type-name='ui_build_selector'/>
@@ -188,7 +188,7 @@
     <global-object name='ui_look_list' type-name='ui_look_list'/>
 
     <!-- To find: select a unit in 'v'iew, open inventory page, trace unit.inventory.* pointers -->
-    <global-object name='ui_sidebar_menus' type-name='ui_sidebar_menus'/>
+    <global-object name='game' type-name='gamest'/>
 
     <!-- To find: search for unit nickname, backtrace pointers to find the main unit list. -->
     <global-object name='world' type-name='world'/>

--- a/df.globals.xml
+++ b/df.globals.xml
@@ -168,7 +168,7 @@
     <global-object name='adventure' type-name='adventurest'/>
 
     <!-- To find: start creating a building, trace the build material item pointers -->
-    <global-object name='ui_build_selector' type-name='ui_build_selector'/>
+    <global-object name='buildreq' type-name='buildreq'/>
 
     <global-object name='ui_building_assign_type'>
         <stl-vector type-name='int8_t'/>

--- a/df.ui-menus.xml
+++ b/df.ui-menus.xml
@@ -57,7 +57,7 @@
         <stl-vector name="candidates">
             <int32_t>
                 <code-helper name='refers-to'>
-                    (let* ((selector $global.ui_build_selector)
+                    (let* ((selector $global.buildreq)
                            (req $selector.requirements[$selector.req_index]))
                       $req.candidates[$])
                 </code-helper>
@@ -71,14 +71,14 @@
         <pointer name='candidate' type-name='item'/>
         <int32_t name='candidate_id'>
             <code-helper name='refers-to'>
-                (let* ((selector $global.ui_build_selector)
+                (let* ((selector $global.buildreq)
                        (req $selector.requirements[$selector.req_index]))
                   $req.candidates[$])
             </code-helper>
         </int32_t>
     </class-type>
 
-    <class-type type-name='ui_build_selector' original-name='buildreqst'>
+    <class-type type-name='buildreq' original-name='buildreqst'>
         <stl-vector name='requirements' pointer-type='ui_build_item_req'/>
 
         <stl-vector name='choices' pointer-type='build_req_choicest'/>
@@ -236,7 +236,7 @@
         <int32_t name="existing_count"/>
     </class-type>
 
-    <struct-type type-name='ui_sidebar_menus'>
+    <struct-type type-name='gamest'>
         dtor 0x8535ee0
         <compound name='designation' since='v0.40.20'>
             <bool name='marker_only'/>

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -148,7 +148,7 @@
         <enum-item name="Brew"/>
     </enum-type>
 
-    <struct-type type-name='ui'>
+    <struct-type type-name='plotinfost'>
         ctor 86e33c0 x
         dtor 8534190
 

--- a/symbols.xml
+++ b/symbols.xml
@@ -30,15 +30,15 @@
         <global-address name='init'/>
         <global-address name='texture'/>
         <global-address name='timed_events'/>
-        <global-address name='ui'/>
-        <global-address name='ui_advmode'/>
-        <global-address name='ui_build_selector'/>
+        <global-address name='plotinfo'/>
+        <global-address name='adventure'/>
+        <global-address name='buildreq'/>
         <global-address name='ui_building_assign_type'/>
         <global-address name='ui_building_assign_is_marked'/>
         <global-address name='ui_building_assign_units'/>
         <global-address name='ui_building_assign_items'/>
         <global-address name='ui_look_list'/>
-        <global-address name='ui_sidebar_menus'/>
+        <global-address name='game'/>
         <global-address name='world'/>
 
         generated cglobals
@@ -120,7 +120,7 @@
     <symbol-table name='v0.50.03-steam SDL win64' os-type='windows'>
         <binary-timestamp value='0x639777b1'/>
         <global-address name='created_item_subtype' value='0x142063b50'/>
-        <global-address name='ui_advmode' value='0x14205a0a0'/>
+        <global-address name='adventure' value='0x14205a0a0'/>
         <global-address name='ui_building_assign_items' value='0x14205a088'/>
         <global-address name='world' value='0x141deb270'/>
         <global-address name='created_item_mattype' value='0x141deb258'/>
@@ -132,11 +132,11 @@
         <global-address name='timed_events' value='0x141de7578'/>
         <global-address name='ui_building_assign_units' value='0x141de7560'/>
         <global-address name='map_renderer' value='0x141db53b0'/>
-        <global-address name='ui_sidebar_menus' value='0x141daa7d0'/>
+        <global-address name='game' value='0x141daa7d0'/>
         <global-address name='created_item_count' value='0x141daa7b8'/>
         <global-address name='flows' value='0x141daa7a0'/>
         <global-address name='texture' value='0x141daa770'/>
-        <global-address name='ui' value='0x141da1670'/>
+        <global-address name='plotinfo' value='0x141da1670'/>
         <global-address name='d_init' value='0x141da0f40'/>
         <global-address name='enabler' value='0x141da0cb0'/>
         <global-address name='created_item_type' value='0x141da0c98'/>
@@ -248,7 +248,7 @@
         <global-address name='debug_fastmining' value='0x1412ebf51'/>
         <global-address name='gps' value='0x1412ab950'/>
         <global-address name='gview' value='0x1412ab910'/>
-        <global-address name='ui_build_selector' value='0x1412aa8a0'/>
+        <global-address name='buildreq' value='0x1412aa8a0'/>
         <global-address name='standingorder_forbid_rearming_traps' value='0x1412aa84c'/>
         <global-address name='standing_orders_auto_collect_webs' value='0x1412aa84b'/>
         <global-address name='standing_orders_auto_fishery' value='0x1412aa84a'/>
@@ -1084,7 +1084,7 @@
     <symbol-table name='v0.50.02-steam SDL win64' os-type='windows'>
         <binary-timestamp value='0x6391b240'/>
         <global-address name='created_item_subtype' value='0x14205b480'/>
-        <global-address name='ui_advmode' value='0x1420519d0'/>
+        <global-address name='adventure' value='0x1420519d0'/>
         <global-address name='ui_building_assign_items' value='0x1420519b8'/>
         <global-address name='world' value='0x141de2ba0'/>
         <global-address name='created_item_mattype' value='0x141de2b88'/>
@@ -1096,11 +1096,11 @@
         <global-address name='timed_events' value='0x141ddeea8'/>
         <global-address name='ui_building_assign_units' value='0x141ddee90'/>
         <global-address name='map_renderer' value='0x141dacce0'/>
-        <global-address name='ui_sidebar_menus' value='0x141da2100'/>
+        <global-address name='game' value='0x141da2100'/>
         <global-address name='created_item_count' value='0x141da20e8'/>
         <global-address name='flows' value='0x141da20d0'/>
         <global-address name='texture' value='0x141da20a0'/>
-        <global-address name='ui' value='0x141d98fa0'/>
+        <global-address name='plotinfo' value='0x141d98fa0'/>
         <global-address name='d_init' value='0x141d98870'/>
         <global-address name='enabler' value='0x141d985e0'/>
         <global-address name='created_item_type' value='0x141d985c8'/>
@@ -1212,7 +1212,7 @@
         <global-address name='ui_lever_target_type' value='0x1412e3881'/>
         <global-address name='gps' value='0x1412a3950'/>
         <global-address name='gview' value='0x1412a3910'/>
-        <global-address name='ui_build_selector' value='0x1412a28a0'/>
+        <global-address name='buildreq' value='0x1412a28a0'/>
         <global-address name='standingorder_forbid_rearming_traps' value='0x1412a27ee'/>
         <global-address name='standing_orders_auto_collect_webs' value='0x1412a27ed'/>
         <global-address name='standing_orders_auto_fishery' value='0x1412a27ec'/>
@@ -2048,7 +2048,7 @@
         <binary-timestamp value='0x638D2F18'/>
 
         <global-address name='created_item_subtype' value='0x14205b480'/>
-        <global-address name='ui_advmode' value='0x1420519d0'/>
+        <global-address name='adventure' value='0x1420519d0'/>
         <global-address name='ui_building_assign_items' value='0x1420519b8'/>
         <global-address name='world' value='0x141de2ba0'/>
         <global-address name='created_item_mattype' value='0x141de2b88'/>
@@ -2060,11 +2060,11 @@
         <global-address name='timed_events' value='0x141ddeea8'/>
         <global-address name='ui_building_assign_units' value='0x141ddee90'/>
         <global-address name='map_renderer' value='0x141dacce0'/>
-        <global-address name='ui_sidebar_menus' value='0x141da2100'/>
+        <global-address name='game' value='0x141da2100'/>
         <global-address name='created_item_count' value='0x141da20e8'/>
         <global-address name='flows' value='0x141da20d0'/>
         <global-address name='texture' value='0x141da20a0'/>
-        <global-address name='ui' value='0x141d98fa0'/>
+        <global-address name='plotinfo' value='0x141d98fa0'/>
         <global-address name='d_init' value='0x141d98870'/>
         <global-address name='enabler' value='0x141d985e0'/>
         <global-address name='created_item_type' value='0x141d985c8'/>
@@ -2176,7 +2176,7 @@
         <global-address name='ui_lever_target_type' value='0x1412e3881'/>
         <global-address name='gps' value='0x1412a3950'/>
         <global-address name='gview' value='0x1412a3910'/>
-        <global-address name='ui_build_selector' value='0x1412a28a0'/>
+        <global-address name='buildreq' value='0x1412a28a0'/>
         <global-address name='standingorder_forbid_rearming_traps' value='0x1412a27ee'/>
         <global-address name='standing_orders_auto_collect_webs' value='0x1412a27ed'/>
         <global-address name='standing_orders_auto_fishery' value='0x1412a27ec'/>


### PR DESCRIPTION
`ui_advmode` -> `adventure`
`ui` -> `plotinfo`
`ui_sidebar_menus` -> `game`
`ui_build_selector` -> `buildreq`

also associated types

per discussion on discord

a collateral change will need to be made to `dump_df_globals.rb` in df_misc: https://github.com/DFHack/df_misc/pull/25