### PR TITLE
civ_alert_idx is gone, its now the next id for whatever lives in the routines vector

### DIFF
--- a/df.military.xml
+++ b/df.military.xml
@@ -160,7 +160,7 @@
             </pointer>
         </stl-vector>
 
-        <int32_t name="cur_alert_idx" refers-to='$$._parent.schedule[$]' init-value='0'/>
+        <int32_t name="cur_routine_idx" refers-to='$$._parent.schedule[$]' init-value='0'/>
 
         <stl-vector name="rooms">
             <pointer>

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -462,8 +462,8 @@
                 </pointer>
             </stl-vector>
             <int32_t name='next_id'/>
-            <stl-vector/> 0.50.01
-            <int32_t name='civ_alert_idx' refers-to='$$._parent.list[$]'/>
+            <stl-vector name="routines"/> 0.50.01
+            <int32_t name='next_routine_id'/>
         </compound>
 
         <compound name='equipment'>


### PR DESCRIPTION
I discovered that the length of anon_1 exactly matches the new squad routines. civ_alert_idx appears to be dead, and instead is a next id counter for the routines

The void* isn't a T_schedule* or a df::squad_schedule_entry*, which is where my reverse engineering abilities end. Figuring it out would be necessary for the ability to programmatically make squads

I renamed the military squad variable as it now definitely is not an alert, but a routine instead. It does however still point into the same element, but I thought it might be worth changing this in case people are using it to look into the alerts struct