### PR TITLE
check-type-sizes workflow: Use base branch of PR for comparison

### DIFF
--- a/.github/workflows/check-type-sizes.yml
+++ b/.github/workflows/check-type-sizes.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install gcc-multilib g++-multilib
         fi
     - name: Clone DFHack
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: dfhack/dfhack
         submodules: true
@@ -41,7 +41,7 @@ jobs:
       # exclude tools to ensure that new versions (from the PR) are used, for consistency
       run: rsync -av library/xml/ xml-old/ --exclude .git --exclude tools
     - name: Clone df-structures
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: xml-new
     - name: Install new structures
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Clone df-structures
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Download reports
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/check-type-sizes.yml
+++ b/.github/workflows/check-type-sizes.yml
@@ -37,13 +37,16 @@ jobs:
       with:
         repository: dfhack/dfhack
         submodules: true
-    - name: Back up old structures
-      # exclude tools to ensure that new versions (from the PR) are used, for consistency
-      run: rsync -av library/xml/ xml-old/ --exclude .git --exclude tools
-    - name: Clone df-structures
+    - name: Clone df-structures (old)
+      uses: actions/checkout@v3
+      with:
+        path: xml-old
+        ref: master
+    - name: Clone df-structures (new)
       uses: actions/checkout@v3
       with:
         path: xml-new
+    # ensure that DFHack configures properly on the new branch:
     - name: Install new structures
       run: rsync -av xml-new/ library/xml/ --exclude .git
     - name: Configure DFHack


### PR DESCRIPTION
Formerly, the submodule ref from dfhack/dfhack:develop was used as the base, which produced spurious reports of changed sizes if df-structures:master was newer.
