### PR TITLE
Update job_skill's labor attribute

### DIFF
--- a/df.skills.xml
+++ b/df.skills.xml
@@ -1263,7 +1263,7 @@
             <item-attr name='caption' value='Engraving'/>
             <item-attr name='caption_noun' value='Engraver'/>
             <item-attr name='profession' value='ENGRAVER'/>
-            <!-- <item-attr name='labor' value='DETAIL'/> -->
+            <item-attr name='labor' value='ENGRAVER'/>
         </enum-item>
         <enum-item name='MASONRY'>
             <item-attr name='caption' value='Masonry'/>
@@ -1514,6 +1514,7 @@
             <item-attr name='caption' value='Crossbow'/>
             <item-attr name='caption_noun' value='Crossbowman'/>
             <item-attr name='profession' value='CROSSBOWMAN'/>
+            <item-attr name='labor' value='HUNT'/>
             <item-attr name='type' value='MilitaryWeapon'/>
         </enum-item>
         <enum-item name='SHIELD'>
@@ -1563,6 +1564,7 @@
             <item-attr name='caption' value='Bow'/>
             <item-attr name='caption_noun' value='Bowman'/>
             <item-attr name='profession' value='BOWMAN'/>
+            <item-attr name='labor' value='HUNT'/>
             <item-attr name='type' value='MilitaryWeapon'/>
         </enum-item>
         <enum-item name='BLOWGUN'>
@@ -1831,6 +1833,7 @@
         <enum-item name='RANGED_COMBAT'>
             <item-attr name='caption' value='Archery'/>
             <item-attr name='caption_noun' value='Archer'/>
+            <item-attr name='labor' value='HUNT'/>
             <item-attr name='type' value='MilitaryAttack'/>
         </enum-item>
         <enum-item name='WRESTLING'>
@@ -2028,11 +2031,13 @@
         <enum-item name='CUT_STONE'>
             <item-attr name='caption' value='Cut Stone'/>
             <item-attr name='caption_noun' value='Stonecutter'/>
+            <item-attr name='labor' value='STONECUTTER'/>
         </enum-item>
 
         <enum-item name='CARVE_STONE'>
             <item-attr name='caption' value='Carve Stone'/>
             <item-attr name='caption_noun' value='Stonecarver'/>
+            <item-attr name='labor' value='STONE_CARVER'/>
         </enum-item>
 
         <enum-item name='MODSKILL01'>


### PR DESCRIPTION
Based on skill displayed in the work detail screen.

`HUNT` labor is associated with multiple skills. I did not find any usage that would break from that kind of change (I did not find any usage for this attribute actually except [mine](https://github.com/cvuchener/df-workdetailtest/blob/911c94ebfb482cf6c670945676f8cd166978e295/src/WorkDetailColumn.cpp#L103-L105)).