### PR TITLE
Identify music and sound raws; plotinfo.unk23c8_flags.caverns_opened

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,11 +19,15 @@ Template for new versions:
 # Future
 
 ## Structures
-- ``markup_text_boxst``: updated based on information from bay12
+- ``markup_text_boxst``: updated based on information from Bay12
 - ``markup_text_linkst``, ``markup_text_wordst``, ``script_environmentst``: defined
-- ``plotinfost``: ``unk23c8_flags`` renamed to ``flags``, updated based on information from bay12
+- ``plotinfost``: ``unk23c8_flags`` renamed to ``flags``, updated based on information from Bay12
 - ``world_raws``: ``unk_v50_1``, ``unk_v50_2``, ``unk_v50_3`` renamed to ``text_set``, ``music``, ``sound``
 - ``soundst``: defined
+- ``announcement_alertst``: defined
+- ``announcement_alert_type``: enum defined
+- ``announcement_type``: added ``alert_type`` enum attribute
+- ``alert_button_announcement_id``: now int32_t vector (contains report ids)
 
 # 50.11-r4
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,9 @@ Template for new versions:
 ## Structures
 - ``markup_text_boxst``: updated based on information from bay12
 - ``markup_text_linkst``, ``markup_text_wordst``, ``script_environmentst``: defined
+- ``plotinfost``: `unk23c8_flags` renamed to `flags`, updated based on information from bay12
+- ``world_raws``: `unk_v50_1`, `unk_v50_2`, `unk_v50_3` renamed to `text_set`, `music`, `sound`
+- ``soundst``: defined
 
 # 50.11-r4
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,8 +21,8 @@ Template for new versions:
 ## Structures
 - ``markup_text_boxst``: updated based on information from bay12
 - ``markup_text_linkst``, ``markup_text_wordst``, ``script_environmentst``: defined
-- ``plotinfost``: `unk23c8_flags` renamed to `flags`, updated based on information from bay12
-- ``world_raws``: `unk_v50_1`, `unk_v50_2`, `unk_v50_3` renamed to `text_set`, `music`, `sound`
+- ``plotinfost``: ``unk23c8_flags`` renamed to ``flags``, updated based on information from bay12
+- ``world_raws``: ``unk_v50_1``, ``unk_v50_2``, ``unk_v50_3`` renamed to ``text_set``, ``music``, ``sound``
 - ``soundst``: defined
 
 # 50.11-r4

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -1221,7 +1221,7 @@
         <enum base-type='int32_t' type-name='announcement_alert_type' name='type'/>
         <stl-vector name='announcement_id' type-name='int32_t'/>
         <stl-vector name='report_unid' type-name='int32_t' comment='unit id'/>
-        <stl-vector name='report_unit_announcement_category'>
+        <stl-vector name='report_unit_announcement_category' comment='vector must be same length as report_unid'>
             <enum type-name='unit_report_type'/>
         </stl-vector>
     </struct-type>

--- a/df.raws.xml
+++ b/df.raws.xml
@@ -208,7 +208,7 @@
             <stl-vector/>
         </compound>
 
-        <compound name='sound'>
+        <compound name='sounds'>
             <stl-vector/>
         </compound>
 

--- a/df.raws.xml
+++ b/df.raws.xml
@@ -199,7 +199,7 @@
 
         -- Unknown new stuff
 
-        <compound name='unk_v50_1'>
+        <compound name='text_set'>
             <stl-vector/>
             <static-array count='63' type-name='int32_t'/>
         </compound>
@@ -208,7 +208,7 @@
             <stl-vector/>
         </compound>
 
-        <compound name='sounds'>
+        <compound name='sound'>
             <stl-vector/>
         </compound>
 

--- a/df.raws.xml
+++ b/df.raws.xml
@@ -25,6 +25,20 @@
         </virtual-methods>
     </class-type>
 
+    <class-type type-name='soundst'>
+        <stl-string name='token'/>
+        <int32_t name='index'/>
+        <stl-vector name='current_definition'>
+            <stl-string/>
+        </stl-vector>
+        <int32_t name='source_hfid'/>
+        <int32_t name='source_enid'/>
+        <int32_t name='sound' comment='index of sound to be played'/>
+        <stl-vector name='announcement' comment='sound can be selected for these announcement types'>
+            <enum type-name='announcement_type'/>
+        </stl-vector>
+    </class-type>
+
     <struct-type type-name='world_raws'>
         !! in bay12 each of these is its own compound and some of them are classes with their own methods !!
 
@@ -197,19 +211,21 @@
 
         <stl-vector name='interactions' since='v0.34.01' pointer-type='interaction'/>
 
-        -- Unknown new stuff
+        -- Text set
 
-        <compound name='text_set'>
+        <compound name='text_set' comment='type text_set_handlerst'>
             <stl-vector/>
             <static-array count='63' type-name='int32_t'/>
         </compound>
 
-        <compound name='music'>
-            <stl-vector/>
+        -- Audio
+        
+        <compound name='music' comment='type music_handlerst'>
+            <stl-vector name='music'/>
         </compound>
 
