### PR TITLE
Realign world_data around constructions

### DIFF
--- a/df.world-data.xml
+++ b/df.world-data.xml
@@ -790,6 +790,8 @@
         <int16_t name="unk_x2"/>
         <int16_t name="unk_y2"/>
 
+        <stl-map name="midmap_place" comment="not saved"/>
+
         <compound name='constructions'>
             <int16_t name="width"/>
             <int16_t name="height"/>
@@ -806,8 +808,6 @@
 
         <compound name="entity_claims1" type-name='entity_claim_mask'/>
         <compound name="entity_claims2" type-name='entity_claim_mask'/>
-
-        <stl-map name="unk_5010_0"/>
 
         <stl-vector name="sites" pointer-type='world_site'/>
 


### PR DESCRIPTION
Based on info from Bay12

Would appreciate if someone could verify this on Windows before merging