### PR TITLE
realign `stockpiles_settings`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ that repo.
 # Future
 
 ## Structures
+- realigned ``stockpile_settings`` for new "corpses" vector
 
 # 50.07-beta1
 

--- a/df.stockpile.xml
+++ b/df.stockpile.xml
@@ -158,6 +158,11 @@
             <static-array type-name='bool' name='quality_total' count='7' index-enum='item_quality'/>
         </compound>
 
+        <compound name='corpses'>
+            <stl-vector type-name='bool' name='corpses'
+            index-refers-to='(find-creature $)'/>
+        </compound>
+
         <compound name='refuse'>
             <stl-vector type-name='bool' name='type' index-enum='item_type'/>
             <stl-vector type-name='bool' name='corpses'
@@ -176,7 +181,6 @@
                         index-refers-to='(find-creature $)'/>
             <stl-vector type-name='bool' name='horns'
                         index-refers-to='(find-creature $)'/>
-            <stl-vector type-name='bool'/> 0.50.01
             <bool name='fresh_raw_hide'/>
             <bool name='rotten_raw_hide'/>
         </compound>


### PR DESCRIPTION
Toady added a separate "corpses" vector which we had inadvertently stuffed into `refuse`; this breaks it out to its own subsection and realigns the rest of `refuse`