### PR TITLE
realign historical_entity

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,8 @@ that repo.
 # Future
 
 ## Structures
+- corrected misalignment in ``historical_entity``
+- partially identified squad-related structures in ``plotinfo`` and corrected position of ``civ_alert_idx`` (does not affect alignment)
 
 # 50.05-alpha1
 

--- a/df.entities.xml
+++ b/df.entities.xml
@@ -589,8 +589,6 @@
 
         <stl-vector name='uniforms' pointer-type='entity_uniform'/>
         <int32_t name='next_uniform_id'/>
-        <int32_t/>
-        <int32_t/>
 
         <compound name='relations'>
             <stl-vector name='known_sites' type-name='int32_t' ref-target='world_site' comment="only civs and site government. Fresh player site government has empty vector"/>

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -462,7 +462,8 @@
                 </pointer>
             </stl-vector>
             <int32_t name='next_id'/>
-            <stl-vector/> 0.50.01
+            <stl-vector name='unk_20' comment='probably squad routines; elements are 0x28 bytes'/> 0.50.01
+            <int32_t name='unk_38' comment='probably next id for vector in unk_20'/>
             <int32_t name='civ_alert_idx' refers-to='$$._parent.list[$]'/>
         </compound>
 


### PR DESCRIPTION
Fixes DFHack/dfhack#2636
Fixes DFHack/dfhack#2631

also update plotinfo to correct position of civilian alert id

Co-Authored-By: Quietust <1005195+quietust@users.noreply.github.com>