### PR TITLE
Fix gps alignment on Linux

### DIFF
--- a/df.graphics.xml
+++ b/df.graphics.xml
@@ -214,7 +214,7 @@
         <int32_t name='viewport_zoom_factor'/>
 
         <int32_t name='screenx'/>
-        <long name='screeny'/>
+        <int32_t name='screeny'/>
         <enum name='screenf' type-name='curses_color'/>
         <enum name='screenb' type-name='curses_color'/>
         <bool name='screenbright'/>
@@ -276,7 +276,7 @@
 
         <long name='rect_id'/>
 
-        <static-array type-name='int64_t' name='print_time' count='100'/>
+        <static-array type-name='large_integer' name='print_time' count='100'/>
         <long name='print_index'/>
         <int8_t name='display_frames'/>
 


### PR DESCRIPTION
Should double-check that the size of gps remains the same (221160) on Windows.