### PR TITLE
Update df.d_init.xml

### DIFF
--- a/df.d_init.xml
+++ b/df.d_init.xml
@@ -22,6 +22,7 @@
         <enum-item name='ENGRAVINGS_START_OBSCURED'/>
         <enum-item name='SHOW_IMP_QUALITY'/>
         <enum-item name='SHOW_FLOW_AMOUNTS'/>
+        <enum-item name='SHOW_RAMP_ARROWS'/>
     </enum-type>
 
     <enum-type type-name='d_init_flags2'>


### PR DESCRIPTION
Add "SHOW_RAMP_ARROWS" as 4th bit in d_init_flags1. Found this while trying to find the Keyboard Cursor setting to see if it could be toggled programattically.