### PR TITLE
Fix game_mode and game_type enums

### DIFF
--- a/df.globals.xml
+++ b/df.globals.xml
@@ -85,13 +85,13 @@
     </global-object>
 
     <enum-type type-name='game_mode'>
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='DWARF'/>
         <enum-item name='ADVENTURE'/>
-        <enum-item name='num'/>
-        <enum-item name='NONE'/>
     </enum-type>
 
     <enum-type type-name='game_type'>
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='DWARF_MAIN'/>
         <enum-item name='ADVENTURE_MAIN'/>
         <enum-item name='VIEW_LEGENDS'/>
@@ -102,8 +102,6 @@
         <enum-item name='DWARF_TUTORIAL'/>
         <enum-item name='DWARF_UNRETIRE'/>
         <enum-item name='ADVENTURE_WORLD_DEBUG'/>
-        <enum-item name='num'/>
-        <enum-item name='NONE'/>
     </enum-type>
 
     <global-object name='gamemode'>


### PR DESCRIPTION
Fix `game_mode` and `game_type` enums by removing `num` value and setting `NONE` to `-1`.