### PR TITLE
Identify chores related fields in plotinfo.hauling

### DIFF
--- a/df.ui.xml
+++ b/df.ui.xml
@@ -595,26 +595,16 @@
             <bool name='in_stop'/>
             <int32_t name='cursor_stop'/>
 
-<!--
-            <stl-vector name='stop_conditions' pointer-type='stop_depart_condition'/>
-            <stl-vector name='stop_links' pointer-type='route_stockpile_link'/>
--->
-            <int32_t/><int32_t/><int32_t/><int32_t/><int32_t/> 0.50.01
+            <int32_t/><int32_t/><int32_t/> 0.50.01
+            <bitfield name="flags">
+                <flag-bit name="children_do_chores" />
+            </bitfield>
+            <int32_t/> 0.50.01
             <stl-vector name='work_details' pointer-type='work_detail'/> 0.50.01
-            <int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/> 0.50.01
-            <int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/> 0.50.01
-            <int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/> 0.50.01
-
-            <bool name='in_advanced_cond'/>
-
-            <bool name='in_assign_vehicle'/>
-            <int32_t name='cursor_vehicle'/>
-            <stl-vector name='vehicles' pointer-type='vehicle'/>
-
-<!--
-            <bool name='in_name'/>
-            <stl-string name='old_name'/>
--->
+            <static-array type-name='bool' name='chores' index-enum='unit_labor' count='94'/>
+            <stl-vector name='chores_exempted_children'> sorted
+                <int32_t ref-target='unit'/>
+            </stl-vector>
         </compound>
 
         <stl-vector name='petitions' type-name='int32_t' comment='related to agreements'/>


### PR DESCRIPTION
I am not sure about the bitfield size, but I cannot check right now.

I have no idea where the stuff I'm removing has gone, but it's not the first time in this structure from the comments. There are two bytes of padding after `chores`, bools could fit in there.