### PR TITLE
`process_unit_aux`

### DIFF
--- a/df.meeting.xml
+++ b/df.meeting.xml
@@ -388,7 +388,7 @@
             <vmethod name='removeParticipant'> <int32_t name='histfig'/> <int32_t name='unit'/> <bool/> </vmethod>
 
             <vmethod name='process'>
-                <pointer/>
+                <pointer type-name='process_unit_aux'/>
                 <pointer type-name='unit' name='unit'/>
             </vmethod>
             <vmethod ret-type='int32_t' name='checkDrillInvalid'>

--- a/df.meeting.xml
+++ b/df.meeting.xml
@@ -388,7 +388,7 @@
             <vmethod name='removeParticipant'> <int32_t name='histfig'/> <int32_t name='unit'/> <bool/> </vmethod>
 
             <vmethod name='process'>
-                <int32_t/>
+                <pointer/>
                 <pointer type-name='unit' name='unit'/>
             </vmethod>
             <vmethod ret-type='int32_t' name='checkDrillInvalid'>

--- a/df.units.xml
+++ b/df.units.xml
@@ -2514,6 +2514,31 @@
         <int32_t name='icon'/>
     </struct-type>
 
+    <struct-type type-name='process_unit_aux'>
+        <pointer name='unit' type-name='unit'/>
+        <int32_t/>
+        <bitfield name='flags' base-type='int32_t'>
+            <flag-bit name='unk0'/>
+            <flag-bit/>
+            <flag-bit name='unk2'/>
+        </bitfield>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/> could be padding
+        <static-array name='unitlist' count='200'>
+            per putnam, this is line of sight data
+            <pointer type-name='unit'/>
+        </static-array>
+        <int32_t/>
+        <int32_t/> could be padding
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+        <int32_t/>
+    </struct-type>
+
 </data-definition>
 
 <!--


### PR DESCRIPTION
this structure was recently discovered in diverse investigations. it appears to have been added to df somewhere between 40d and 34.05, possibly as early as 31.01, but we only recently became aware of it

per comments from putnam, it is involved in line-of-sight processing. it is also associated with unit movement and job handling, and is associated with 50.09's multithreaded performance improvements

the reason we're including it in structures is this structure is the type of one of the arguments of one of `activity_eventst`'s vmethods