### PR TITLE
selective update from bay12 info

### DIFF
--- a/df.advmode.xml
+++ b/df.advmode.xml
@@ -1,5 +1,5 @@
 <data-definition>
-    <enum-type type-name='ui_advmode_menu' base-type='int16_t' original-name='AdventureViewModes'>
+    <enum-type type-name='ui_advmode_menu' base-type='int16_t'> original name is 'AdventureViewModes'
         <enum-item name='Default' value='0'/> MAIN
         <enum-item name='Look'/>
         <enum-item name='ConversationAddress'/> CONVERSATION_START_NEW

--- a/df.advmode.xml
+++ b/df.advmode.xml
@@ -1,10 +1,10 @@
 <data-definition>
-    <enum-type type-name='ui_advmode_menu' base-type='int16_t'>
-        <enum-item name='Default' value='0'/>
+    <enum-type type-name='ui_advmode_menu' base-type='int16_t' original-name='AdventureViewModes'>
+        <enum-item name='Default' value='0'/> MAIN
         <enum-item name='Look'/>
-        <enum-item name='ConversationAddress'/>
-        <enum-item name='ConversationSelect'/>
-        <enum-item name='ConversationSpeak'/>
+        <enum-item name='ConversationAddress'/> CONVERSATION_START_NEW
+        <enum-item name='ConversationSelect'/> CONVERSATION_LIST
+        <enum-item name='ConversationSpeak'/> CONVERATION_TALK
         5
         <enum-item name='Inventory'/>
         <enum-item name='Drop'/>
@@ -20,12 +20,12 @@
         15
         <enum-item name='Fire'/>
         <enum-item name='Get'/>
-        <enum-item name='Unk17'/>
+        <enum-item name='GetAmount'/> PICKUP_AMOUNT
         <enum-item name='CombatPrefs'/>
         <enum-item name='Companions'/>
         20
         <enum-item name='MovementPrefs'/>
-        <enum-item name='SpeedPrefs'/>
+        <enum-item name='SpeedPrefs'/> SPEED_SNEAK
         <enum-item name='InteractAction'/>
         <enum-item name='MoveCarefully'/>
         <enum-item name='Announcements'/>
@@ -43,18 +43,18 @@
         <enum-item name='ViewTracks'/>
         35
         <enum-item name='Jump'/>
-        <enum-item name='AttackCreature'/>
-        <enum-item name='AttackConfirm'/>
-        <enum-item name='AttackType'/>
-        <enum-item name='AttackBodypart'/>
+        <enum-item name='AttackCreature'/> ATTACKCREATURE_UNIT_CHOICE
+        <enum-item name='AttackConfirm'/> ATTACKCREATURE_CONFIRM
+        <enum-item name='AttackType'/> ATTACKCREATURE_MOVE_CHOICE
+        <enum-item name='AttackBodypart'/> ATTACKCREATURE_AIM_TARGET
         40
-        <enum-item name='AttackStrike'/>
-        <enum-item name='Unk41'/> segfaults when set directly
-        <enum-item name='Unk42'/>
-        <enum-item name='DodgeDirection'/>
-        <enum-item name='PerformanceSelect'/>
+        <enum-item name='AttackStrike'/> ATTACKCREATURE_AIM_ATTACK
+        <enum-item name='DefendParry'/> ATTACKCREATURE_PARRY_CHOICE
+        <enum-item name='DefendBlock'/> ATTACKCREATURE_BLOCK_CHOICE
+        <enum-item name='DodgeDirection'/> ATTACKCREATURE_DODGE_CHOICE
+        <enum-item name='PerformanceSelect'/> START_PERFORMANCE
         45
-        <enum-item name='InterruptPerformanceConfirm'/>
+        <enum-item name='InterruptPerformanceConfirm'/> MOVE_CONFIRM
         <enum-item name='Build'/>
         <enum-item name='AssumeIdentity'/>
         <enum-item name='NameItem'/>

--- a/df.entities.xml
+++ b/df.entities.xml
@@ -363,7 +363,8 @@
     </struct-type>
 
     <struct-type type-name='historical_entity' key-field='id'
-                 instance-vector='$global.world.entities.all'>
+                 instance-vector='$global.world.entities.all'
+                 original-name='entityst'>
         <enum name='type' base-type='int16_t' type-name='historical_entity_type'/>
         <int32_t name='id' comment='index in the array'/>
 

--- a/df.history.xml
+++ b/df.history.xml
@@ -833,7 +833,8 @@
         <enum-item name='shared_entity' comment="Religion/PerformanceTroupe/MerchantCompany/Guild"/>
     </enum-type>
 
-    <struct-type type-name='historical_figure' instance-vector='$global.world.history.figures' key-field='id'>
+    <struct-type type-name='historical_figure' instance-vector='$global.world.history.figures' key-field='id'
+                 original-name='history_figurest'>
         <enum base-type='int16_t' name='profession' type-name='profession'/>
 
         <int16_t name='race' ref-target='creature_raw'/>

