### PR TITLE
Add stub std::map support to codegen

### DIFF
--- a/StructFields.pm
+++ b/StructFields.pm
@@ -129,6 +129,13 @@ my %custom_container_handlers = (
         header_ref("vector");
         return "std::vector<bool>";
     },
+    'stl-map' => sub {
+        # TODO: implement get_container_key_type?
+        my $key  = 'void*';
+        my $item = get_container_item_type($_, -void => 'void*');
+        header_ref("map");
+        return "std::map<$key, $item>";
+    },
     'df-flagarray' => sub {
         my $type = decode_type_name_ref($_, -attr_name => 'index-enum', -force_type => 'enum-type') || 'int';
         return "BitArray<$type>";

--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -168,11 +168,11 @@
     </class-type>
 
     <struct-type type-name='widget_menu'>
-        <padding name='pad_1' size='24' comment='lines, std::map'/>
+        <stl-map name='lines'/>
         <int32_t name='selection'/>
         <int32_t name='last_displayheight'/>
         <bool name='bleached'/>
-        <padding name='pad_2' size='24' comment='colors, std::map'/>
+        <stl-map name='colors'/>
     </struct-type>
 
     <struct-type type-name='widget_textbox'>

--- a/lower-1.xslt
+++ b/lower-1.xslt
@@ -333,7 +333,7 @@ Error: field <xsl:value-of select='$enum-key'/> corresponds to an enum value of 
     </xsl:template>
 
     <!-- Misc containers: meta='container' subtype='$tag' -->
-    <xsl:template match='stl-vector|stl-deque|stl-set|stl-bit-vector|df-flagarray|df-static-flagarray|df-array|df-linked-list'>
+    <xsl:template match='stl-vector|stl-deque|stl-set|stl-bit-vector|stl-map|df-flagarray|df-static-flagarray|df-array|df-linked-list'>
         <xsl:param name='level' select='-1'/>
         <ld:field ld:meta='container'>
             <xsl:attribute name='ld:level'><xsl:value-of select='$level'/></xsl:attribute>


### PR DESCRIPTION
Fixes #498
Requires https://github.com/DFHack/dfhack/pull/2532

Deliberately targeting v0.47.05 first since this was tested there (and fixes an alignment issue)