### PR TITLE
Init values for military, extract equipment update

### DIFF
--- a/df.military.xml
+++ b/df.military.xml
@@ -114,7 +114,7 @@
                       type-name='int32_t' ref-target='activity_event'
                       aux-value='$._global.activities[$._key]'/>
 
-        <int32_t name='unk_2'/>
+        <int32_t name='unk_2' init-value='-1'/>
     </struct-type>
 
     <struct-type type-name='squad_schedule_order'>
@@ -191,7 +191,7 @@
             <stl-vector name="ammo_units">
                 <int32_t ref-target='unit'/>
             </stl-vector>
-            <int32_t name='unk_v50_1'/>
+            <bitfield name='update' type-name='equipment_update'/>
         </compound>
 
         <int16_t name="carry_food"/>
@@ -202,7 +202,7 @@
                  refers-to='(find-by-id $$._global.entity_id.ref-target.positions.own $id $)'/>
         <int32_t name="leader_assignment" since='v0.40.01'
                  refers-to='(find-by-id $$._global.entity_id.ref-target.positions.assignments $id $)'/>
-        <int32_t name='unk_1' since='v0.44.01'/>
+        <int32_t name='unk_1' init-value='-1' since='v0.44.01'/>
         <int32_t name='unk_v50_1' comment='Appears to be a transient per-squad texture id. Initialised on squad ui click'/>
         <int32_t name='unk_v50_2' comment='Always 1 less than the above field when initialised, and has tied initialisation'/>
         <int32_t name='symbol' comment='0 to 22 inclusive, row-wise. Only used in graphics mode'/>
@@ -257,9 +257,9 @@
     <class-type type-name='squad_order' original-name='squad_orderst'>
         <int32_t name='unk_v40_1' init-value='-1' since='v0.40.01'/>
         <int32_t name='unk_v40_2' init-value='-1' since='v0.40.01'/>
-        <int32_t name='year' since='v0.40.01'/>
-        <int32_t name='year_tick' since='v0.40.01'/>
-        <int32_t name='unk_v40_3' since='v0.40.01'/>
+        <int32_t name='year' init-value='-1' since='v0.40.01'/>
+        <int32_t name='year_tick' init-value='-1' since='v0.40.01'/>
+        <int32_t name='unk_v40_3' init-value='-1' since='v0.40.01'/>
         <int32_t name='unk_1'/>
 
         <virtual-methods>

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -204,6 +204,23 @@
         <enum-item name='Finishing'/>
     </enum-type>
 
+    <bitfield-type type-name='equipment_update' base-type='uint32_t'>
+        <flag-bit name='weapon'/>
+        <flag-bit name='armor'/>
+        <flag-bit name='shoes'/>
+        <flag-bit name='shield'/>
+        <flag-bit name='helm'/>
+        <flag-bit name='gloves'/>
+        <flag-bit name='ammo'/>
+        <flag-bit name='pants'/>
+
+        <flag-bit name='backpack'/>
+        <flag-bit name='quiver'/>
+        <flag-bit name='flask'/>
+        <flag-bit/>
+        <flag-bit name='buildings'/>
+    </bitfield-type>
+
     <struct-type type-name='plotinfost'>
         ctor 86e33c0 x
         dtor 8534190
@@ -542,22 +559,7 @@
                 <stl-vector pointer-type='item'/>
             </static-array>
 
-            <bitfield name='update'>
-                <flag-bit name='weapon'/>
-                <flag-bit name='armor'/>
-                <flag-bit name='shoes'/>
-                <flag-bit name='shield'/>
-                <flag-bit name='helm'/>
-                <flag-bit name='gloves'/>
-                <flag-bit name='ammo'/>
-                <flag-bit name='pants'/>
-
-                <flag-bit name='backpack'/>
-                <flag-bit name='quiver'/>
-                <flag-bit name='flask'/>
-                <flag-bit/>
-                <flag-bit name='buildings'/>
-            </bitfield>
+            <bitfield name='update' type-name='equipment_update'/>
 
             <stl-vector name='work_weapons' comment='i.e. woodcutter axes, and miner picks'>
                 <int32_t ref-target='item'/>


### PR DESCRIPTION
This sets the initial values for various unks that were largely found via memory inspection, though the changes to squad_order were found very kindly by ab9rf via reverse engineering

The change to equipment update in ammo was discussed a while back in the discord (search for 2047 for info), but never formally committed. These changes are collectively for the military module PR