--- a/df.itemimprovements.xml
+++ b/df.itemimprovements.xml
@@ -1,5 +1,6 @@
 <data-definition>
     <enum-type type-name='improvement_type'>
+        <enum-item name='NONE' value='-1'/>
         <enum-item name="ART_IMAGE"/>
         <enum-item name="COVERED"/>
         <enum-item name="RINGS_HANGING"/>

--- a/df.items.xml
+++ b/df.items.xml
@@ -137,6 +137,7 @@
     </enum-type>
 
     <enum-type type-name='trade_good_purpose' base-type='int16_t'>
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='MERCHANT'/>
         <enum-item name='TRAVELER'/>
         <enum-item name='RICH_TRAVELER'/>

--- a/df.items.xml
+++ b/df.items.xml
@@ -136,6 +136,26 @@
         <enum-item name='TavernSign'/>
     </enum-type>
 
+    <enum-type type-name='trade_good_purpose' base-type='int16_t'>
+        <enum-item name='MERCHANT'/>
+        <enum-item name='TRAVELER'/>
+        <enum-item name='RICH_TRAVELER'/>
+        <enum-item name='STORE_CRAFTS'/>
+        <enum-item name='STORE_WEAPON'/>
+        <enum-item name='STORE_ARMOR'/>
+        <enum-item name='STORE_GENERAL'/>
+        <enum-item name='STORE_FOOD'/>
+        <enum-item name='CONTAINER'/>
+        <enum-item name='PRODUCTION_SHODDY'/>
+        <enum-item name='PRODUCTION_BEGINNER'/>
+        <enum-item name='PRODUCTION_MIDDLING'/>
+        <enum-item name='PRODUCTION_HIGH'/>
+        <enum-item name='PRODUCTION_EXCELLENT'/>
+        <enum-item name='TOMB_TREASURE'/>
+        <enum-item name='TREASURE_ROOM'/>
+        <enum-item name='PILLAGE'/>
+    </enum-type>
+
     -- CORE ITEM
 
     <class-type type-name='item' original-name='itemst'
@@ -341,13 +361,20 @@
                 <int16_t name='mat_type'/>
                 <int32_t name='mat_index'/>
                 <int32_t name='shape' ref-target='descriptor_shape'/>
-                <int16_t name='forced_quality'/>
-                <pointer type-name='historical_entity' name='entity'/>
+                <int16_t name='force_quality'/>
+                <pointer type-name='historical_entity' name='civ'/>
                 <pointer type-name='world_site' name='site'/>
-                <int16_t name='unk' comment='used to compute quality if !job||!unit'/>
-                <bool name='unshaped' comment='glazed'/>
-                <bool/>
-                <int32_t/>
+                <enum type-name='trade_good_purpose' name='tradegoodpurpose'/>
+                <bool name='suppress_shaping'/>
+                <bool name='use_roll'/>
+                <int32_t name='roll'/>
+                <comment>
+                virtual itemimprovementst *improve(
+                    ItemImprovement imp,jobst *jbp,unitst *un,Material mat,MatGloss mg,int32_t shape,
+                    int32_t force_quality,entityst *civ,sitest *st,TradeGoodPurpose tradegoodpurpose,
+                    bool suppress_shaping,bool use_roll,RollResult roll
+                )
+                </comment>
             </vmethod>
 
             -- 90

--- a/df.jobs.xml
+++ b/df.jobs.xml
@@ -554,7 +554,7 @@
         <int32_t name='timeout_limit' comment='once counter passes limit, mandate ends'/>
     </struct-type>
 
-    <enum-type base-type='int16_t' type-name='job_cancel_reason'>
+    <enum-type base-type='int16_t' type-name='killjob_exception_type'>
         <enum-item name='CANNOT_REACH_SITE'/>
         <enum-item name='INTERRUPTED'/>
         <enum-item name='MOVED'/>
@@ -692,29 +692,25 @@
         <enum-item name='NEEDS_SPECIFIC_ITEM_2'/>
     </enum-type>
 
-    <struct-type type-name='job_cancel'>
-        <enum base-type='int16_t' type-name='job_cancel_reason'/>
-        <enum base-type='int16_t' type-name='item_type'/>
-        <int16_t/>
-        <int16_t/>
-        <pointer/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <bitfield base-type='int32_t' type-name='stockpile_group_set'/>
-        <int16_t/>
-        <int16_t/>
-        <int32_t/>
-        <stl-string/>
-        <stl-string/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector type-name='int32_t'/>
-        <int32_t/>
-        <enum base-type='int16_t' type-name='tool_uses'/>
-        <int16_t/>
-        <int16_t/>
-        <int16_t/>
+    <struct-type type-name='killjob_exceptionst'>
+        <enum base-type='int16_t' type-name='killjob_exception_type' name='type'/>
+        <enum base-type='int16_t' type-name='item_type' name='item_type'/>
+        <int16_t name='item_subtype'/>
+        <int16_t name='item_material'/>
+        <int32_t name='item_matgloss'/>
+        <int32_t name='item_flag1'/>
+        <int32_t name='item_flag2'/>
+        <int32_t name='item_flag3'/>
+        <int32_t name='item_flag4'/>
+        <int32_t name='item_flag5'/>
+        <stl-string name='item_reaction_class'/>
+        <stl-string name='item_reaction_product_class'/>
+        <int32_t name='metal_ore'/>
+        <int32_t name='min_dimension_taken'/>
+        <stl-vector type-name='int32_t' name='reagent_index'/>
+        <int32_t name='reaction_index'/>
+        <enum base-type='int16_t' type-name='tool_uses' name='tool_use'/>
+        <compound type-name='coord' name='pos'/>
     </struct-type>
 
 </data-definition>

