### PR TITLE
brutal hack to support `std::variant`

### DIFF
--- a/StructFields.pm
+++ b/StructFields.pm
@@ -73,6 +73,22 @@ sub get_container_item_type($;%) {
     }
 }
 
+sub get_variant_item_type($;%) {
+    my ($tag, %flags) = @_;
+    my ($rawtype) = $tag->getAttribute('raw-type');
+    if ($rawtype) {
+        return $rawtype;
+    }
+    my @items = $tag->findnodes('ld:item');
+    if (@items) {
+        return get_struct_field_type($items[0], -local => $in_struct_body, %container_flags, %flags);
+    } elsif ($flags{-void}) {
+        return $flags{-void};
+    } else {
+        die "Container without element: $tag\n";
+    }
+}
+
 sub get_container_count($;%) {
     my ($tag) = @_;
     my $count = $tag->getAttribute('count');
@@ -155,6 +171,11 @@ my %custom_container_handlers = (
         my $item = get_container_item_type($_, -void => 'void');
         header_ref("optional");
         return "std::optional<$item >";
+    },
+    'stl-variant' => sub {
+        my $item = get_variant_item_type($_, -void => 'void');
+        header_ref("variant");
+        return "std::variant<$item >"; # TODO handle more than one type?
     },
     'stl-shared-ptr' => sub {
         my $item = get_container_item_type($_, -void => 'void');

--- a/data-definition.xsd
+++ b/data-definition.xsd
@@ -229,6 +229,7 @@
             <xs:element name="stl-optional" type="StlOptionalField" />
             <xs:element name="stl-shared-ptr" type="StlSharedPtrField" />
             <xs:element name="stl-function" type="StlFunctionField" />
+            <xs:element name="stl-variant" type="StlVariantField" />
             <xs:element name="df-linked-list" type="DfLinkedListField" />
             <xs:element name="df-array" type="DfArrayField" />
             <xs:element name="df-flagarray" type="DfFlagArrayField" />
@@ -305,6 +306,8 @@
                     <xs:group ref="CompoundField" />
                 </xs:choice>
                 <xs:attribute name="type-name">
+                </xs:attribute>
+                <xs:attribute name="raw-type">
                 </xs:attribute>
             </xs:extension>
         </xs:complexContent>
@@ -397,6 +400,12 @@
         </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="StlOptionalField">
+        <xs:complexContent>
+            <xs:extension base="ContainerFieldType">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="StlVariantField">
         <xs:complexContent>
             <xs:extension base="ContainerFieldType">
             </xs:extension>

--- a/lower-1.xslt
+++ b/lower-1.xslt
@@ -339,7 +339,7 @@ Error: field <xsl:value-of select='$enum-key'/> corresponds to an enum value of 
     </xsl:template>
 
     <!-- Misc containers: meta='container' subtype='$tag' -->
-    <xsl:template match='stl-vector|stl-deque|stl-set|stl-bit-vector|stl-map|stl-unordered-map|stl-optional|stl-shared-ptr|stl-function|df-flagarray|df-static-flagarray|df-array|df-linked-list'>
+    <xsl:template match='stl-vector|stl-deque|stl-set|stl-bit-vector|stl-map|stl-unordered-map|stl-optional|stl-variant|stl-shared-ptr|stl-function|df-flagarray|df-static-flagarray|df-array|df-linked-list'>
         <xsl:param name='level' select='-1'/>
         <ld:field ld:meta='container'>
             <xsl:attribute name='ld:level'><xsl:value-of select='$level'/></xsl:attribute>


### PR DESCRIPTION
this is a fairly brutal hack to allow `std::variant` to appear in structures

the attribute `raw-type` is used to specify the C++ type string that will appear between the brackets when instantiating the type. no processing of this type is done by codegen. note that `<` and `>` are special in XML and will have to be substituted by `&lt;` and `&gt;`

note also that this does not deal with identity trait issues at all; an `OPAQUE_IDENTITY_TRAIT` will be needed to be added to `DataIdentity.h` and `DataIdentity.cpp` for each specialization of `std::variant` that results from the use of this specification