### PR TITLE
[buildingst] remove field that isn't actually there

### DIFF
--- a/df.buildings.xml
+++ b/df.buildings.xml
@@ -324,7 +324,6 @@
         <int32_t name='unk_v40_2' init-value='-1' since='v0.40.01'/>
         <int32_t name='site_id' ref-target='world_site' since='v0.42.01'/>
         <int32_t name='location_id' ref-target='abstract_building' aux-value='$$.site_id' since='v0.42.01'/>
-        <int32_t name='unk_v40_3' init-value='-1' since='v0.40.01'/>
 
         <virtual-methods>
             <vmethod ret-type='int32_t' name='getCustomType'/>


### PR DESCRIPTION
wasn't an issue on Windows, but causes misalignment on Linux