### PR TITLE
Remove specific_ref_type BUILDING_PARTY, PETINFO_PET, and PETINFO_OWNER

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ that repo.
 # Future
 
 ## Structures
+- ``specific_ref_type``: Removed ``BUILDING_PARTY``, ``PETINFO_PET``, and ``PETINFO_OWNER`` enum values to fix alignment.
 
 # 50.07-alpha2
 

--- a/df.refs.xml
+++ b/df.refs.xml
@@ -355,7 +355,6 @@
         <enum-item name='JOB'>
             <item-attr name='union_field' value='job'/>
         </enum-item>
-        (enum-item name='BUILDING_PARTY'/) removed in v50
         <enum-item name='ACTIVITY'>
             <item-attr name='union_field' value='activity'/>
         </enum-item>
@@ -366,8 +365,6 @@
         <enum-item name='EFFECT'>
             <item-attr name='union_field' value='effect'/>
         </enum-item>
-        (enum-item name='PETINFO_PET' comment='unused'/) removed in v50
-        (enum-item name='PETINFO_OWNER' comment='unused'/) removed in v50
         <enum-item name='VERMIN_EVENT'/>
 
         <enum-item name='VERMIN_ESCAPED_PET'>

--- a/df.refs.xml
+++ b/df.refs.xml
@@ -402,7 +402,7 @@
 
         <enum-item name='ART_IMAGE'/>
         <enum-item name='CREATURE_DEF'/>
-        <enum-item name='ENTITY_ART_IMAGE'/>
+        <enum-item name='ENTITY_ART_IMAGE' comment='unused?'/>
         <enum-item/>
         <enum-item name='ENTITY_POPULATION'/>
         <enum-item name='BREED'/>

--- a/df.refs.xml
+++ b/df.refs.xml
@@ -355,7 +355,7 @@
         <enum-item name='JOB'>
             <item-attr name='union_field' value='job'/>
         </enum-item>
-        <enum-item name='BUILDING_PARTY'/>
+        (enum-item name='BUILDING_PARTY'/) removed in v50
         <enum-item name='ACTIVITY'>
             <item-attr name='union_field' value='activity'/>
         </enum-item>
@@ -366,8 +366,8 @@
         <enum-item name='EFFECT'>
             <item-attr name='union_field' value='effect'/>
         </enum-item>
-        <enum-item name='PETINFO_PET' comment='unused'/>
-        <enum-item name='PETINFO_OWNER' comment='unused'/>
+        (enum-item name='PETINFO_PET' comment='unused'/) removed in v50
+        (enum-item name='PETINFO_OWNER' comment='unused'/) removed in v50
         <enum-item name='VERMIN_EVENT'/>
 
         <enum-item name='VERMIN_ESCAPED_PET'>


### PR DESCRIPTION
These ref types were removed in v50, causing misalignment of the remaining values.

Closes #549