### PR TITLE
codegen: generate friend declarations for classes that contain members with vtables

### DIFF
--- a/StructFields.pm
+++ b/StructFields.pm
@@ -165,6 +165,10 @@ my %custom_container_inits = (
     },
 );
 
+# track objects that contain members with vtables
+# map of: type name -> @{names of classes containing type}
+my %field_backrefs;
+
 sub emit_typedef($$) {
     # Convert a prefix/postfix pair into a single name
     my ($pre, $post) = @_;
@@ -231,6 +235,14 @@ sub get_struct_field_type($;%) {
             or die "Global field without type-name";
         $type_def = register_ref($tname, !$flags{-weak} || ($subtype && $subtype eq 'enum'));
         $prefix = $main_namespace.'::'.$tname;
+
+        if ($tag->nodeName eq 'ld:field') {
+            my $parentName = $tag->parentNode->getAttribute('type-name');
+            my $fieldMeta = $types{$tname}->getAttribute('ld:meta');
+            if ($parentName && $fieldMeta eq 'class-type') {
+                push @{$field_backrefs{$tname}}, $tag->parentNode->getAttribute('type-name');
+            }
+        }
     } elsif ($meta eq 'compound') {
         die "Unnamed compound in global mode: ".$tag->toString."\n" unless $flags{-local};
 
@@ -688,6 +700,13 @@ sub emit_struct_fields($$;%) {
                     "${ftable}${maybe_index_enum});";
         }
     } 'fields-' . $fields_group;
+
+    if ($field_backrefs{$name}) {
+        for my $backref (@{$field_backrefs{$name}}) {
+            register_ref $backref;
+            emit "friend struct ${main_namespace}::${backref};";
+        }
+    }
 }
 
 for my $letter ('a' .. 'z') {

--- a/codegen.pl
+++ b/codegen.pl
@@ -50,12 +50,33 @@ for my $fn (sort { $a cmp $b } bsd_glob "$input_dir/df.*.xml") {
 
 # Generate type text representations
 
+my %type_preprocessors = (
+    'class-type' => \&preprocess_struct_type,
+    'struct-type' => \&preprocess_struct_type,
+);
+
 my %type_handlers = (
     'enum-type' => \&render_enum_type,
     'bitfield-type' => \&render_bitfield_type,
     'class-type' => \&render_struct_type,
     'struct-type' => \&render_struct_type,
 );
+
+for my $name (sort { $a cmp $b } keys %types) {
+    local $typename = $name;
+
+    eval {
+        my $type = $types{$typename};
+        my $meta = $type->getAttribute('ld:meta');
+        my $handler = $type_preprocessors{$meta};
+        if ($handler) {
+            $handler->($type);
+        }
+    };
+    if ($@) {
+        print "Error preprocessing type $typename: ".$@;
+    }
+}
 
 for my $name (sort { $a cmp $b } keys %types) {
     local $typename = $name;


### PR DESCRIPTION
This is needed because class-type constructors (i.e. constructors for types with vmethods) are protected.

For instance, in the SDL2 beta builds, there is a `widget_textbox` (which has vmethods) contained in `MacroScreenSave`. This prevented the default `MacroScreenSave` constructor from compiling. Adding a friend declaration allows `MacroScreenSave` to invoke the constructor for `widget_textbox`.

We actually have a few cases of this already (`interfacest` contains a `viewscreenst`, `world` contains a `machine_handlerst`), and we have previously worked around this issue by adding `custom-methods=true` to the affected classes, then adding friend declarations to the `df/custom/*.inc` files in the dfhack repo. This change makes that unnecessary, but I am opting to hold off on cleaning up those declarations to unblock SDL2 work faster (they are redundant but cause no harm).