### PR TITLE
add codegen support for `std::function` and `std::optional`

### DIFF
--- a/StructFields.pm
+++ b/StructFields.pm
@@ -149,6 +149,11 @@ my %custom_container_handlers = (
         header_ref("optional");
         return "std::optional<$item >";
     },
+    'stl-shared-ptr' => sub {
+        my $item = get_container_item_type($_, -void => 'void');
+        header_ref("memory");
+        return "std::shared_ptr<$item >";
+    },
     'df-flagarray' => sub {
         my $type = decode_type_name_ref($_, -attr_name => 'index-enum', -force_type => 'enum-type') || 'int';
         return "BitArray<$type>";

--- a/StructFields.pm
+++ b/StructFields.pm
@@ -139,6 +139,16 @@ my %custom_container_handlers = (
         header_ref("map");
         return "std::map<$key, $item>";
     },
+    'stl-function' => sub {
+        my $item = get_container_item_type($_, -void => 'void');
+        header_ref("functional");
+        return "std::function<$item() >"; # TODO: get the full prototype
+    },
+    'stl-optional' => sub {
+        my $item = get_container_item_type($_, -void => 'void');
+        header_ref("optional");
+        return "std::optional<$item >";
+    },
     'df-flagarray' => sub {
         my $type = decode_type_name_ref($_, -attr_name => 'index-enum', -force_type => 'enum-type') || 'int';
         return "BitArray<$type>";

--- a/data-definition.xsd
+++ b/data-definition.xsd
@@ -225,6 +225,8 @@
             <xs:element name="stl-mutex" type="OpaqueField" />
             <xs:element name="stl-condition-variable" type="OpaqueField" />
             <xs:element name="stl-future" type="OpaqueField" />
+            <xs:element name="stl-optional" type="StlOptionalField" />
+            <xs:element name="stl-function" type="StlFunctionField" />
             <xs:element name="df-linked-list" type="DfLinkedListField" />
             <xs:element name="df-array" type="DfArrayField" />
             <xs:element name="df-flagarray" type="DfFlagArrayField" />
@@ -387,6 +389,18 @@
         </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="StlMapField">
+        <xs:complexContent>
+            <xs:extension base="ContainerFieldType">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="StlOptionalField">
+        <xs:complexContent>
+            <xs:extension base="ContainerFieldType">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="StlFunctionField">
         <xs:complexContent>
             <xs:extension base="ContainerFieldType">
             </xs:extension>

--- a/data-definition.xsd
+++ b/data-definition.xsd
@@ -226,6 +226,7 @@
             <xs:element name="stl-condition-variable" type="OpaqueField" />
             <xs:element name="stl-future" type="OpaqueField" />
             <xs:element name="stl-optional" type="StlOptionalField" />
+            <xs:element name="stl-shared-ptr" type="StlSharedPtrField" />
             <xs:element name="stl-function" type="StlFunctionField" />
             <xs:element name="df-linked-list" type="DfLinkedListField" />
             <xs:element name="df-array" type="DfArrayField" />
@@ -395,6 +396,12 @@
         </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="StlOptionalField">
+        <xs:complexContent>
+            <xs:extension base="ContainerFieldType">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="StlSharedPtrField">
         <xs:complexContent>
             <xs:extension base="ContainerFieldType">
             </xs:extension>

--- a/lower-1.xslt
+++ b/lower-1.xslt
@@ -339,7 +339,7 @@ Error: field <xsl:value-of select='$enum-key'/> corresponds to an enum value of 
     </xsl:template>
 
     <!-- Misc containers: meta='container' subtype='$tag' -->
-    <xsl:template match='stl-vector|stl-deque|stl-set|stl-bit-vector|stl-map|stl-optional|stl-function|df-flagarray|df-static-flagarray|df-array|df-linked-list'>
+    <xsl:template match='stl-vector|stl-deque|stl-set|stl-bit-vector|stl-map|stl-optional|stl-shared-ptr|stl-function|df-flagarray|df-static-flagarray|df-array|df-linked-list'>
         <xsl:param name='level' select='-1'/>
         <ld:field ld:meta='container'>
             <xsl:attribute name='ld:level'><xsl:value-of select='$level'/></xsl:attribute>

--- a/lower-1.xslt
+++ b/lower-1.xslt
@@ -339,7 +339,7 @@ Error: field <xsl:value-of select='$enum-key'/> corresponds to an enum value of 
     </xsl:template>
 
     <!-- Misc containers: meta='container' subtype='$tag' -->
-    <xsl:template match='stl-vector|stl-deque|stl-set|stl-bit-vector|stl-map|df-flagarray|df-static-flagarray|df-array|df-linked-list'>
+    <xsl:template match='stl-vector|stl-deque|stl-set|stl-bit-vector|stl-map|stl-optional|stl-function|df-flagarray|df-static-flagarray|df-array|df-linked-list'>
         <xsl:param name='level' select='-1'/>
         <ld:field ld:meta='container'>
             <xsl:attribute name='ld:level'><xsl:value-of select='$level'/></xsl:attribute>


### PR DESCRIPTION
support for std::function is currently halfassed, we only handle the return type for now but at least will let us get alignment correct