### PR TITLE
Zone settings flags

### DIFF
--- a/df.buildings.xml
+++ b/df.buildings.xml
@@ -667,8 +667,32 @@
         <int32_t/>
         <int32_t/>
         <int32_t name='zone_num'/>
-        <int32_t name='dir_x' comment='dir_x and dir_y appear to be flags variables'/>
-        <int32_t name='dir_y'/>
+        <compound name='zone_settings' is-union='true'>
+            <compound name='whole'>
+                <int32_t name='i1'/>
+                <int32_t name='i2'/>
+            </compound>
+            <bitfield name='gather' base-type='uint32_t'>
+                <flag-bit name='pick_trees'/>
+                <flag-bit name='pick_shrubs'/>
+                <flag-bit name='gather_fallen'/>
+            </bitfield>
+            <compound name='pen'>
+                <int32_t name='unk' init-value='1'/>
+            </compound>
+            <bitfield name='tomb' base-type='uint32_t'>
+                <flag-bit name='no_pets'/>
+                <flag-bit name='no_citizens'/>
+            </bitfield>
+            <compound name='archery'>
+                <int32_t name='dir_x'/>
+                <int32_t name='dir_y'/>
+            </compound>
+            <enum name='pit_pond' base-type='int32_t'>
+                <enum-item name='top_of_pit' value='2' />
+                <enum-item name='top_of_pond' value='3' />
+            </enum>
+        </compound>
         <int32_t/>
         <stl-vector type-name='int32_t'/>
         <stl-vector name='contained_buildings' pointer-type='building' comment='includes eg workshops and beds'/>


### PR DESCRIPTION
I wasn't quite sure what the protocol was here for a uint64_t union, so I opted to stick the raw flags in a struct

This breaks remotefortressreader as it relies on dir_x and dir_y, and I'm not quite sure what the protocol is here for syncing changes with the main repo with this change. The fix is this https://github.com/20k/dfhack-ui/commit/90a4ea8d938ca22184210aca2945338fc8693d0e

I've tested setting all these flags manually, and it all seems to work and sync up with the UI