### PR TITLE
update & rename some intrigue/crime related types

### DIFF
--- a/df.history.xml
+++ b/df.history.xml
@@ -250,7 +250,7 @@
             <int32_t name='unk_10' init-value='-1' comment="All are gods with the DEATH sphere having created slabs, but the value isn't the id of the slab"/>
             <stl-vector name='known_written_contents' type-name='int32_t' ref-target='written_content' comment="ID of written_contents known to the historical figure. Aside from the contents of read books, these so-called written contents also include known derivations of poetic forms, dance forms and musical forms" since='v0.42.01'/>
             <stl-vector name="known_identities" type-name='int32_t' ref-target='identity' comment="identity ID of identities known to the historical figure, such as demon true names"/>
-            <stl-vector name='known_witness_reports' pointer-type='witness_report'/>
+            <stl-vector name='known_witness_reports' pointer-type='witness_incidentst'/>
             <stl-vector name='known_events' pointer-type='entity_event'/>
             <stl-vector name='unk_4' type-name='int32_t'/>
             <stl-vector name='unk_5' type-name='int32_t'/>

--- a/df.units.xml
+++ b/df.units.xml
@@ -1102,7 +1102,8 @@
             <int32_t name='interaction' refers-to='$$._global.body.body_plan.interactions[$]' since='v0.34.01' comment='is set when a RETRACT_INTO_BP interaction is active'/>
 
             <stl-vector name='appearances' pointer-type='unit_appearance'/>
-            <stl-vector name='witness_reports' pointer-type='witness_report'/>
+                svector((physical_formst *)) physical_form
+            <stl-vector name='witness_reports' pointer-type='witness_incidentst'/>
 
             <stl-vector name='unk_a5c' pointer-type='entity_event'/>
             <static-array name='gait_index' type-name='int32_t' count='5' index-enum='gait_type'/>
@@ -1256,31 +1257,29 @@
         </virtual-methods>
     </class-type>
 
-    <enum-type type-name='witness_report_type' base-type='int32_t'>
-        <enum-item name='None' value='-1'/>
-        <enum-item name='WitnessedCrime'/>
-        <enum-item name='FoundCorpse'/>
-    </enum-type>
-
     <bitfield-type type-name='witness_report_flags'>
-        <flag-bit name='accuses'/>
+        <flag-bit name='HAVE_SET_RPHS'/>
+        <flag-bit name='DO_NOT_SEARCH_WI_IF_NULL'/>
+        <flag-bit name='INCIDENT_NO_RUMOR_DATA_IF_WI_SET'/>
+        <flag-bit name='KNOW_NAME_OF_RELEVANT_HF_BY_OTHER_MEANS'/>
     </bitfield-type>
 
-    <struct-type type-name='witness_report'>
-        <int32_t name='death_id' ref-target='incident'/>
+    <struct-type type-name='witness_incidentst'>
+        <int32_t name='incident_id' ref-target='incident'/>
         <int32_t name='crime_id' ref-target='crime'/>
-        <enum name='type' type-name='witness_report_type'/>
+        <enum type-name='witness_type' name='type'/>
         <int32_t name='year'/>
         <int32_t name='year_tick'/>
         <bitfield name='flags' type-name='witness_report_flags'/>
-        <int32_t name='unk_18' init-value='-1' since='v0.47.01'/>
-        <int32_t name='unk_1c' init-value='-1' since='v0.47.01'/>
-        <int32_t name='unk_20' init-value='-1' since='v0.47.01'/>
-        <int32_t name='unk_24' init-value='-1' since='v0.47.01'/>
-        <int32_t name='unk_28' init-value='-1' since='v0.47.01'/>
-        <int32_t name='unk_2c' init-value='-1' since='v0.47.01'/>
-        <int32_t name='unk_30' init-value='-1' since='v0.47.01' ref-target='historical_figure'/>
-        <int32_t name='unk_34' init-value='-1' since='v0.47.01' ref-target='identity'/>
+        this looks like it "should be" two structures of the same type, but they're flat in bay12 code
+        <int32_t name='relevant_hfid' init-value='-1' since='v0.47.01' ref-target='historical_figure'/>
+        <int32_t name='relevant_visual_hfid' init-value='-1' since='v0.47.01' ref-target='historical_figure'/>
+        <int32_t name='relevant_historical_hfid' init-value='-1' since='v0.47.01' ref-target='historical_figure'/>
+        <int32_t name='relevant_ident_id' init-value='-1' since='v0.47.01' ref-target='identity'/>
+        <int32_t name='ic_hfid' init-value='-1' since='v0.47.01' ref-target='historical_figure'/>
+        <int32_t name='ic_visual_hfid' init-value='-1' since='v0.47.01' ref-target='historical_figure'/>
+        <int32_t name='ic_historical_hfid' init-value='-1' since='v0.47.01' ref-target='historical_figure'/>
+        <int32_t name='ic_ident_id' init-value='-1' since='v0.47.01' ref-target='identity'/>
         <compound type-name='coord' name='pos' since='v0.47.01'/>
     </struct-type>
 

--- a/df.world.xml
+++ b/df.world.xml
@@ -319,7 +319,7 @@
         <enum-item name='COCONSPIRATOR_IMPLICATED'/>
     </enum-type>
 
