### PR TITLE
change `unitst::owned_buildings` to `vector<building_civzonest*>`

### DIFF
--- a/df.units.xml
+++ b/df.units.xml
@@ -766,7 +766,7 @@
 
         <stl-vector name='owned_items' type-name='int32_t' ref-target='item'/>
         <stl-vector name='traded_items' comment='items brought to trade depot' type-name='int32_t' ref-target='item'/>
-        <stl-vector name='owned_buildings' pointer-type='building'/>
+        <stl-vector name='owned_buildings' pointer-type='building_civzonest' comment='bay12: zone_assigned'/>
         <stl-vector name='corpse_parts' comment='entries remain even when items are destroyed' type-name='int32_t' ref-target='item'/>
 
         <int32_t name='riding_item_id' ref-target='item' since='v0.34.08'/>


### PR DESCRIPTION
This change is based on analysis of bay12-provided information and correctly reflects the actual type in the structure

This change requires a coordinated change to DFHack - see DFHack/DFHack#4068
