### PR TITLE
Update announcement enums from g_src/basics.h

### DIFF
--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -393,13 +393,6 @@
         <enum-item name='SATISFIED_MONARCH' since='v0.50.01'/>
         <enum-item name='MOUNTAINHOME' since='v0.50.01'/>
         <enum-item name='FOOD_WARNING' since='v0.50.01'/>
-
-        <enum-item name='UNUSED_46'/>
-        <enum-item name='UNUSED_47'/>
-        <enum-item name='UNUSED_48'/>
-        <enum-item name='UNUSED_49'/>
-        <enum-item name='UNUSED_50'/>
-        <enum-item name='num'/>
     </enum-type>
 
     <enum-type type-name='announcement_alert_type' base-type='int32_t'>
@@ -441,7 +434,6 @@
         <enum-item name='COMBAT'/>
         <enum-item name='SPARRING'/>
         <enum-item name='HUNTING'/>
-        <enum-item name='num'/>
     </enum-type>
 
     <bitfield-type type-name='announcement_flags'>
@@ -521,8 +513,8 @@
         <int16_t name='display_timer' init-value='2000' comment='graphical frames for announcement bar to linger on last line with no new announcement'/>
         <pointer type-name='unit' name='unit_a'/>
         <pointer type-name='unit' name='unit_d'/>
-        <int32_t name='activity_id' init-value='-1' comment='same as unknown field in report'/>
-        <int32_t name='activity_event_id' init-value='-1' comment='same as unknown field in report'/>
+        <int32_t name='activity_id' init-value='-1' comment='same as field in report'/>
+        <int32_t name='activity_event_id' init-value='-1' comment='same as field in report'/>
         <int32_t name='speaker_id' ref-target='unit'/>
         <bitfield base-type='uint8_t' name='flags'>
             <flag-bit name='hostile_combat' comment='hunting or combat report, not sparring'/>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -455,7 +455,7 @@
 
     <struct-type type-name='announcements'>
         <static-array name='flags' type-name='announcement_flags'
-                      count='354' index-enum='announcement_type'/> c
+                      count='354' index-enum='announcement_type'/>
     </struct-type>
 
     <struct-type type-name='report' original-name='announcementst'

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -393,6 +393,12 @@
         <enum-item name='SATISFIED_MONARCH' since='v0.50.01'/>
         <enum-item name='MOUNTAINHOME' since='v0.50.01'/>
         <enum-item name='FOOD_WARNING' since='v0.50.01'/>
+
+        <enum-item name='UNUSED_46'/>
+        <enum-item name='UNUSED_47'/>
+        <enum-item name='UNUSED_48'/>
+        <enum-item name='UNUSED_49'/>
+        <enum-item name='UNUSED_50'/>
     </enum-type>
 
     <enum-type type-name='announcement_alert_type' base-type='int32_t'>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -1,5 +1,6 @@
 <data-definition>
     <enum-type type-name='announcement_type' base-type='int16_t'>
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='REACHED_PEAK'/>
         <enum-item name='ERA_CHANGE'/>
         <enum-item name='FEATURE_DISCOVERY'/>
@@ -399,10 +400,10 @@
         <enum-item name='UNUSED_49'/>
         <enum-item name='UNUSED_50'/>
         <enum-item name='num'/>
-        <enum-item name='NONE' value='-1'/>
     </enum-type>
 
     <enum-type type-name='announcement_alert_type' base-type='int32_t'>
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='GENERAL'/>
         <enum-item name='ERA_CHANGE'/>
         <enum-item name='UNDERGROUND'/>
@@ -441,7 +442,6 @@
         <enum-item name='SPARRING'/>
         <enum-item name='HUNTING'/>
         <enum-item name='num'/>
-        <enum-item name='NONE' value='-1'/>
     </enum-type>
 
     <bitfield-type type-name='announcement_flags'>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -455,8 +455,7 @@
 
     <struct-type type-name='announcements'>
         <static-array name='flags' type-name='announcement_flags'
-                      count='349' index-enum='announcement_type'/>
-        <pointer name='unused' comment='needed to fix alignment on 64-bit platforms'/>
+                      count='354' index-enum='announcement_type'/> c
     </struct-type>
 
     <struct-type type-name='report' original-name='announcementst'

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -392,6 +392,14 @@
         <enum-item name='SATISFIED_MONARCH' since='v0.50.01'/>
         <enum-item name='MOUNTAINHOME' since='v0.50.01'/>
         <enum-item name='FOOD_WARNING' since='v0.50.01'/>
+
+        <enum-item name='UNUSED_46'/>
+        <enum-item name='UNUSED_47'/>
+        <enum-item name='UNUSED_48'/>
+        <enum-item name='UNUSED_49'/>
+        <enum-item name='UNUSED_50'/>
+        <enum-item name='num'/>
+        <enum-item name='NONE' value='-1'/>
     </enum-type>
 
     <bitfield-type type-name='announcement_flags'>
