### PR TITLE
fix size of tree body data

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ that repo.
 
 - identified ``divine_treasure`` and ``encased_horror`` map events
 - identified fields in ``deep_vein_hollow``, ``glowing_barrier``, and ``cursed_tomb`` map events
+- correct bit size of tree body data
 
 # 50.07-beta2
 

--- a/df.plants.xml
+++ b/df.plants.xml
@@ -35,6 +35,17 @@
         <flag-bit name='blocked' comment='e.g. by other tree'/>
     </bitfield-type>
 
+    <bitfield-type type-name='plant_root_tile' base-type='uint8_t'>
+        <flag-bit name='trunk'/>
+        <flag-bit name='connection_east'/>
+        <flag-bit name='connection_south'/>
+        <flag-bit name='connection_west'/>
+        <flag-bit name='connection_north'/>
+        <flag-bit name='branches'/>
+        <flag-bit name='twigs'/>
+        <flag-bit name='blocked' comment='e.g. by other tree'/>
+    </bitfield-type>
+
     <struct-type type-name='plant_tree_info'>
         <pointer name='body' is-array='true' comment='dimension body_height'>
             <pointer type-name='plant_tree_tile' is-array='true' comment='dimension dim_x*dim_y'/>
@@ -47,7 +58,7 @@
         <int32_t name='dim_x'/>
         <int32_t name='dim_y'/>
         <pointer name='roots' is-array='true' comment='dimension roots_depth'>
-            <pointer type-name='plant_tree_tile' is-array='true' comment='dimension dim_x*dim_y'/>
+            <pointer type-name='plant_root_tile' is-array='true' comment='dimension dim_x*dim_y'/>
         </pointer>
         <int32_t name='roots_depth'/>
         <int16_t name='unk6'/>

--- a/df.plants.xml
+++ b/df.plants.xml
@@ -24,7 +24,7 @@
         <pointer name='tree_info' type-name='plant_tree_info'/>
     </struct-type>
 
-    <bitfield-type type-name='plant_tree_tile' base-type='uint8_t'>
+    <bitfield-type type-name='plant_tree_tile' base-type='uint16_t'>
         <flag-bit name='trunk'/>
         <flag-bit name='connection_east'/>
         <flag-bit name='connection_south'/>


### PR DESCRIPTION
I discovered this from dumping the tree body data to make a visual bitmap of the tree structure. When we interpret each element as 8 bits, there were gaps between adjacent trunk tiles and the trunk is not centered in the tree dimensions. With a 16-bit tree body data element, trunks are adjacent and centered, and match the visual representation of the in-game trees.

Why did the bit size increase? Are there more flags now in the enum? I'm not equipped to divine that knowledge.

The impact of this change is that `Designations::markPlant()` will now mark the correct (southeast) tile of 3x3 trees instead of the (unreachable) center tile. Also, autochop will get the right count of trunk tiles for estimating log yield, which should fix its chronic under-estimation issues.