### PR TITLE
various 50.09 realignments

### DIFF
--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -181,7 +181,7 @@
     </class-type>
 
     <class-type type-name='widget_button' original-name='widgets::button' inherits-from='widget'>
-        <pointer name='callback'/>
+        <padding pointer name='callback' size='64'/> actually std::function((void()))
     </class-type>
 
     <class-type type-name='widget_container' original-name='widgets::container' inherits-from='widget'>

--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -178,10 +178,11 @@
         <stl-string name='str'/>
         <bool name='toggle'/>
         <int32_t name='flags'/>
+        <padding name='callback' size='64'/> actually std::function((void()))
     </class-type>
 
     <class-type type-name='widget_button' original-name='widgets::button' inherits-from='widget'>
-        <padding pointer name='callback' size='64'/> actually std::function((void()))
+        <padding name='callback' size='64'/> actually std::function((void()))
     </class-type>
 
     <class-type type-name='widget_container' original-name='widgets::container' inherits-from='widget'>

--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -179,7 +179,7 @@
         <bool name='toggle'/>
         <int32_t name='flags'/>
         <padding size='4' comment='alignment padding before std::function'/>
-        <padding name='callback' size='64' comment='actually std::function<void()>'/>
+        <padding name='callback' size='64' comment='actually std::function&lt;void()&gt;'/>
         <int16_t name='fg'/>
         <int16_t name='bg'/>
         <int8_t name='bright'/>

--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -178,7 +178,12 @@
         <stl-string name='str'/>
         <bool name='toggle'/>
         <int32_t name='flags'/>
-        <padding name='callback' size='64'/> actually std::function((void()))
+        <padding size='4' comment='alignment padding before std::function'/>
+        <padding name='callback' size='64' comment='actually std::function<void()>'/>
+        <int16_t name='fg'/>
+        <int16_t name='bg'/>
+        <int8_t name='bright'/>
+        <bool name='input'/>
     </class-type>
 
     <class-type type-name='widget_button' original-name='widgets::button' inherits-from='widget'>

--- a/df.world.xml
+++ b/df.world.xml
@@ -1069,36 +1069,35 @@
             <stl-vector name='unk_v50_3'/>
             <int32_t name='display_timer'/>
 
-            <static-array name='slots' count='100'>
-                <comment>Written to by code at 0x80fd7b0</comment>
-                <enum type-name='combat_report_event_type' name='type'/>
-                <int32_t name='item' comment='or body part layer'/>
-                <int32_t name='unk1b'/>
-                <int32_t name='unk1c'/>
-                <int32_t name='unk1d'/>
-                <int16_t name='body_part'/>
-                <int16_t name='unk2b'/>
-                <int16_t name='unk2c'/>
-                <int16_t name='unk2d'/>
-                <stl-string name='target_bp_name'/>
-                <stl-string name='verb'/>
-                <stl-string name='with_item_name'/>
-                <stl-string name='unk3d'/>
-                <bitfield name='flags' base-type='int32_t'>
-                    <flag-bit name='behind'/>
-                    <flag-bit name='side'/>
-                    <flag-bit name='by'/>
-                    <flag-bit name='item'/>
-                    <flag-bit name='tap'/>
-                    <flag-bit name='sever'/>
-                </bitfield>
-            </static-array>
-
-            <static-array name='slot_id_used' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
-            <static-array name='slot_id_idx1' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
-            <static-array name='slot_id_idx2' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
-
-            <int16_t name='slots_used'/>
+            <compound name='slots'>
+                <static-array name='slotdata' count='100'>
+                    <enum type-name='combat_report_event_type' name='type'/>
+                    <int32_t name='item' comment='or body part layer'/>
+                    <int32_t name='unk1b'/>
+                    <int32_t name='unk1c'/>
+                    <int32_t name='unk1d'/>
+                    <int16_t name='body_part'/>
+                    <int16_t name='unk2b'/>
+                    <int16_t name='unk2c'/>
+                    <int16_t name='unk2d'/>
+                    <stl-string name='target_bp_name'/>
+                    <stl-string name='verb'/>
+                    <stl-string name='with_item_name'/>
+                    <stl-string name='unk3d'/>
+                    <bitfield name='flags' base-type='int32_t'>
+                        <flag-bit name='behind'/>
+                        <flag-bit name='side'/>
+                        <flag-bit name='by'/>
+                        <flag-bit name='item'/>
+                        <flag-bit name='tap'/>
+                        <flag-bit name='sever'/>
+                    </bitfield>
+                </static-array>
+                <static-array name='slot_id_used' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
+                <static-array name='slot_id_idx1' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
+                <static-array name='slot_id_idx2' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
+                <int16_t name='slots_used'/>
+            </compound>
         </compound>
 
         <compound name='interaction_instances'>


### PR DESCRIPTION
the regrouping of these fields as a subcompound is because they are being passed around as a unit in the actual code

this has no consumer-facing impact; this is far too deep in the weeds

added: realign `widgets::button` and `widgets::textbox`