@@ -404,6 +412,48 @@
         <flag-bit name='UNIT_COMBAT_REPORT_ALL_ACTIVE' comment='UCR_A'/>
         <flag-bit name='ALERT' comment='ALERT' since='v0.50.01'/>
     </bitfield-type>
+
+    <enum-type type-name='announcement_alert_type' base-type='int32_t'>
+        <enum-item name='GENERAL'/>
+        <enum-item name='ERA_CHANGE'/>
+        <enum-item name='UNDERGROUND'/>
+        <enum-item name='MIGRANT'/>
+        <enum-item name='MONSTER'/>
+        <enum-item name='AMBUSH'/>
+        <enum-item name='TRADE'/>
+        <enum-item name='NOBLE'/>
+        <enum-item name='ANIMAL'/>
+        <enum-item name='BIRTH'/>
+        <enum-item name='MOOD'/>
+        <enum-item name='LABOR_CHANGE'/>
+        <enum-item name='MILITARY'/>
+        <enum-item name='MARRIAGE'/>
+        <enum-item name='BERSERK'/>
+        <enum-item name='MARTIAL_TRANCE'/>
+        <enum-item name='LOSE_EMOTION'/>
+        <enum-item name='STRESS'/>
+        <enum-item name='ART_DEFACEMENT'/>
+        <enum-item name='MASTERPIECE'/>
+        <enum-item name='JOB_FAILED'/>
+        <enum-item name='DEATH'/>
+        <enum-item name='GHOST'/>
+        <enum-item name='UNDEAD_ATTACK'/>
+        <enum-item name='WEATHER'/>
+        <enum-item name='VERMIN'/>
+        <enum-item name='CURIOUS_GUZZLER'/>
+        <enum-item name='RESEARCH_BREAKTHROUGH'/>
+        <enum-item name='GUEST_ARRIVAL'/>
+        <enum-item name='HOLDINGS'/>
+        <enum-item name='RUMOR'/>
+        <enum-item name='AGREEMENT'/>
+        <enum-item name='CRIME'/>
+        <enum-item name='DEITY_CURSE'/>
+        <enum-item name='COMBAT'/>
+        <enum-item name='SPARRING'/>
+        <enum-item name='HUNTING'/>
+        <enum-item name='num'/>
+        <enum-item name='NONE' value='-1'/>
+    </enum-type>
 
     <struct-type type-name='announcements'>
         <static-array name='flags' type-name='announcement_flags'

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -402,17 +402,6 @@
         <enum-item name='NONE' value='-1'/>
     </enum-type>
 
-    <bitfield-type type-name='announcement_flags'>
-        <flag-bit name='DO_MEGA' comment='BOX'/>
-        <flag-bit name='PAUSE' comment='P'/>
-        <flag-bit name='RECENTER' comment='R'/>
-        <flag-bit name='A_DISPLAY' comment='A_D'/>
-        <flag-bit name='D_DISPLAY' comment='D_D'/>
-        <flag-bit name='UNIT_COMBAT_REPORT' comment='UCR'/>
-        <flag-bit name='UNIT_COMBAT_REPORT_ALL_ACTIVE' comment='UCR_A'/>
-        <flag-bit name='ALERT' comment='ALERT' since='v0.50.01'/>
-    </bitfield-type>
-
     <enum-type type-name='announcement_alert_type' base-type='int32_t'>
         <enum-item name='GENERAL'/>
         <enum-item name='ERA_CHANGE'/>
@@ -454,6 +443,17 @@
         <enum-item name='num'/>
         <enum-item name='NONE' value='-1'/>
     </enum-type>
+
+    <bitfield-type type-name='announcement_flags'>
+        <flag-bit name='DO_MEGA' comment='BOX'/>
+        <flag-bit name='PAUSE' comment='P'/>
+        <flag-bit name='RECENTER' comment='R'/>
+        <flag-bit name='A_DISPLAY' comment='A_D'/>
+        <flag-bit name='D_DISPLAY' comment='D_D'/>
+        <flag-bit name='UNIT_COMBAT_REPORT' comment='UCR'/>
+        <flag-bit name='UNIT_COMBAT_REPORT_ALL_ACTIVE' comment='UCR_A'/>
+        <flag-bit name='ALERT' comment='ALERT' since='v0.50.01'/>
+    </bitfield-type>
 
     <struct-type type-name='announcements'>
         <static-array name='flags' type-name='announcement_flags'


### PR DESCRIPTION
From current available [g_src/basics.h](https://github.com/Putnam3145/Dwarf-Fortress--libgraphics--/blob/172e9946f95019edf6083cefe3328eb1d6d4079b/g_src/basics.h#L489):

Update `announcement_type` enum with `UNUSED` and `num` entries.
Create `announcement_alert_type` enum for future use.