--- a/df.jobs.xml
+++ b/df.jobs.xml
@@ -371,7 +371,7 @@
     </bitfield-type>
 
     <struct-type type-name='job_art_specification'>
-        <enum base-type='int32_t' name='type'>
+        <enum base-type='int32_t' name='type'> bay12: JobArtSpecifierType
             <enum-item name='None' value='-1'/>
             <enum-item name='HistoricalFigure'/>
             <enum-item name='Site'/>

--- a/df.jobs.xml
+++ b/df.jobs.xml
@@ -703,6 +703,7 @@
         <int32_t name='item_flag3'/>
         <int32_t name='item_flag4'/>
         <int32_t name='item_flag5'/>
+        <int32_t name='id_number'/>
         <stl-string name='item_reaction_class'/>
         <stl-string name='item_reaction_product_class'/>
         <int32_t name='metal_ore'/>

--- a/df.refs.xml
+++ b/df.refs.xml
@@ -344,11 +344,11 @@
     <class-type type-name='general_ref_entity_offeredst' inherits-from='general_ref_entity'/>
     <class-type type-name='general_ref_entity_itemownerst' inherits-from='general_ref_entity'/>
 
-    <enum-type type-name='specific_ref_type'>
+    <enum-type type-name='specific_ref_type'> Bay12: ReferenceType
         <enum-attr name='union_field'/>
 
         <enum-item name='NONE' value='-1'/>
-        <enum-item/>
+        <enum-item name='BUILDING'/>
         <enum-item name='UNIT'>
             <item-attr name='union_field' value='unit'/>
         </enum-item>
@@ -400,7 +400,7 @@
         <enum-item name='ART_IMAGE'/>
         <enum-item name='CREATURE_DEF'/>
         <enum-item name='ENTITY_ART_IMAGE' comment='unused?'/>
-        <enum-item/>
+        <enum-item name='ABSTRACT_BUILDING'/>
         <enum-item name='ENTITY_POPULATION'/>
         <enum-item name='BREED'/>
     </enum-type>

--- a/df.unit-thoughts.xml
+++ b/df.unit-thoughts.xml
@@ -611,7 +611,7 @@
     </enum-type>
 
 
-    <enum-type type-name='unit_thought_type'>
+    <enum-type type-name='unit_thought_type' original-name='Circumstance'>
         <enum-attr name='caption'/>
         <enum-attr name='xml_caption'/>
 

--- a/df.unit-thoughts.xml
+++ b/df.unit-thoughts.xml
@@ -611,7 +611,7 @@
     </enum-type>
 
 
-    <enum-type type-name='unit_thought_type' original-name='Circumstance'>
+    <enum-type type-name='unit_thought_type'> original name is 'Circumstance'
         <enum-attr name='caption'/>
         <enum-attr name='xml_caption'/>
 

--- a/df.units.xml
+++ b/df.units.xml
@@ -1815,7 +1815,7 @@
             <flag-bit name='marry_female'/>
     </bitfield-type>
 
-    <struct-type type-name='unit_soul'>
+    <struct-type type-name='unit_soul' original-name='soulst'>
         <int32_t name='id'/>
 
         <compound name='name' type-name='language_name'/>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -357,7 +357,8 @@
     </struct-type>  --  Cannot rule out the type having additional fields, although the 8 following bytes were all 0 in all cases in the save examined.
 
     <struct-type type-name='world_site' key-field='id'
-                 instance-vector='$global.world.world_data.sites'>
+                 instance-vector='$global.world.world_data.sites'
+                 original-name='sitest'>
         <compound name='name' type-name='language_name'/>
 
         <code-helper name='describe'>(describe-obj $.name)</code-helper>


### PR DESCRIPTION
this PR updates several structures definitions with information from the headers provided to us by bay12

some infrequently used types have been renamed (most notably `job_cancel`, which is a research-only type at this point), while more frequently used types have had their bay12 names logged (as `original-name` when our DTD allows it, as a comment when it does not) without changing their names in dfhack. a couple of enums had `NONE` (-1) values that we did not previously have in our definitions

none of these changes should have any implications for existing code