### PR TITLE
Move mutex into world.status

### DIFF
--- a/df.world.xml
+++ b/df.world.xml
@@ -1102,9 +1102,9 @@
                 <static-array name='slot_id_idx2' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
                 <int16_t name='slots_used'/>
             </compound>
-        </compound>
 
-        <stl-mutex name='unk_v5010_1166a8'/>
+            <stl-mutex name='announcement_mutex'/>
+        </compound>
 
         <compound name='interaction_instances'>
             <stl-vector name='all' pointer-type='interaction_instance'/>


### PR DESCRIPTION
Looks like the mutex `unk_v5010_1166a8` is in `world.status` based on its use here (v50.11 win64 Steam, `make_announcement` function):
```
14005765b LEA       RSI,[RDI + 0x43c0]
140057662 MOV       qword ptr [RBP + -0x30],RSI
140057666 MOV       RCX,RSI
140057669 CALL      qword ptr [->MSVCP140.DLL::_Mtx_lock]
```
where `RDI` is `world.status`.

I renamed the mutex `announcement_mutex`, since `world.status` is `announcement_handlerst`. Not sure if the mutex has a purpose beyond that.