### PR TITLE
various updates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,10 +12,14 @@ that repo.
 ]]]
 
 # Future
+
 ## Structures
 - corrected misalignment in ``unitst`` (affecting ``occupation`` and ``adjective``)
 - identified some anons in ``unitst`` related to textures (thanks, putnam)
 - realigned and fleshed out ``entity_site_link`` (again, thanks, putnam)
+- add "hospital" language name category
+- remove some no-longer-valid reputation types
+- identify a table of daily events scheduled to take place inthe current year
 
 # 50.05-alpha2
 

--- a/df.entity-raws.xml
+++ b/df.entity-raws.xml
@@ -164,6 +164,7 @@
         <enum-item name='FESTIVAL'/>
         <enum-item name='MERCHANT_COMPANY'/>
         <enum-item name='CRAFT_GUILD'/>
+        <enum-item name='HOSPITAL'/>
     </enum-type>
 
     <struct-type type-name='entity_raw' instance-vector='$global.world.raws.entities'>

--- a/df.history.xml
+++ b/df.history.xml
@@ -35,8 +35,6 @@
 
     <enum-type type-name='reputation_type' base-type='int32_t'>
         <enum-item name='Hero'/>
-        <enum-item name='Buddy'/>
-        <enum-item name='Grudge'/>
         <enum-item name='AnimalPartner'/>
         <enum-item name='Brawler'/>
         <enum-item name='Psycho'/>
@@ -3636,7 +3634,7 @@
         <stl-vector name='unk_4' since='v0.47.01'/>
         <stl-vector name='unk_5' since='v0.47.01' pointer-type='historical_figure'/>
         <stl-vector name='unk_6' since='v0.47.01'/>
-        <stl-vector name='unk_7' since='v0.47.01'/>
+        <stl-vector type-name='int32_t' name='unk_7' since='v0.47.01'/>
         <int8_t name='unk_8'/>
         <stl-vector name='active_event_collections' pointer-type='history_event_collection'/>
         <int8_t name='unk_10'/>

--- a/df.language.xml
+++ b/df.language.xml
@@ -354,6 +354,7 @@
         <enum-item name='EntityMerchantCompany2'/>
         <enum-item name='Guildhall'/>
         <enum-item name='NecromancerTower'/>
+        <enum-item name='Hospital'/>
     </enum-type>
 
     <enum-type type-name='language_name_type' base-type='int16_t'>

--- a/df.world.xml
+++ b/df.world.xml
@@ -1447,23 +1447,23 @@
 
         <stl-vector name='entity_populations' pointer-type='entity_population'/>
 
-        <compound name='unk_v40_6' comment="every value matches a nemesis, but unk2/3 have too few values to draw conclusions. Note that nemesis matches may just be a conincidence of falling within the nemesis range">
-            <static-array name='unk1' since='v0.40.01' count='336'>
+        <compound name='daily_events' comment="for each calendar day, a list of major life events (by nemesis id)">
+            <static-array name='deaths' since='v0.40.01' count='336'>
                 <stl-vector type-name='int32_t' ref-target='nemesis_record'/>
             </static-array>
-            <static-array name='unk2' since='v0.40.01' count='336'>
-                <stl-vector type-name='int32_t'/>
-            </static-array>
-            <static-array name='unk3' since='v0.40.01' count='336'>
-                <stl-vector type-name='int32_t'/>
-            </static-array>
-            <static-array name='unk4' since='v0.40.01' count='336'>
+            <static-array name='pregnancies' since='v0.40.01' count='336'>
                 <stl-vector type-name='int32_t' ref-target='nemesis_record'/>
             </static-array>
-            <static-array name='unk5' since='v0.40.01' count='336'>
+            <static-array name='births' since='v0.40.01' count='336'>
                 <stl-vector type-name='int32_t' ref-target='nemesis_record'/>
             </static-array>
-            <static-array name='unk6' since='v0.40.01' count='336'>
+            <static-array name='grown_up' since='v0.40.01' count='336'>
+                <stl-vector type-name='int32_t' ref-target='nemesis_record'/>
+            </static-array>
+            <static-array name='marriage_1' since='v0.40.01' count='336'>
+                <stl-vector type-name='int32_t' ref-target='nemesis_record'/>
+            </static-array>
+            <static-array name='marriage_2' since='v0.40.01' count='336'>
                 <stl-vector type-name='int32_t' ref-target='nemesis_record' comment="same length as corresponding previous vector element. Not true for other pairs"/>
             </static-array>
         </compound>


### PR DESCRIPTION
* add "HOSPITAL" name type
* remove "Buddy" and "Grudge" reputation types (which were deprecated in 47.05 and actually deleted in v50)
* add "Hospital" language name category
* note the "this day in history" table (formerly `unk_v40_6`) that SeerSkye found, with appropriate adjustments

Co-Authored-By: SeerSkye <58483868+SeerSkye@users.noreply.github.com>