-        <compound name='sound'>
-            <stl-vector/>
+        <compound name='sound' comment='type sound_handlerst'>
+            <stl-vector name='sound' pointer-type='soundst'/>
         </compound>
 
         -- Material index

--- a/df.raws.xml
+++ b/df.raws.xml
@@ -219,7 +219,7 @@
         </compound>
 
         -- Audio
-        
+
         <compound name='music' comment='type music_handlerst'>
             <stl-vector name='music'/>
         </compound>

--- a/df.raws.xml
+++ b/df.raws.xml
@@ -213,18 +213,18 @@
 
         -- Text set
 
-        <compound name='text_set' comment='type text_set_handlerst'>
+        <compound name='text_set'>
             <stl-vector/>
             <static-array count='63' type-name='int32_t'/>
         </compound>
 
         -- Audio
 
-        <compound name='music' comment='type music_handlerst'>
+        <compound name='music'>
             <stl-vector name='music'/>
         </compound>
 
-        <compound name='sound' comment='type sound_handlerst'>
+        <compound name='sound'>
             <stl-vector name='sound' pointer-type='soundst'/>
         </compound>
 

--- a/df.raws.xml
+++ b/df.raws.xml
@@ -28,9 +28,8 @@
     <class-type type-name='soundst'>
         <stl-string name='token'/>
         <int32_t name='index'/>
-        <stl-vector name='current_definition'>
-            <stl-string/>
-        </stl-vector>
+        <stl-vector name='current_definition' pointer-type='stl-string'/>
+        <df-flagarray name='flag'/>
         <int32_t name='source_hfid'/>
         <int32_t name='source_enid'/>
         <int32_t name='sound' comment='index of sound to be played'/>

--- a/df.raws.xml
+++ b/df.raws.xml
@@ -204,11 +204,11 @@
             <static-array count='63' type-name='int32_t'/>
         </compound>
 
-        <compound name='unk_v50_2'>
+        <compound name='music'>
             <stl-vector/>
         </compound>
 
-        <compound name='unk_v50_3'>
+        <compound name='sound'>
             <stl-vector/>
         </compound>
 

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -350,15 +350,15 @@
         <stl-vector name='economic_stone' type-name='bool'
                     index-refers-to='(material-by-id 0 $)'/>
 
-        <bitfield name='unk23c8_flags'>
-            <flag-bit name='first_year'/>
-            <flag-bit name='recheck_aid_requests'/>
-            <flag-bit name='force_elections'/>
-            <flag-bit/>
-            <flag-bit/>
-            <flag-bit/>
-            <flag-bit/>
-            <flag-bit name='caverns_opened'/>
+        <bitfield name='flags'>
+            <flag-bit name='first_year' comment='(FIRSTYEAR)'/>
+            <flag-bit name='recheck_aid_requests' comment='(EVAL_REQUESTERCANCHECK)'/>
+            <flag-bit name='force_elections' comment='(RUN_SPECIAL_ELECTIONS)'/>
+            <flag-bit name='need_to_do_tutorial' comment='(NEED_TO_DO_TUTORIAL)'/>
+            <flag-bit name='minor_victory' comment='(MINOR_VICTORY)'/>
+            <flag-bit name='major_victory' comment='(MAJOR_VICTORY)'/>
+            <flag-bit name='did_first_caravan_announcement' comment='(DID_FIRST_CARAVAN_ANNOUNCEMENT)'/>
+            <flag-bit name='did_first_cavern_announcement' comment='(DID_FIRST_CAVERN_ANNOUNCEMENT)'/>
         </bitfield>
         <int16_t name='mood_cooldown'/>
 

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -358,7 +358,7 @@
             <flag-bit name='minor_victory' comment='(MINOR_VICTORY)'/>
             <flag-bit name='major_victory' comment='(MAJOR_VICTORY)'/>
             <flag-bit name='did_first_caravan_announcement' comment='(DID_FIRST_CARAVAN_ANNOUNCEMENT)'/>
-            <flag-bit name='did_first_cavern_announcement' comment='(DID_FIRST_CAVERN_ANNOUNCEMENT)'/>
+            <flag-bit name='did_first_cavern_announcement' comment='(DID_FIRST_CAVERN_ANNOUNCEMENT) required for CAVERNS_OPENED music context'/>
         </bitfield>
         <int16_t name='mood_cooldown'/>
 

--- a/df.ui.xml
+++ b/df.ui.xml
@@ -354,6 +354,11 @@
             <flag-bit name='first_year'/>
             <flag-bit name='recheck_aid_requests'/>
             <flag-bit name='force_elections'/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit/>
+            <flag-bit name='caverns_opened'/>
         </bitfield>
         <int16_t name='mood_cooldown'/>
 


### PR DESCRIPTION
`world.raws.unk_v50_2` seems to be raws for music tracks, based on some conditions tested in a function (0x14030df60 win64 Steam) that references it. One of those conditions tested (at 0x14030f92e) was `(plotinfo.unk23c8_flags >> 7) & 1`, which is `caverns_opened` via process of elimination (confirmed ingame.)

`world.raws.unk_v50_3` seems to be raws for sounds, based on use in `make_announcement` function (0x1400574e0 win64 Steam.)