### PR TITLE
Some more unit info for 50.09

### DIFF
--- a/df.units.xml
+++ b/df.units.xml
@@ -1245,8 +1245,8 @@
         <int32_t name='sheet_icon_texpos'/>
         <static-array name='texpos_currently_in_use' count='3'><static-array count='2' type-name='bool'/></static-array>
 
-        <int8_t name='unk_140a'/>
-        <int64_t name='unk_1410'/>
+        <int8_t name='cached_glowtile_type'/>
+        <int64_t name='pool_index'/> this should be size_t but we don't support size_t in structures yet
         <padding name='mtx' size='80'/> should be std::mutex
 
         <virtual-methods>


### PR DESCRIPTION
pool_index in particular I'm using for debugging some, so it's good to keep it around; cached_glowtile_type is used for a line-of-sight optimization and should generally be irrelevant, but might be usable for some "aggressive, incorrect" optimizations done at runtime, by setting it to 0--anything set to 1 will check the raws in line-of-sight code for every unit within 26 tiles and anything set to 2 will check if it has an eye popped out, while 0 will just assume there's no glowtile at all and run with that--faster, but technically incorrect, one of those things that can be tweaked at runtime now.

Should be noted that pool_index is `protected`, which means how it's aligned might end up being compiler-specific--the standard only specifies that all variables of the same access specifier are in the order they are declared, but _only_ for variables of the same access specifier, i.e. the protected variables might go _before_ all the public ones on some platforms. Hopefully this won't actually happen?