-    <struct-type type-name='witness_reportst' original-type='witness_reportst'>
+    <struct-type type-name='witness_reportst'>
         <int32_t name='incident_id' ref-target='incident' init-value='-1'/>
         <int32_t name='crime_id' ref-target='crime' init-value='-1'/>
         <enum type-name='witness_type' name='type' init-value='NONE'/>

--- a/df.world.xml
+++ b/df.world.xml
@@ -63,11 +63,11 @@
         <enum-item name='NoQuarter'/>
     </enum-type>
 
-    <struct-type type-name='incident_hfid'>
-        <int32_t name="hfid" ref-target='historical_figure' since='v0.40.01'/>
-        <int32_t name='unk_hfid' ref-target='historical_figure' since='v0.44.01' comment="same as hfid seen"/>
-        <int32_t name='unk_hfid2' ref-target='historical_figure' since='v0.44.01' comment="same as hfid seen"/>
-        <stl-vector name='unk_3' type-name='int32_t' ref-target='identity' since='v0.44.01'/>
+    <struct-type type-name='incident_hfid' original-name='incident_hfst'>
+        <int32_t name="hfid" init-value='-1' ref-target='historical_figure' since='v0.40.01' comment="bay12: true hf of incident"/>
+        <int32_t name='visual_hfid' init-value='-1' ref-target='historical_figure' since='v0.44.01' comment="bay12: basic visual id"/>
+        <int32_t name='historical_hfid' init-value='-1' ref-target='historical_figure' since='v0.44.01' comment="bay12: if any witness knew actual name"/>
+        <stl-vector name='all_witnessed_ident' type-name='int32_t' ref-target='identity' since='v0.44.01'/>
     </struct-type>
 
     <struct-type type-name='incident'
@@ -304,32 +304,33 @@
             </pointer>
         </stl-vector>
 
-        <stl-vector name='witnesses' pointer-type='crime_witness'/>
+        <stl-vector name='witnesses' pointer-type='witness_reportst'/>
         <int32_t name='agreement_id' ref-target='agreement'/>
     </struct-type>
 
-    <struct-type type-name='crime_witness'>
-        <int32_t name='incident_id' ref-target='incident'/>
-        <int32_t name='crime_id' ref-target='crime'/>
-        <enum name='witness_claim'>
-            <enum-item name='SawDisorderlyConduct'/>
-            <enum-item name='FoundTheBody'/>
-            <enum-item name='SawObjectWasMissing'/>
-            <enum-item name='SawObjectWasDisturbed'/>
-            <enum-item name='SawSomebodyAdmireObject'/>
-            <enum-item name='Confessed'/>
-            <enum-item name='ImplicatesSomeone'/>
-            <enum-item name='AccusesSomeone'/>
-        </enum>
-        <int32_t name='year'/>
-        <int32_t name='tick'/>
-        <int32_t name='witness_id' ref-target='unit'/>
-        <compound name='witness_data' type-name='incident_hfid'/>
-        <int32_t name='accused_id' ref-target='unit'/>
-        <int32_t name='accused_identity_id' ref-target='identity'/>
-        <compound name='accused_data' type-name='incident_hfid'/>
-        <int32_t name='reported_year'/>
-        <int32_t name='reported_tick'/>
+    <enum-type type-name='witness_type' base-type='int32_t'> bay12: Witness
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='SAW_ACTUAL_INCIDENT'/>
+        <enum-item name='FOUND_BODY'/>
+        <enum-item name='SAW_THAT_OBJECT_WAS_MISSING'/>
+        <enum-item name='SAW_DISTURBED_OBJECT'/>
+        <enum-item name='SOMEBODY_ADMIRED_OBJECT'/>
+        <enum-item name='CONFESSED'/>
+        <enum-item name='COCONSPIRATOR_IMPLICATED'/>
+    </enum-type>
+
+    <struct-type type-name='witness_reportst' original-type='witness_reportst'>
+        <int32_t name='incident_id' ref-target='incident' init-value='-1'/>
+        <int32_t name='crime_id' ref-target='crime' init-value='-1'/>
+        <enum type-name='witness_type' name='type' init-value='NONE'/>
+        <int32_t name='year' init-value='0'/>
+        <int32_t name='year_tick' init-value='0'/>
+        <int32_t name='witness_id' ref-target='unit' init-value='-1'/>
+        <compound name='witness_ihf' type-name='incident_hfid' init-value='-1'/>
+        <int32_t name='accused_id' ref-target='unit' init-value='-1'/>
+        <compound name='accused_ihf' type-name='incident_hfid' init-value='-1'/>
+        <int32_t name='reported_year' init-value='0'/>
+        <int32_t name='reported_year_tick' init-value='0'/>
     </struct-type>
 
     <struct-type type-name='mission_campaign_report'>


### PR DESCRIPTION
`witness_report` -> `witness_incidentst`
`crime_witness` -> `witness_reportst`

our names for these types were similar to bay12's name in a way that was going to be perpetually confusing

also unified and corrected the `witness_type` enum (bay12: `Witness`) which was incorrect in both places it appeared separately