### PR TITLE
change `tiletype_shape::RAMP_TOP` `walkable` attr to false

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ that repo.
 # Future
 
 ## Structures
+- ``tiletype_shape``: changed RAMP_TOP to not walkable
 
 # 50.08-r4
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@ that repo.
 # Future
 
 ## Structures
-- ``tiletype_shape``: changed RAMP_TOP to not walkable
+- ``tiletype_shape``: changed RAMP_TOP and ENDLESS_PIT to not walkable to reflect how scripts actually need these types to be treated
 
 # 50.08-r4
 

--- a/df.tile-types.xml
+++ b/df.tile-types.xml
@@ -90,7 +90,7 @@
             <item-attr name='passable_high' value='true'/>
             <item-attr name='passable_flow' value='true'/>
             <item-attr name='passable_flow_down' value='true'/>
-            <item-attr name='walkable' value='true'/>
+            <item-attr name='walkable' value='false'/>
         </enum-item>
         <enum-item name='BROOK_BED'>
             <item-attr name='caption' value='mineable, water-passable rock on the bottom of a brook'/>

--- a/df.tile-types.xml
+++ b/df.tile-types.xml
@@ -15,7 +15,7 @@
         <enum-attr name='passable_high' type-name='bool' default-value='false' comment='tile is missing a roof'/>
         <enum-attr name='passable_flow' type-name='bool' default-value='false' comment='tile is non-solid'/>
         <enum-attr name='passable_flow_down' type-name='bool' default-value='false' comment='floor is non-solid'/>
-        <enum-attr name='walkable' type-name='bool' default-value='false' comment='can be walked into'/>
+        <enum-attr name='walkable' type-name='bool' default-value='false' comment='can be stood upon'/>
         <enum-attr name='walkable_up' type-name='bool' default-value='false' comment='can walk to ceiling'/>
 
         <enum-item name='NONE' value='-1'/>
@@ -90,7 +90,6 @@
             <item-attr name='passable_high' value='true'/>
             <item-attr name='passable_flow' value='true'/>
             <item-attr name='passable_flow_down' value='true'/>
-            <item-attr name='walkable' value='false'/>
         </enum-item>
         <enum-item name='BROOK_BED'>
             <item-attr name='caption' value='mineable, water-passable rock on the bottom of a brook'/>
@@ -147,7 +146,6 @@
             <item-attr name='basic_shape' value='Open'/>
             <item-attr name='passable_high' value='true'/>
             <item-attr name='passable_flow' value='true'/>
-            <item-attr name='walkable' value='true'/>
         </enum-item>
     </enum-type>
 


### PR DESCRIPTION
based on research by @plule 

necessary to implement suspendmanager @plule also found evidence that other tools are working around this being wrong

see dfhack/dfhack#3492