### PR TITLE
Identify new RNG state var in world

### DIFF
--- a/df.ui-menus.xml
+++ b/df.ui-menus.xml
@@ -2560,18 +2560,16 @@
         -- End Steam-only stuff
     </struct-type>
 
+    <struct-type type-name='hash_rngst'>
+        <int64_t name='splitmix64_state'/>
+        <int64_t/>
+        <int64_t/>
+    </struct-type>
+
     this is the tail of `gamest` that appears after the steam-specific part
     <struct-type type-name='gamest_extra'>
-        <compound name='hash_rng'>
-            <int64_t/>
-            <int64_t/>
-            <int64_t/>
-        </compound>
-        <compound name='play_rng'>
-            <int64_t/>
-            <int64_t/>
-            <int64_t/>
-        </compound>
+        <compound name='hash_rng' type-name='hash_rngst'/>
+        <compound name='play_rng' type-name='hash_rngst'/>
         <uint32_t name='start_tick_count'/>
         <int32_t name='autosave_cycle'/>
         <bool name='want_to_quit_to_title'/>

--- a/df.world.xml
+++ b/df.world.xml
@@ -1433,7 +1433,7 @@
             <compound name='worldgen_parms' type-name='worldgen_parms'/>
         </compound>
 
-        <int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/> 0.50.01
+        <compound name='unk_rng' type-name='hash_rngst'/>
 
         -- hist figures
 


### PR DESCRIPTION
Also identify the first field as a "splitmix64" state. No idea what the other fields are for.