### PR TITLE
Convert plotinfo.equipment vectors from pointers to refs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ that repo.
 - corrected alignment in ``world.status``
 - ``dipscript_popup``: ``meeting_holder`` converted from unit pointer into two unit refs ``meeting_holder_actor`` and ``meeting_holder_noble``.
 - ``activity_info``: ``unit_actor``, ``unit_noble``, and ``place`` converted from pointers to integer references.
+- ``plotinfost``.``equipment``: Converted ``items_unmanifested``, ``items_unassigned``, and ``items_assigned`` vectors from pointers to item refs
 - split ``gamest`` into ``gamest`` and ``gamest_extra`` to accommodate steam-specific data in ``gamest.mod_manager``
 - identify item vmethod 213 (applies a thread improvements to appropriate items based on an RNG)
 - identify various data types related to job completion/cancellation

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -548,15 +548,15 @@
 
         <compound name='equipment'>
             <static-array name='items_unmanifested' count='113' index-enum='item_type'>
-                <stl-vector pointer-type='item'/>
+                <stl-vector type-name='int32_t' ref-target='item'/>
             </static-array>
 
             <static-array name='items_unassigned' count='113' index-enum='item_type'>
-                <stl-vector pointer-type='item'/>
+                <stl-vector type-name='int32_t' ref-target='item'/>
             </static-array>
 
             <static-array name='items_assigned' count='113' index-enum='item_type'>
-                <stl-vector pointer-type='item'/>
+                <stl-vector type-name='int32_t' ref-target='item'/>
             </static-array>
 
             <bitfield name='update' type-name='equipment_update'/>


### PR DESCRIPTION
Fix crashing when accessing these vectors in `gui/gm-editor` or lua.