### PR TITLE
hf_visual unk_2v is identity ref

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -461,7 +461,7 @@
                     <flag-bit/>
                     <flag-bit name='believes_false_identity'/>
                 </bitfield>
-                <stl-vector name='unk_2v' type-name='int32_t'/>
+                <stl-vector name='unk_2v' type-name='int32_t' ref-target='identity' comment="Involves adventurer knowing name?"/>
                 <stl-vector name="attitude">
                     <enum type-name='reputation_type' comment="Probably ordered"/>
                 </stl-vector>


### PR DESCRIPTION
If `units.active[0]` has a relationship with a target whose current identity has an entry in the respective `hf_visual`'s `unk_2v` vector, then the target's visible name appears after their title (e.g., "the deity" or "Slave") regardless of the `information_source` flag not being set or not sharing the same `cultural_identity`.