### PR TITLE
Add enum-attr alert_type to announcement_type

### DIFF
--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -3,7 +3,9 @@
         <enum-attr name='alert_type' type-name='announcement_alert_type' default-value='GENERAL'/>
 
         <enum-item name='NONE' value='-1'/>
-        <enum-item name='REACHED_PEAK'/>
+        <enum-item name='REACHED_PEAK'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='ERA_CHANGE'>
             <item-attr name='alert_type' value='ERA_CHANGE'/>
         </enum-item>
@@ -19,55 +21,141 @@
         <enum-item name='STRUCK_ECONOMIC_MINERAL'>
             <item-attr name='alert_type' value='UNDERGROUND'/>
         </enum-item>
-        <enum-item name='COMBAT_TWIST_WEAPON'/>
-        <enum-item name='COMBAT_LET_ITEM_DROP'/>
+        <enum-item name='COMBAT_TWIST_WEAPON'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_LET_ITEM_DROP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='COMBAT_START_CHARGE'/>
-        <enum-item name='COMBAT_SURPRISE_CHARGE'/>
-        <enum-item name='COMBAT_JUMP_DODGE_PROJ'/>
-        <enum-item name='COMBAT_JUMP_DODGE_STRIKE'/>
-        <enum-item name='COMBAT_DODGE'/>
-        <enum-item name='COMBAT_COUNTERSTRIKE'/>
-        <enum-item name='COMBAT_BLOCK'/>
-        <enum-item name='COMBAT_PARRY'/>
+        <enum-item name='COMBAT_START_CHARGE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_SURPRISE_CHARGE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_JUMP_DODGE_PROJ'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_JUMP_DODGE_STRIKE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_DODGE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_COUNTERSTRIKE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_BLOCK'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_PARRY'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='COMBAT_CHARGE_COLLISION'/>
-        <enum-item name='COMBAT_CHARGE_DEFENDER_TUMBLES'/>
-        <enum-item name='COMBAT_CHARGE_DEFENDER_KNOCKED_OVER'/>
-        <enum-item name='COMBAT_CHARGE_ATTACKER_TUMBLES'/>
-        <enum-item name='COMBAT_CHARGE_ATTACKER_BOUNCE_BACK'/>
-        <enum-item name='COMBAT_CHARGE_TANGLE_TOGETHER'/>
-        <enum-item name='COMBAT_CHARGE_TANGLE_TUMBLE'/>
-        <enum-item name='COMBAT_CHARGE_RUSH_BY'/>
+        <enum-item name='COMBAT_CHARGE_COLLISION'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_CHARGE_DEFENDER_TUMBLES'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_CHARGE_DEFENDER_KNOCKED_OVER'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_CHARGE_ATTACKER_TUMBLES'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_CHARGE_ATTACKER_BOUNCE_BACK'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_CHARGE_TANGLE_TOGETHER'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_CHARGE_TANGLE_TUMBLE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_CHARGE_RUSH_BY'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='COMBAT_CHARGE_MANAGE_STOP'/>
-        <enum-item name='COMBAT_CHARGE_OBSTACLE_SLAM'/>
-        <enum-item name='COMBAT_WRESTLE_LOCK'/>
-        <enum-item name='COMBAT_WRESTLE_CHOKEHOLD'/>
-        <enum-item name='COMBAT_WRESTLE_TAKEDOWN'/>
-        <enum-item name='COMBAT_WRESTLE_THROW'/>
-        <enum-item name='COMBAT_WRESTLE_RELEASE_LOCK'/>
-        <enum-item name='COMBAT_WRESTLE_RELEASE_CHOKE'/>
+        <enum-item name='COMBAT_CHARGE_MANAGE_STOP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_CHARGE_OBSTACLE_SLAM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_LOCK'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_CHOKEHOLD'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_TAKEDOWN'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_THROW'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_RELEASE_LOCK'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_RELEASE_CHOKE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='COMBAT_WRESTLE_RELEASE_GRIP'/>
-        <enum-item name='COMBAT_WRESTLE_STRUGGLE'/>
-        <enum-item name='COMBAT_WRESTLE_RELEASE_LATCH'/>
-        <enum-item name='COMBAT_WRESTLE_STRANGLE_KO'/>
-        <enum-item name='COMBAT_WRESTLE_ADJUST_GRIP'/>
-        <enum-item name='COMBAT_GRAB_TEAR'/>
-        <enum-item name='COMBAT_STRIKE_DETAILS'/>
-        <enum-item name='COMBAT_STRIKE_DETAILS_2'/>
+        <enum-item name='COMBAT_WRESTLE_RELEASE_GRIP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_STRUGGLE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_RELEASE_LATCH'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_STRANGLE_KO'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_ADJUST_GRIP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_GRAB_TEAR'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_STRIKE_DETAILS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_STRIKE_DETAILS_2'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='COMBAT_EVENT_ENRAGED'/>
-        <enum-item name='COMBAT_EVENT_STUCKIN'/>
-        <enum-item name='COMBAT_EVENT_LATCH_BP'/>
-        <enum-item name='COMBAT_EVENT_LATCH_GENERAL'/>
-        <enum-item name='COMBAT_EVENT_PROPELLED_AWAY'/>
-        <enum-item name='COMBAT_EVENT_KNOCKED_OUT'/>
-        <enum-item name='COMBAT_EVENT_STUNNED'/>
-        <enum-item name='COMBAT_EVENT_WINDED'/>
+        <enum-item name='COMBAT_EVENT_ENRAGED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_EVENT_STUCKIN'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_EVENT_LATCH_BP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_EVENT_LATCH_GENERAL'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_EVENT_PROPELLED_AWAY'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_EVENT_KNOCKED_OUT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_EVENT_STUNNED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_EVENT_WINDED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='COMBAT_EVENT_NAUSEATED'/>
+        <enum-item name='COMBAT_EVENT_NAUSEATED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='MIGRANT_ARRIVAL_NAMED'>
             <item-attr name='alert_type' value='MIGRANT'/>
         </enum-item>
@@ -233,13 +321,19 @@
         <enum-item name='MASTER_CONSTRUCTION_LOST'>
             <item-attr name='alert_type' value='ART_DEFACEMENT'/>
         </enum-item>
-        <enum-item name='ADV_AWAKEN'/>
-        <enum-item name='ADV_SLEEP_INTERRUPTED'/>
+        <enum-item name='ADV_AWAKEN'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='ADV_SLEEP_INTERRUPTED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='CANCEL_JOB'>
             <item-attr name='alert_type' value='JOB_FAILED'/>
         </enum-item>
 
-        <enum-item name='ADV_CREATURE_DEATH'/>
+        <enum-item name='ADV_CREATURE_DEATH'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='CITIZEN_DEATH'>
             <item-attr name='alert_type' value='DEATH'/>
         </enum-item>
@@ -255,58 +349,128 @@
         <enum-item name='ENDGAME_EVENT_2'>
             <item-attr name='alert_type' value='MONSTER'/>
         </enum-item>
-        <enum-item name='FALL_OVER'/>
-        <enum-item name='CAUGHT_IN_FLAMES'/>
-        <enum-item name='CAUGHT_IN_WEB'/>
+        <enum-item name='FALL_OVER'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CAUGHT_IN_FLAMES'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CAUGHT_IN_WEB'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='UNIT_PROJECTILE_SLAM_BLOW_APART'/>
-        <enum-item name='UNIT_PROJECTILE_SLAM'/>
-        <enum-item name='UNIT_PROJECTILE_SLAM_INTO_UNIT'/>
-        <enum-item name='VOMIT'/>
-        <enum-item name='LOSE_HOLD_OF_ITEM'/>
-        <enum-item name='REGAIN_CONSCIOUSNESS'/>
-        <enum-item name='FREE_FROM_WEB'/>
-        <enum-item name='PARALYZED'/>
+        <enum-item name='UNIT_PROJECTILE_SLAM_BLOW_APART'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='UNIT_PROJECTILE_SLAM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='UNIT_PROJECTILE_SLAM_INTO_UNIT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='VOMIT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='LOSE_HOLD_OF_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='REGAIN_CONSCIOUSNESS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='FREE_FROM_WEB'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='PARALYZED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='OVERCOME_PARALYSIS'/>
-        <enum-item name='NOT_STUNNED'/>
-        <enum-item name='EXHAUSTION'/>
-        <enum-item name='PAIN_KO'/>
-        <enum-item name='BREAK_GRIP'/>
-        <enum-item name='NO_BREAK_GRIP'/>
-        <enum-item name='BLOCK_FIRE'/>
-        <enum-item name='BREATHE_FIRE'/>
+        <enum-item name='OVERCOME_PARALYSIS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NOT_STUNNED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='EXHAUSTION'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='PAIN_KO'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='BREAK_GRIP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_BREAK_GRIP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='BLOCK_FIRE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='BREATHE_FIRE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='SHOOT_WEB'/>
-        <enum-item name='PULL_OUT_DROP'/>
-        <enum-item name='STAND_UP'/>
+        <enum-item name='SHOOT_WEB'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='PULL_OUT_DROP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='STAND_UP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='MARTIAL_TRANCE'>
             <item-attr name='alert_type' value='MARTIAL_TRANCE'/>
         </enum-item>
-        <enum-item name='MAT_BREATH'/>
-        <enum-item name='ADV_REACTION_PRODUCTS'/>
-        <enum-item name='NIGHT_ATTACK_STARTS'/>
-        <enum-item name='NIGHT_ATTACK_ENDS'/>
+        <enum-item name='MAT_BREATH'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='ADV_REACTION_PRODUCTS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NIGHT_ATTACK_STARTS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NIGHT_ATTACK_ENDS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='NIGHT_ATTACK_TRAVEL'/>
+        <enum-item name='NIGHT_ATTACK_TRAVEL'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='GHOST_ATTACK'>
             <item-attr name='alert_type' value='GHOST'/>
         </enum-item>
-        <enum-item name='FLAME_HIT'/>
-        <enum-item name='TRAVEL_SITE_DISCOVERY'/>
-        <enum-item name='TRAVEL_SITE_BUMP'/>
-        <enum-item name='ADVENTURE_INTRO'/>
-        <enum-item name='CREATURE_SOUND'/>
+        <enum-item name='FLAME_HIT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='TRAVEL_SITE_DISCOVERY'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='TRAVEL_SITE_BUMP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='ADVENTURE_INTRO'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CREATURE_SOUND'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='CREATURE_STEALS_OBJECT'>
             <item-attr name='alert_type' value='CRIME'/>
         </enum-item>
 
-        <enum-item name='FOUND_TRAP'/>
+        <enum-item name='FOUND_TRAP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='BODY_TRANSFORMATION'>
             <item-attr name='alert_type' value='MONSTER'/>
         </enum-item>
-        <enum-item name='INTERACTION_ACTOR'/>
-        <enum-item name='INTERACTION_TARGET'/>
+        <enum-item name='INTERACTION_ACTOR'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='INTERACTION_TARGET'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='UNDEAD_ATTACK'>
             <item-attr name='alert_type' value='UNDEAD_ATTACK'/>
         </enum-item>
@@ -316,7 +480,9 @@
         <enum-item name='PET_MISSING'>
             <item-attr name='alert_type' value='DEATH'/>
         </enum-item>
-        <enum-item name='EMBRACE'/>
+        <enum-item name='EMBRACE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
         <enum-item name='STRANGE_RAIN_SNOW'>
             <item-attr name='alert_type' value='WEATHER'/>
@@ -324,8 +490,12 @@
         <enum-item name='STRANGE_CLOUD'>
             <item-attr name='alert_type' value='WEATHER'/>
         </enum-item>
-        <enum-item name='SIMPLE_ANIMAL_ACTION'/>
-        <enum-item name='FLOUNDER_IN_LIQUID'/>
+        <enum-item name='SIMPLE_ANIMAL_ACTION'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='FLOUNDER_IN_LIQUID'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='TRAINING_DOWN_TO_SEMI_WILD'>
             <item-attr name='alert_type' value='ANIMAL'/>
         </enum-item>
@@ -335,34 +505,66 @@
         <enum-item name='ANIMAL_TRAINING_KNOWLEDGE'>
             <item-attr name='alert_type' value='ANIMAL'/>
         </enum-item>
-        <enum-item name='SKIP_ON_LIQUID'/>
+        <enum-item name='SKIP_ON_LIQUID'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='DODGE_FLYING_OBJECT'/>
+        <enum-item name='DODGE_FLYING_OBJECT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='REGULAR_CONVERSATION'>
             <item-attr name='alert_type' value='RUMOR'/>
         </enum-item>
-        <enum-item name='BANDIT_EMPTY_CONTAINER'/>
-        <enum-item name='BANDIT_GRAB_ITEM'/>
-        <enum-item name='COMBAT_EVENT_ATTACK_INTERRUPTED'/>
-        <enum-item name='COMBAT_WRESTLE_CATCH_ATTACK'/>
-        <enum-item name='FAIL_TO_GRAB_SURFACE'/>
-        <enum-item name='LOSE_HOLD_OF_SURFACE'/>
+        <enum-item name='BANDIT_EMPTY_CONTAINER'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='BANDIT_GRAB_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_EVENT_ATTACK_INTERRUPTED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMBAT_WRESTLE_CATCH_ATTACK'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='FAIL_TO_GRAB_SURFACE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='LOSE_HOLD_OF_SURFACE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='TRAVEL_COMPLAINT'/>
+        <enum-item name='TRAVEL_COMPLAINT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='LOSE_EMOTION'>
             <item-attr name='alert_type' value='LOSE_EMOTION'/>
         </enum-item>
-        <enum-item name='REORGANIZE_POSSESSIONS'/>
-        <enum-item name='PUSH_ITEM'/>
-        <enum-item name='DRAW_ITEM'/>
-        <enum-item name='STRAP_ITEM'/>
-        <enum-item name='GAIN_SITE_CONTROL'/>
-        <enum-item name='CONFLICT_CONVERSATION'/>
+        <enum-item name='REORGANIZE_POSSESSIONS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='PUSH_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='DRAW_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='STRAP_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='GAIN_SITE_CONTROL'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CONFLICT_CONVERSATION'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
         <enum-item name='FORT_POSITION_SUCCESSION'>
             <item-attr name='alert_type' value='NOBLE'/>
         </enum-item>
-        <enum-item name='MECHANISM_SOUND'/>
+        <enum-item name='MECHANISM_SOUND'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='BIRTH_WILD_ANIMAL'>
             <item-attr name='alert_type' value='BIRTH'/>
         </enum-item>
@@ -375,65 +577,169 @@
         <enum-item name='CITIZEN_TANTRUM'>
             <item-attr name='alert_type' value='STRESS'/>
         </enum-item>
-        <enum-item name='MOVED_OUT_OF_RANGE'/>
-        <enum-item name='CANNOT_JUMP'/>
+        <enum-item name='MOVED_OUT_OF_RANGE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CANNOT_JUMP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='NO_TRACKS'/>
-        <enum-item name='ALREADY_SEARCHED_AREA'/>
-        <enum-item name='SEARCH_FOUND_SOMETHING'/>
-        <enum-item name='SEARCH_FOUND_NOTHING'/>
-        <enum-item name='NOTHING_TO_INTERACT'/>
-        <enum-item name='NOTHING_TO_EXAMINE'/>
-        <enum-item name='YOU_YIELDED'/>
-        <enum-item name='YOU_UNYIELDED'/>
+        <enum-item name='NO_TRACKS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='ALREADY_SEARCHED_AREA'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='SEARCH_FOUND_SOMETHING'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='SEARCH_FOUND_NOTHING'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NOTHING_TO_INTERACT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NOTHING_TO_EXAMINE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='YOU_YIELDED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='YOU_UNYIELDED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='YOU_STRAP_ITEM'/>
-        <enum-item name='YOU_DRAW_ITEM'/>
-        <enum-item name='NO_GRASP_TO_DRAW_ITEM'/>
-        <enum-item name='NO_ITEM_TO_STRAP'/>
-        <enum-item name='NO_INV_TO_REMOVE'/>
-        <enum-item name='NO_INV_TO_WEAR'/>
-        <enum-item name='NO_INV_TO_EAT'/>
-        <enum-item name='NO_INV_TO_CONTAIN'/>
+        <enum-item name='YOU_STRAP_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='YOU_DRAW_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_GRASP_TO_DRAW_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_ITEM_TO_STRAP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_INV_TO_REMOVE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_INV_TO_WEAR'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_INV_TO_EAT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_INV_TO_CONTAIN'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='NO_INV_TO_DROP'/>
-        <enum-item name='NOTHING_TO_PICK_UP'/>
-        <enum-item name='NO_INV_TO_THROW'/>
-        <enum-item name='NO_INV_TO_FIRE'/>
-        <enum-item name='CURRENT_SMELL'/>
-        <enum-item name='CURRENT_WEATHER'/>
-        <enum-item name='CURRENT_TEMPERATURE'/>
-        <enum-item name='CURRENT_DATE'/>
+        <enum-item name='NO_INV_TO_DROP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NOTHING_TO_PICK_UP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_INV_TO_THROW'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_INV_TO_FIRE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CURRENT_SMELL'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CURRENT_WEATHER'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CURRENT_TEMPERATURE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CURRENT_DATE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='NO_GRASP_FOR_PICKUP'/>
-        <enum-item name='CANNOT_CHOP_TREE' comment='formerly TRAVEL_ADVISORY'/>
-        <enum-item name='CANNOT_CLIMB'/>
-        <enum-item name='CANNOT_STAND'/>
-        <enum-item name='MUST_UNRETRACT_FIRST'/>
-        <enum-item name='CANNOT_REST'/>
-        <enum-item name='CANNOT_MAKE_CAMPFIRE'/>
-        <enum-item name='MADE_CAMPFIRE'/>
+        <enum-item name='NO_GRASP_FOR_PICKUP'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CANNOT_CHOP_TREE' comment='formerly TRAVEL_ADVISORY'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CANNOT_CLIMB'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CANNOT_STAND'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='MUST_UNRETRACT_FIRST'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CANNOT_REST'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CANNOT_MAKE_CAMPFIRE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='MADE_CAMPFIRE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='CANNOT_SET_FIRE'/>
-        <enum-item name='SET_FIRE'/>
-        <enum-item name='DAWN_BREAKS'/>
-        <enum-item name='NOON'/>
-        <enum-item name='NIGHTFALL'/>
-        <enum-item name='NO_INV_INTERACTION'/>
-        <enum-item name='EMPTY_CONTAINER'/>
-        <enum-item name='TAKE_OUT_OF_CONTAINER'/>
+        <enum-item name='CANNOT_SET_FIRE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='SET_FIRE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='DAWN_BREAKS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NOON'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NIGHTFALL'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='NO_INV_INTERACTION'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='EMPTY_CONTAINER'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='TAKE_OUT_OF_CONTAINER'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='NO_CONTAINER_FOR_ITEM'/>
-        <enum-item name='PUT_INTO_CONTAINER'/>
-        <enum-item name='EAT_ITEM'/>
-        <enum-item name='DRINK_ITEM'/>
-        <enum-item name='CONSUME_FAILURE'/>
-        <enum-item name='DROP_ITEM'/>
-        <enum-item name='PICK_UP_ITEM'/>
-        <enum-item name='YOU_BUILDING_INTERACTION'/>
+        <enum-item name='NO_CONTAINER_FOR_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='PUT_INTO_CONTAINER'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='EAT_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='DRINK_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CONSUME_FAILURE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='DROP_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='PICK_UP_ITEM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='YOU_BUILDING_INTERACTION'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='YOU_ITEM_INTERACTION'/>
-        <enum-item name='YOU_TEMPERATURE_EFFECTS'/>
+        <enum-item name='YOU_ITEM_INTERACTION'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='YOU_TEMPERATURE_EFFECTS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='PROFESSION_CHANGES'>
             <item-attr name='alert_type' value='LABOR_CHANGE'/>
         </enum-item>
@@ -443,9 +749,15 @@
         <enum-item name='SOLDIER_BECOMES_MASTER'>
             <item-attr name='alert_type' value='MILITARY'/>
         </enum-item>
-        <enum-item name='RESOLVE_SHARED_ITEMS'/>
-        <enum-item name='COUGH_BLOOD'/>
-        <enum-item name='VOMIT_BLOOD'/>
+        <enum-item name='RESOLVE_SHARED_ITEMS'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COUGH_BLOOD'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='VOMIT_BLOOD'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
         <enum-item name='MERCHANTS_UNLOADING'>
             <item-attr name='alert_type' value='TRADE'/>
@@ -497,8 +809,12 @@
             <item-attr name='alert_type' value='ART_DEFACEMENT'/>
         </enum-item>
 
-        <enum-item name='POWER_LEARNED'/>
-        <enum-item name='YOU_FEED_ON_SUCKEE'/>
+        <enum-item name='POWER_LEARNED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='YOU_FEED_ON_SUCKEE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='ANIMAL_TRAINED'>
             <item-attr name='alert_type' value='ANIMAL'/>
         </enum-item>
@@ -514,7 +830,9 @@
         <enum-item name='SLOWDOWN_ENDS'>
             <item-attr name='alert_type' value='AGREEMENT'/>
         </enum-item>
-        <enum-item name='FAREWELL_HELPER'/>
+        <enum-item name='FAREWELL_HELPER'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
         <enum-item name='ELECTION_RESULTS'>
             <item-attr name='alert_type' value='NOBLE'/>
@@ -628,20 +946,40 @@
         <enum-item name='GUEST_ARRIVAL'>
             <item-attr name='alert_type' value='GUEST_ARRIVAL'/>
         </enum-item>
-        <enum-item name='CANNOT_SPEAK'/>
+        <enum-item name='CANNOT_SPEAK'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='RESEARCH_BREAKTHROUGH'>
             <item-attr name='alert_type' value='RESEARCH_BREAKTHROUGH'/>
         </enum-item>
-        <enum-item name='SERVICE_ORDER_DELIVERY'/>
-        <enum-item name='PERFORMANCE_START_FAILURE'/>
+        <enum-item name='SERVICE_ORDER_DELIVERY'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='PERFORMANCE_START_FAILURE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='BEGIN_ACTIVITY'/>
-        <enum-item name='MIDDLE_OF_ACTIVITY'/>
-        <enum-item name='ACTIVITY_SECTION_CHANGE'/>
-        <enum-item name='CONCLUDE_ACTIVITY'/>
-        <enum-item name='LEARNED_WRITTEN_CONTENT'/>
-        <enum-item name='LEARNED_ART_FORM'/>
-        <enum-item name='PERFORMER_UPDATE'/>
+        <enum-item name='BEGIN_ACTIVITY'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='MIDDLE_OF_ACTIVITY'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='ACTIVITY_SECTION_CHANGE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CONCLUDE_ACTIVITY'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='LEARNED_WRITTEN_CONTENT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='LEARNED_ART_FORM'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='PERFORMER_UPDATE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='BUILDING_DESTROYED_OR_TOPPLED'>
             <item-attr name='alert_type' value='ART_DEFACEMENT'/>
         </enum-item>
@@ -649,16 +987,24 @@
         <enum-item name='DEITY_CURSE'>
             <item-attr name='alert_type' value='DEITY_CURSE'/>
         </enum-item>
-        <enum-item name='COMPOSITION_COMPLETE'/>
-        <enum-item name='COMPOSITION_FAILED'/>
+        <enum-item name='COMPOSITION_COMPLETE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='COMPOSITION_FAILED'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='NEW_APPRENTICESHIP'>
             <item-attr name='alert_type' value='AGREEMENT'/>
         </enum-item>
         <enum-item name='PETITION_IGNORED'>
             <item-attr name='alert_type' value='AGREEMENT'/>
         </enum-item>
-        <enum-item name='CHOP_TREE'/>
-        <enum-item name='CANNOT_CONSTRUCT'/>
+        <enum-item name='CHOP_TREE'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CANNOT_CONSTRUCT'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='RUMOR_SPREAD'>
             <item-attr name='alert_type' value='RUMOR'/>
         </enum-item>
@@ -678,7 +1024,9 @@
         <enum-item name='NEW_MARKET_LINK'>
             <item-attr name='alert_type' value='HOLDINGS'/>
         </enum-item>
-        <enum-item name='EMERGENCY_TACTICAL_CONTROL' since='v0.47.01'/>
+        <enum-item name='EMERGENCY_TACTICAL_CONTROL' since='v0.47.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='AGREEMENT_SATISFIED' since='v0.47.01'>
             <item-attr name='alert_type' value='AGREEMENT'/>
         </enum-item>
@@ -704,29 +1052,63 @@
         <enum-item name='CRIME_WITNESS_ITEM_MISSING' since='v0.47.01'>
             <item-attr name='alert_type' value='CRIME'/>
         </enum-item>
-        <enum-item name='MOUNT' since='v0.47.01'/>
-        <enum-item name='CANNOT_MOUNT' since='v0.47.01'/>
+        <enum-item name='MOUNT' since='v0.47.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='CANNOT_MOUNT' since='v0.47.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='FAILED_MOUNT' since='v0.47.01'/>
-        <enum-item name='DISMOUNT' since='v0.47.01'/>
-        <enum-item name='FAILED_DISMOUNT' since='v0.47.01'/>
+        <enum-item name='FAILED_MOUNT' since='v0.47.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='DISMOUNT' since='v0.47.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='FAILED_DISMOUNT' since='v0.47.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
 
-        <enum-item name='DIPLOMAT_LEFT_UNHAPPY' since='v0.50.01'/> former Dipscript messages
-        <enum-item name='EMBARK_MESSAGE' since='v0.50.01'/>
-        <enum-item name='FIRST_CARAVAN_ARRIVAL' since='v0.50.01'/>
-        <enum-item name='MONARCH_ARRIVAL' since='v0.50.01'/>
-        <enum-item name='HASTY_MONARCH' since='v0.50.01'/>
-        <enum-item name='SATISFIED_MONARCH' since='v0.50.01'/>
-        <enum-item name='MOUNTAINHOME' since='v0.50.01'/>
+        <enum-item name='DIPLOMAT_LEFT_UNHAPPY' since='v0.50.01'> former Dipscript messages
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='EMBARK_MESSAGE' since='v0.50.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='FIRST_CARAVAN_ARRIVAL' since='v0.50.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='MONARCH_ARRIVAL' since='v0.50.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='HASTY_MONARCH' since='v0.50.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='SATISFIED_MONARCH' since='v0.50.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='MOUNTAINHOME' since='v0.50.01'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
         <enum-item name='FOOD_WARNING' since='v0.50.01'>
             <item-attr name='alert_type' value='DEATH'/>
         </enum-item>
 
-        <enum-item name='UNUSED_46'/>
-        <enum-item name='UNUSED_47'/>
-        <enum-item name='UNUSED_48'/>
-        <enum-item name='UNUSED_49'/>
-        <enum-item name='UNUSED_50'/>
+        <enum-item name='UNUSED_46'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='UNUSED_47'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='UNUSED_48'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='UNUSED_49'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
+        <enum-item name='UNUSED_50'>
+            <item-attr name='alert_type' value='GENERAL'/>
+        </enum-item>
     </enum-type>
 
     <enum-type type-name='announcement_alert_type' base-type='int32_t'>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -675,7 +675,7 @@
         <enum-item name='NEW_HOLDING'>
             <item-attr name='alert_type' value='HOLDINGS'/>
         </enum-item>
-        <enum-item name='NEW_MARKET_LINK'/>
+        <enum-item name='NEW_MARKET_LINK'>
             <item-attr name='alert_type' value='HOLDINGS'/>
         </enum-item>
         <enum-item name='EMERGENCY_TACTICAL_CONTROL' since='v0.47.01'/>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -327,7 +327,7 @@
         <enum-item name='SIMPLE_ANIMAL_ACTION'/>
         <enum-item name='FLOUNDER_IN_LIQUID'/>
         <enum-item name='TRAINING_DOWN_TO_SEMI_WILD'>
-            <item-attr name='alert_type' value='ANIMAL'>
+            <item-attr name='alert_type' value='ANIMAL'/>
         </enum-item>
         <enum-item name='TRAINING_FULL_REVERSION'>
             <item-attr name='alert_type' value='ANIMAL'/>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -679,11 +679,11 @@
             <item-attr name='alert_type' value='HOLDINGS'/>
         </enum-item>
         <enum-item name='EMERGENCY_TACTICAL_CONTROL' since='v0.47.01'/>
-        <enum-item name='AGREEMENT_SATISFIED' since='v0.47.01'/>
-            <item-attr name='alert_type' value='AGREEMENT'>
+        <enum-item name='AGREEMENT_SATISFIED' since='v0.47.01'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
         </enum-item>
-        <enum-item name='AGREEMENT_WARNING' since='v0.47.01'/>
-            <item-attr name='alert_type' value='AGREEMENT'>
+        <enum-item name='AGREEMENT_WARNING' since='v0.47.01'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
         </enum-item>
 
         <enum-item name='AGREEMENT_ABANDONED' since='v0.47.01'>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -326,7 +326,7 @@
         </enum-item>
         <enum-item name='SIMPLE_ANIMAL_ACTION'/>
         <enum-item name='FLOUNDER_IN_LIQUID'/>
-        <enum-item name='TRAINING_DOWN_TO_SEMI_WILD'/>
+        <enum-item name='TRAINING_DOWN_TO_SEMI_WILD'>
             <item-attr name='alert_type' value='ANIMAL'>
         </enum-item>
         <enum-item name='TRAINING_FULL_REVERSION'>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -1,12 +1,24 @@
 <data-definition>
     <enum-type type-name='announcement_type' base-type='int16_t'>
+        <enum-attr name='alert_type' type-name='announcement_alert_type' default-value='GENERAL'/>
+
         <enum-item name='NONE' value='-1'/>
         <enum-item name='REACHED_PEAK'/>
-        <enum-item name='ERA_CHANGE'/>
-        <enum-item name='FEATURE_DISCOVERY'/>
-        <enum-item name='STRUCK_DEEP_METAL'/>
-        <enum-item name='STRUCK_MINERAL'/>
-        <enum-item name='STRUCK_ECONOMIC_MINERAL'/>
+        <enum-item name='ERA_CHANGE'>
+            <item-attr name='alert_type' value='ERA_CHANGE'/>
+        </enum-item>
+        <enum-item name='FEATURE_DISCOVERY'>
+            <item-attr name='alert_type' value='UNDERGROUND'/>
+        </enum-item>
+        <enum-item name='STRUCK_DEEP_METAL'>
+            <item-attr name='alert_type' value='UNDERGROUND'/>
+        </enum-item>
+        <enum-item name='STRUCK_MINERAL'>
+            <item-attr name='alert_type' value='UNDERGROUND'/>
+        </enum-item>
+        <enum-item name='STRUCK_ECONOMIC_MINERAL'>
+            <item-attr name='alert_type' value='UNDERGROUND'/>
+        </enum-item>
         <enum-item name='COMBAT_TWIST_WEAPON'/>
         <enum-item name='COMBAT_LET_ITEM_DROP'/>
 
@@ -56,75 +68,193 @@
         <enum-item name='COMBAT_EVENT_WINDED'/>
 
         <enum-item name='COMBAT_EVENT_NAUSEATED'/>
-        <enum-item name='MIGRANT_ARRIVAL_NAMED'/>
-        <enum-item name='MIGRANT_ARRIVAL'/>
-        <enum-item name='DIG_CANCEL_WARM'/>
-        <enum-item name='DIG_CANCEL_DAMP'/>
-        <enum-item name='AMBUSH_DEFENDER'/>
-        <enum-item name='AMBUSH_RESIDENT'/>
-        <enum-item name='AMBUSH_THIEF'/>
+        <enum-item name='MIGRANT_ARRIVAL_NAMED'>
+            <item-attr name='alert_type' value='MIGRANT'/>
+        </enum-item>
+        <enum-item name='MIGRANT_ARRIVAL'>
+            <item-attr name='alert_type' value='MIGRANT'/>
+        </enum-item>
+        <enum-item name='DIG_CANCEL_WARM'>
+            <item-attr name='alert_type' value='UNDERGROUND'/>
+        </enum-item>
+        <enum-item name='DIG_CANCEL_DAMP'>
+            <item-attr name='alert_type' value='UNDERGROUND'/>
+        </enum-item>
+        <enum-item name='AMBUSH_DEFENDER'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
+        <enum-item name='AMBUSH_RESIDENT'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
+        <enum-item name='AMBUSH_THIEF'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
 
-        <enum-item name='AMBUSH_THIEF_SUPPORT_SKULKING'/>
-        <enum-item name='AMBUSH_THIEF_SUPPORT_NATURE'/>
-        <enum-item name='AMBUSH_THIEF_SUPPORT'/>
-        <enum-item name='AMBUSH_MISCHIEVOUS'/>
-        <enum-item name='AMBUSH_SNATCHER'/>
-        <enum-item name='AMBUSH_SNATCHER_SUPPORT'/>
-        <enum-item name='AMBUSH_AMBUSHER_NATURE'/>
-        <enum-item name='AMBUSH_AMBUSHER'/>
+        <enum-item name='AMBUSH_THIEF_SUPPORT_SKULKING'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
+        <enum-item name='AMBUSH_THIEF_SUPPORT_NATURE'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
+        <enum-item name='AMBUSH_THIEF_SUPPORT'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
+        <enum-item name='AMBUSH_MISCHIEVOUS'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
+        <enum-item name='AMBUSH_SNATCHER'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='AMBUSH_SNATCHER_SUPPORT'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
+        <enum-item name='AMBUSH_AMBUSHER_NATURE'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
+        <enum-item name='AMBUSH_AMBUSHER'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
 
-        <enum-item name='AMBUSH_INJURED'/>
-        <enum-item name='AMBUSH_OTHER'/>
-        <enum-item name='AMBUSH_INCAPACITATED'/>
-        <enum-item name='CARAVAN_ARRIVAL'/>
-        <enum-item name='NOBLE_ARRIVAL'/>
-        <enum-item name='D_MIGRANTS_ARRIVAL'/>
-        <enum-item name='D_MIGRANT_ARRIVAL'/>
-        <enum-item name='D_MIGRANT_ARRIVAL_DISCOURAGED'/>
+        <enum-item name='AMBUSH_INJURED'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
+        <enum-item name='AMBUSH_OTHER'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
+        <enum-item name='AMBUSH_INCAPACITATED'>
+            <item-attr name='alert_type' value='AMBUSH'/>
+        </enum-item>
+        <enum-item name='CARAVAN_ARRIVAL'>
+            <item-attr name='alert_type' value='TRADE'/>
+        </enum-item>
+        <enum-item name='NOBLE_ARRIVAL'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='D_MIGRANTS_ARRIVAL'>
+            <item-attr name='alert_type' value='MIGRANT'/>
+        </enum-item>
+        <enum-item name='D_MIGRANT_ARRIVAL'>
+            <item-attr name='alert_type' value='MIGRANT'/>
+        </enum-item>
+        <enum-item name='D_MIGRANT_ARRIVAL_DISCOURAGED'>
+            <item-attr name='alert_type' value='MIGRANT'/>
+        </enum-item>
 
-        <enum-item name='D_NO_MIGRANT_ARRIVAL'/>
-        <enum-item name='ANIMAL_TRAP_CATCH'/>
-        <enum-item name='ANIMAL_TRAP_ROBBED'/>
-        <enum-item name='MISCHIEF_LEVER'/>
-        <enum-item name='MISCHIEF_PLATE'/>
-        <enum-item name='MISCHIEF_CAGE'/>
-        <enum-item name='MISCHIEF_CHAIN'/>
-        <enum-item name='DIPLOMAT_ARRIVAL'/>
+        <enum-item name='D_NO_MIGRANT_ARRIVAL'>
+            <item-attr name='alert_type' value='MIGRANT'/>
+        </enum-item>
+        <enum-item name='ANIMAL_TRAP_CATCH'>
+            <item-attr name='alert_type' value='ANIMAL'/>
+        </enum-item>
+        <enum-item name='ANIMAL_TRAP_ROBBED'>
+            <item-attr name='alert_type' value='ANIMAL'/>
+        </enum-item>
+        <enum-item name='MISCHIEF_LEVER'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='MISCHIEF_PLATE'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='MISCHIEF_CAGE'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='MISCHIEF_CHAIN'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='DIPLOMAT_ARRIVAL'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
 
-        <enum-item name='LIAISON_ARRIVAL'/>
-        <enum-item name='TRADE_DIPLOMAT_ARRIVAL'/>
-        <enum-item name='CAVE_COLLAPSE'/>
-        <enum-item name='BIRTH_CITIZEN'/>
-        <enum-item name='BIRTH_ANIMAL'/>
-        <enum-item name='STRANGE_MOOD'/>
-        <enum-item name='MADE_ARTIFACT'/>
-        <enum-item name='NAMED_ARTIFACT'/>
+        <enum-item name='LIAISON_ARRIVAL'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='TRADE_DIPLOMAT_ARRIVAL'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='CAVE_COLLAPSE'>
+            <item-attr name='alert_type' value='UNDERGROUND'/>
+        </enum-item>
+        <enum-item name='BIRTH_CITIZEN'>
+            <item-attr name='alert_type' value='BIRTH'/>
+        </enum-item>
+        <enum-item name='BIRTH_ANIMAL'>
+            <item-attr name='alert_type' value='BIRTH'/>
+        </enum-item>
+        <enum-item name='STRANGE_MOOD'>
+            <item-attr name='alert_type' value='MOOD'/>
+        </enum-item>
+        <enum-item name='MADE_ARTIFACT'>
+            <item-attr name='alert_type' value='MOOD'/>
+        </enum-item>
+        <enum-item name='NAMED_ARTIFACT'>
+            <item-attr name='alert_type' value='MILITARY'/>
+        </enum-item>
 
-        <enum-item name='ITEM_ATTACHMENT'/>
-        <enum-item name='VERMIN_CAGE_ESCAPE'/>
-        <enum-item name='TRIGGER_WEB'/>
-        <enum-item name='MOOD_BUILDING_CLAIMED'/>
-        <enum-item name='ARTIFACT_BEGUN'/>
-        <enum-item name='MEGABEAST_ARRIVAL'/>
-        <enum-item name='WEREBEAST_ARRIVAL'/>
-        <enum-item name='BEAST_AMBUSH'/>
-        <enum-item name='BERSERK_CITIZEN'/>
-        <enum-item name='MAGMA_DEFACES_ENGRAVING'/>
+        <enum-item name='ITEM_ATTACHMENT'>
+            <item-attr name='alert_type' value='MILITARY'/>
+        </enum-item>
+        <enum-item name='VERMIN_CAGE_ESCAPE'>
+            <item-attr name='alert_type' value='ANIMAL'/>
+        </enum-item>
+        <enum-item name='TRIGGER_WEB'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
+        <enum-item name='MOOD_BUILDING_CLAIMED'>
+            <item-attr name='alert_type' value='MOOD'/>
+        </enum-item>
+        <enum-item name='ARTIFACT_BEGUN'>
+            <item-attr name='alert_type' value='MOOD'/>
+        </enum-item>
+        <enum-item name='MEGABEAST_ARRIVAL'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
+        <enum-item name='WEREBEAST_ARRIVAL'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
+        <enum-item name='BEAST_AMBUSH'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
+        <enum-item name='BERSERK_CITIZEN'>
+            <item-attr name='alert_type' value='BERSERK'/>
+        </enum-item>
+        <enum-item name='MAGMA_DEFACES_ENGRAVING'>
+            <item-attr name='alert_type' value='ART_DEFACEMENT'/>
+        </enum-item>
 
-        <enum-item name='ENGRAVING_MELTS'/>
-        <enum-item name='MASTERPIECE_CONSTRUCTION'/>
-        <enum-item name='MASTER_ARCHITECTURE_LOST'/>
-        <enum-item name='MASTER_CONSTRUCTION_LOST'/>
+        <enum-item name='ENGRAVING_MELTS'>
+            <item-attr name='alert_type' value='ART_DEFACEMENT'/>
+        </enum-item>
+        <enum-item name='MASTERPIECE_CONSTRUCTION'>
+            <item-attr name='alert_type' value='MASTERPIECE'/>
+        </enum-item>
+        <enum-item name='MASTER_ARCHITECTURE_LOST'>
+            <item-attr name='alert_type' value='ART_DEFACEMENT'/>
+        </enum-item>
+        <enum-item name='MASTER_CONSTRUCTION_LOST'>
+            <item-attr name='alert_type' value='ART_DEFACEMENT'/>
+        </enum-item>
         <enum-item name='ADV_AWAKEN'/>
         <enum-item name='ADV_SLEEP_INTERRUPTED'/>
-        <enum-item name='CANCEL_JOB'/>
+        <enum-item name='CANCEL_JOB'>
+            <item-attr name='alert_type' value='JOB_FAILED'/>
+        </enum-item>
 
         <enum-item name='ADV_CREATURE_DEATH'/>
-        <enum-item name='CITIZEN_DEATH'/>
-        <enum-item name='PET_DEATH'/>
-        <enum-item name='ENDGAME_EVENT_1'/>
-        <enum-item name='ENDGAME_EVENT_1B'/>
-        <enum-item name='ENDGAME_EVENT_2'/>
+        <enum-item name='CITIZEN_DEATH'>
+            <item-attr name='alert_type' value='DEATH'/>
+        </enum-item>
+        <enum-item name='PET_DEATH'>
+            <item-attr name='alert_type' value='DEATH'/>
+        </enum-item>
+        <enum-item name='ENDGAME_EVENT_1'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
+        <enum-item name='ENDGAME_EVENT_1B'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
+        <enum-item name='ENDGAME_EVENT_2'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
         <enum-item name='FALL_OVER'/>
         <enum-item name='CAUGHT_IN_FLAMES'/>
         <enum-item name='CAUGHT_IN_WEB'/>
@@ -150,41 +280,67 @@
         <enum-item name='SHOOT_WEB'/>
         <enum-item name='PULL_OUT_DROP'/>
         <enum-item name='STAND_UP'/>
-        <enum-item name='MARTIAL_TRANCE'/>
+        <enum-item name='MARTIAL_TRANCE'>
+            <item-attr name='alert_type' value='MARTIAL_TRANCE'/>
+        </enum-item>
         <enum-item name='MAT_BREATH'/>
         <enum-item name='ADV_REACTION_PRODUCTS'/>
         <enum-item name='NIGHT_ATTACK_STARTS'/>
         <enum-item name='NIGHT_ATTACK_ENDS'/>
 
         <enum-item name='NIGHT_ATTACK_TRAVEL'/>
-        <enum-item name='GHOST_ATTACK'/>
+        <enum-item name='GHOST_ATTACK'>
+            <item-attr name='alert_type' value='GHOST'/>
+        </enum-item>
         <enum-item name='FLAME_HIT'/>
         <enum-item name='TRAVEL_SITE_DISCOVERY'/>
         <enum-item name='TRAVEL_SITE_BUMP'/>
         <enum-item name='ADVENTURE_INTRO'/>
         <enum-item name='CREATURE_SOUND'/>
-        <enum-item name='CREATURE_STEALS_OBJECT'/>
+        <enum-item name='CREATURE_STEALS_OBJECT'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
 
         <enum-item name='FOUND_TRAP'/>
-        <enum-item name='BODY_TRANSFORMATION'/>
+        <enum-item name='BODY_TRANSFORMATION'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
         <enum-item name='INTERACTION_ACTOR'/>
         <enum-item name='INTERACTION_TARGET'/>
-        <enum-item name='UNDEAD_ATTACK'/>
-        <enum-item name='CITIZEN_MISSING'/>
-        <enum-item name='PET_MISSING'/>
+        <enum-item name='UNDEAD_ATTACK'>
+            <item-attr name='alert_type' value='UNDEAD_ATTACK'/>
+        </enum-item>
+        <enum-item name='CITIZEN_MISSING'>
+            <item-attr name='alert_type' value='DEATH'/>
+        </enum-item>
+        <enum-item name='PET_MISSING'>
+            <item-attr name='alert_type' value='DEATH'/>
+        </enum-item>
         <enum-item name='EMBRACE'/>
 
-        <enum-item name='STRANGE_RAIN_SNOW'/>
-        <enum-item name='STRANGE_CLOUD'/>
+        <enum-item name='STRANGE_RAIN_SNOW'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
+        <enum-item name='STRANGE_CLOUD'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
         <enum-item name='SIMPLE_ANIMAL_ACTION'/>
         <enum-item name='FLOUNDER_IN_LIQUID'/>
         <enum-item name='TRAINING_DOWN_TO_SEMI_WILD'/>
-        <enum-item name='TRAINING_FULL_REVERSION'/>
-        <enum-item name='ANIMAL_TRAINING_KNOWLEDGE'/>
+            <item-attr name='alert_type' value='ANIMAL'>
+        </enum-item>
+        <enum-item name='TRAINING_FULL_REVERSION'>
+            <item-attr name='alert_type' value='ANIMAL'/>
+        </enum-item>
+        <enum-item name='ANIMAL_TRAINING_KNOWLEDGE'>
+            <item-attr name='alert_type' value='ANIMAL'/>
+        </enum-item>
         <enum-item name='SKIP_ON_LIQUID'/>
 
         <enum-item name='DODGE_FLYING_OBJECT'/>
-        <enum-item name='REGULAR_CONVERSATION'/>
+        <enum-item name='REGULAR_CONVERSATION'>
+            <item-attr name='alert_type' value='RUMOR'/>
+        </enum-item>
         <enum-item name='BANDIT_EMPTY_CONTAINER'/>
         <enum-item name='BANDIT_GRAB_ITEM'/>
         <enum-item name='COMBAT_EVENT_ATTACK_INTERRUPTED'/>
@@ -193,7 +349,9 @@
         <enum-item name='LOSE_HOLD_OF_SURFACE'/>
 
         <enum-item name='TRAVEL_COMPLAINT'/>
-        <enum-item name='LOSE_EMOTION'/>
+        <enum-item name='LOSE_EMOTION'>
+            <item-attr name='alert_type' value='LOSE_EMOTION'/>
+        </enum-item>
         <enum-item name='REORGANIZE_POSSESSIONS'/>
         <enum-item name='PUSH_ITEM'/>
         <enum-item name='DRAW_ITEM'/>
@@ -201,12 +359,22 @@
         <enum-item name='GAIN_SITE_CONTROL'/>
         <enum-item name='CONFLICT_CONVERSATION'/>
 
-        <enum-item name='FORT_POSITION_SUCCESSION'/>
+        <enum-item name='FORT_POSITION_SUCCESSION'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
         <enum-item name='MECHANISM_SOUND'/>
-        <enum-item name='BIRTH_WILD_ANIMAL'/>
-        <enum-item name='STRESSED_CITIZEN'/>
-        <enum-item name='CITIZEN_LOST_TO_STRESS'/>
-        <enum-item name='CITIZEN_TANTRUM'/>
+        <enum-item name='BIRTH_WILD_ANIMAL'>
+            <item-attr name='alert_type' value='BIRTH'/>
+        </enum-item>
+        <enum-item name='STRESSED_CITIZEN'>
+            <item-attr name='alert_type' value='STRESS'/>
+        </enum-item>
+        <enum-item name='CITIZEN_LOST_TO_STRESS'>
+            <item-attr name='alert_type' value='STRESS'/>
+        </enum-item>
+        <enum-item name='CITIZEN_TANTRUM'>
+            <item-attr name='alert_type' value='STRESS'/>
+        </enum-item>
         <enum-item name='MOVED_OUT_OF_RANGE'/>
         <enum-item name='CANNOT_JUMP'/>
 
@@ -266,82 +434,204 @@
 
         <enum-item name='YOU_ITEM_INTERACTION'/>
         <enum-item name='YOU_TEMPERATURE_EFFECTS'/>
-        <enum-item name='PROFESSION_CHANGES'/>
-        <enum-item name='RECRUIT_PROMOTED'/>
-        <enum-item name='SOLDIER_BECOMES_MASTER'/>
+        <enum-item name='PROFESSION_CHANGES'>
+            <item-attr name='alert_type' value='LABOR_CHANGE'/>
+        </enum-item>
+        <enum-item name='RECRUIT_PROMOTED'>
+            <item-attr name='alert_type' value='MILITARY'/>
+        </enum-item>
+        <enum-item name='SOLDIER_BECOMES_MASTER'>
+            <item-attr name='alert_type' value='MILITARY'/>
+        </enum-item>
         <enum-item name='RESOLVE_SHARED_ITEMS'/>
         <enum-item name='COUGH_BLOOD'/>
         <enum-item name='VOMIT_BLOOD'/>
 
-        <enum-item name='MERCHANTS_UNLOADING'/>
-        <enum-item name='MERCHANTS_NEED_DEPOT'/>
-        <enum-item name='MERCHANT_WAGONS_BYPASSED'/>
-        <enum-item name='MERCHANTS_LEAVING_SOON'/>
-        <enum-item name='MERCHANTS_EMBARKED'/>
-        <enum-item name='PET_LOSES_DEAD_OWNER'/>
-        <enum-item name='PET_ADOPTS_OWNER'/>
-        <enum-item name='VERMIN_BITE'/>
+        <enum-item name='MERCHANTS_UNLOADING'>
+            <item-attr name='alert_type' value='TRADE'/>
+        </enum-item>
+        <enum-item name='MERCHANTS_NEED_DEPOT'>
+            <item-attr name='alert_type' value='TRADE'/>
+        </enum-item>
+        <enum-item name='MERCHANT_WAGONS_BYPASSED'>
+            <item-attr name='alert_type' value='TRADE'/>
+        </enum-item>
+        <enum-item name='MERCHANTS_LEAVING_SOON'>
+            <item-attr name='alert_type' value='TRADE'/>
+        </enum-item>
+        <enum-item name='MERCHANTS_EMBARKED'>
+            <item-attr name='alert_type' value='TRADE'/>
+        </enum-item>
+        <enum-item name='PET_LOSES_DEAD_OWNER'>
+            <item-attr name='alert_type' value='ANIMAL'/>
+        </enum-item>
+        <enum-item name='PET_ADOPTS_OWNER'>
+            <item-attr name='alert_type' value='ANIMAL'/>
+        </enum-item>
+        <enum-item name='VERMIN_BITE'>
+            <item-attr name='alert_type' value='VERMIN'/>
+        </enum-item>
 
-        <enum-item name='UNABLE_TO_COMPLETE_BUILDING'/>
-        <enum-item name='JOBS_REMOVED_FROM_UNPOWERED_BUILDING'/>
-        <enum-item name='CITIZEN_SNATCHED'/>
-        <enum-item name='VERMIN_DISTURBED'/>
-        <enum-item name='LAND_GAINS_STATUS'/>
-        <enum-item name='LAND_ELEVATED_STATUS'/>
-        <enum-item name='MASTERPIECE_CRAFTED'/>
-        <enum-item name='ARTWORK_DEFACED'/>
+        <enum-item name='UNABLE_TO_COMPLETE_BUILDING'>
+            <item-attr name='alert_type' value='JOB_FAILED'/>
+        </enum-item>
+        <enum-item name='JOBS_REMOVED_FROM_UNPOWERED_BUILDING'>
+            <item-attr name='alert_type' value='JOB_FAILED'/>
+        </enum-item>
+        <enum-item name='CITIZEN_SNATCHED'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='VERMIN_DISTURBED'>
+            <item-attr name='alert_type' value='VERMIN'/>
+        </enum-item>
+        <enum-item name='LAND_GAINS_STATUS'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='LAND_ELEVATED_STATUS'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='MASTERPIECE_CRAFTED'>
+            <item-attr name='alert_type' value='MASTERPIECE'/>
+        </enum-item>
+        <enum-item name='ARTWORK_DEFACED'>
+            <item-attr name='alert_type' value='ART_DEFACEMENT'/>
+        </enum-item>
 
         <enum-item name='POWER_LEARNED'/>
         <enum-item name='YOU_FEED_ON_SUCKEE'/>
-        <enum-item name='ANIMAL_TRAINED'/>
-        <enum-item name='DYED_MASTERPIECE'/>
-        <enum-item name='COOKED_MASTERPIECE'/>
-        <enum-item name='MANDATE_ENDS'/>
-        <enum-item name='SLOWDOWN_ENDS'/>
+        <enum-item name='ANIMAL_TRAINED'>
+            <item-attr name='alert_type' value='ANIMAL'/>
+        </enum-item>
+        <enum-item name='DYED_MASTERPIECE'>
+            <item-attr name='alert_type' value='MASTERPIECE'/>
+        </enum-item>
+        <enum-item name='COOKED_MASTERPIECE'>
+            <item-attr name='alert_type' value='MASTERPIECE'/>
+        </enum-item>
+        <enum-item name='MANDATE_ENDS'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='SLOWDOWN_ENDS'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
+        </enum-item>
         <enum-item name='FAREWELL_HELPER'/>
 
-        <enum-item name='ELECTION_RESULTS'/>
-        <enum-item name='SITE_PRESENT'/>
-        <enum-item name='CONSTRUCTION_SUSPENDED'/>
-        <enum-item name='LINKAGE_SUSPENDED'/>
-        <enum-item name='QUOTA_FILLED'/>
-        <enum-item name='JOB_OVERWRITTEN'/>
-        <enum-item name='NOTHING_TO_CATCH_IN_WATER'/>
-        <enum-item name='DEMAND_FORGOTTEN'/>
+        <enum-item name='ELECTION_RESULTS'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='SITE_PRESENT'>
+            <item-attr name='alert_type' value='UNDERGROUND'/>
+        </enum-item>
+        <enum-item name='CONSTRUCTION_SUSPENDED'>
+            <item-attr name='alert_type' value='JOB_FAILED'/>
+        </enum-item>
+        <enum-item name='LINKAGE_SUSPENDED'>
+            <item-attr name='alert_type' value='JOB_FAILED'/>
+        </enum-item>
+        <enum-item name='QUOTA_FILLED'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
+        </enum-item>
+        <enum-item name='JOB_OVERWRITTEN'>
+            <item-attr name='alert_type' value='JOB_FAILED'/>
+        </enum-item>
+        <enum-item name='NOTHING_TO_CATCH_IN_WATER'>
+            <item-attr name='alert_type' value='JOB_FAILED'/>
+        </enum-item>
+        <enum-item name='DEMAND_FORGOTTEN'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
 
-        <enum-item name='NEW_DEMAND'/>
-        <enum-item name='NEW_MANDATE'/>
-        <enum-item name='PRICES_ALTERED'/>
-        <enum-item name='NAMED_RESIDENT_CREATURE'/>
-        <enum-item name='SOMEBODY_GROWS_UP'/>
-        <enum-item name='GUILD_REQUEST_TAKEN'/>
-        <enum-item name='GUILD_WAGES_CHANGED'/>
-        <enum-item name='NEW_WORK_MANDATE'/>
+        <enum-item name='NEW_DEMAND'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='NEW_MANDATE'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='PRICES_ALTERED'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='NAMED_RESIDENT_CREATURE'>
+            <item-attr name='alert_type' value='MONSTER'/>
+        </enum-item>
+        <enum-item name='SOMEBODY_GROWS_UP'>
+            <item-attr name='alert_type' value='BIRTH'/>
+        </enum-item>
+        <enum-item name='GUILD_REQUEST_TAKEN'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
+        </enum-item>
+        <enum-item name='GUILD_WAGES_CHANGED'>
+            <item-attr name='alert_type' value='NOBLE'/>
+        </enum-item>
+        <enum-item name='NEW_WORK_MANDATE'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
+        </enum-item>
 
-        <enum-item name='CITIZEN_BECOMES_SOLDIER'/>
-        <enum-item name='CITIZEN_BECOMES_NONSOLDIER'/>
-        <enum-item name='PARTY_ORGANIZED'/>
-        <enum-item name='POSSESSED_TANTRUM'/>
-        <enum-item name='BUILDING_TOPPLED_BY_GHOST'/>
-        <enum-item name='MASTERFUL_IMPROVEMENT'/>
-        <enum-item name='MASTERPIECE_ENGRAVING'/>
-        <enum-item name='MARRIAGE'/>
+        <enum-item name='CITIZEN_BECOMES_SOLDIER'>
+            <item-attr name='alert_type' value='MILITARY'/>
+        </enum-item>
+        <enum-item name='CITIZEN_BECOMES_NONSOLDIER'>
+            <item-attr name='alert_type' value='LABOR_CHANGE'/>
+        </enum-item>
+        <enum-item name='PARTY_ORGANIZED'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
+        </enum-item>
+        <enum-item name='POSSESSED_TANTRUM'>
+            <item-attr name='alert_type' value='GHOST'/>
+        </enum-item>
+        <enum-item name='BUILDING_TOPPLED_BY_GHOST'>
+            <item-attr name='alert_type' value='GHOST'/>
+        </enum-item>
+        <enum-item name='MASTERFUL_IMPROVEMENT'>
+            <item-attr name='alert_type' value='MASTERPIECE'/>
+        </enum-item>
+        <enum-item name='MASTERPIECE_ENGRAVING'>
+            <item-attr name='alert_type' value='MASTERPIECE'/>
+        </enum-item>
+        <enum-item name='MARRIAGE'>
+            <item-attr name='alert_type' value='MARRIAGE'/>
+        </enum-item>
 
-        <enum-item name='NO_MARRIAGE_CELEBRATION'/>
-        <enum-item name='CURIOUS_GUZZLER'/>
-        <enum-item name='WEATHER_BECOMES_CLEAR'/>
-        <enum-item name='WEATHER_BECOMES_SNOW'/>
-        <enum-item name='WEATHER_BECOMES_RAIN'/>
-        <enum-item name='SEASON_WET'/>
-        <enum-item name='SEASON_DRY'/>
-        <enum-item name='SEASON_SPRING'/>
+        <enum-item name='NO_MARRIAGE_CELEBRATION'>
+            <item-attr name='alert_type' value='MARRIAGE'/>
+        </enum-item>
+        <enum-item name='CURIOUS_GUZZLER'>
+            <item-attr name='alert_type' value='CURIOUS_GUZZLER'/>
+        </enum-item>
+        <enum-item name='WEATHER_BECOMES_CLEAR'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
+        <enum-item name='WEATHER_BECOMES_SNOW'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
+        <enum-item name='WEATHER_BECOMES_RAIN'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
+        <enum-item name='SEASON_WET'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
+        <enum-item name='SEASON_DRY'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
+        <enum-item name='SEASON_SPRING'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
 
-        <enum-item name='SEASON_SUMMER'/>
-        <enum-item name='SEASON_AUTUMN'/>
-        <enum-item name='SEASON_WINTER'/>
-        <enum-item name='GUEST_ARRIVAL'/>
+        <enum-item name='SEASON_SUMMER'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
+        <enum-item name='SEASON_AUTUMN'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
+        <enum-item name='SEASON_WINTER'>
+            <item-attr name='alert_type' value='WEATHER'/>
+        </enum-item>
+        <enum-item name='GUEST_ARRIVAL'>
+            <item-attr name='alert_type' value='GUEST_ARRIVAL'/>
+        </enum-item>
         <enum-item name='CANNOT_SPEAK'/>
-        <enum-item name='RESEARCH_BREAKTHROUGH'/>
+        <enum-item name='RESEARCH_BREAKTHROUGH'>
+            <item-attr name='alert_type' value='RESEARCH_BREAKTHROUGH'/>
+        </enum-item>
         <enum-item name='SERVICE_ORDER_DELIVERY'/>
         <enum-item name='PERFORMANCE_START_FAILURE'/>
 
@@ -352,32 +642,68 @@
         <enum-item name='LEARNED_WRITTEN_CONTENT'/>
         <enum-item name='LEARNED_ART_FORM'/>
         <enum-item name='PERFORMER_UPDATE'/>
-        <enum-item name='BUILDING_DESTROYED_OR_TOPPLED'/>
+        <enum-item name='BUILDING_DESTROYED_OR_TOPPLED'>
+            <item-attr name='alert_type' value='ART_DEFACEMENT'/>
+        </enum-item>
 
-        <enum-item name='DEITY_CURSE'/>
+        <enum-item name='DEITY_CURSE'>
+            <item-attr name='alert_type' value='DEITY_CURSE'/>
+        </enum-item>
         <enum-item name='COMPOSITION_COMPLETE'/>
         <enum-item name='COMPOSITION_FAILED'/>
-        <enum-item name='NEW_APPRENTICESHIP'/>
-        <enum-item name='PETITION_IGNORED'/>
+        <enum-item name='NEW_APPRENTICESHIP'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
+        </enum-item>
+        <enum-item name='PETITION_IGNORED'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
+        </enum-item>
         <enum-item name='CHOP_TREE'/>
         <enum-item name='CANNOT_CONSTRUCT'/>
-        <enum-item name='RUMOR_SPREAD'/>
+        <enum-item name='RUMOR_SPREAD'>
+            <item-attr name='alert_type' value='RUMOR'/>
+        </enum-item>
 
-        <enum-item name='AMBUSH_HERO'/>
-        <enum-item name='SERVICE_ORDER_RUMOR_RECEIVED'/>
-        <enum-item name='RETURNING_RUMOR_RECEIVED'/>
-        <enum-item name='NEW_HOLDING'/>
+        <enum-item name='AMBUSH_HERO'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='SERVICE_ORDER_RUMOR_RECEIVED'>
+            <item-attr name='alert_type' value='RUMOR'/>
+        </enum-item>
+        <enum-item name='RETURNING_RUMOR_RECEIVED'>
+            <item-attr name='alert_type' value='RUMOR'/>
+        </enum-item>
+        <enum-item name='NEW_HOLDING'>
+            <item-attr name='alert_type' value='HOLDINGS'/>
+        </enum-item>
         <enum-item name='NEW_MARKET_LINK'/>
+            <item-attr name='alert_type' value='HOLDINGS'/>
+        </enum-item>
         <enum-item name='EMERGENCY_TACTICAL_CONTROL' since='v0.47.01'/>
         <enum-item name='AGREEMENT_SATISFIED' since='v0.47.01'/>
+            <item-attr name='alert_type' value='AGREEMENT'>
+        </enum-item>
         <enum-item name='AGREEMENT_WARNING' since='v0.47.01'/>
+            <item-attr name='alert_type' value='AGREEMENT'>
+        </enum-item>
 
-        <enum-item name='AGREEMENT_ABANDONED' since='v0.47.01'/>
-        <enum-item name='NEW_GUILD' since='v0.47.01'/>
-        <enum-item name='CRIME_WITNESS_HANDOFF' since='v0.47.01'/>
-        <enum-item name='CRIME_WITNESS_STOLEN' since='v0.47.01'/>
-        <enum-item name='CRIME_WITNESS_ITEM_MOVED' since='v0.47.01'/>
-        <enum-item name='CRIME_WITNESS_ITEM_MISSING' since='v0.47.01'/>
+        <enum-item name='AGREEMENT_ABANDONED' since='v0.47.01'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
+        </enum-item>
+        <enum-item name='NEW_GUILD' since='v0.47.01'>
+            <item-attr name='alert_type' value='AGREEMENT'/>
+        </enum-item>
+        <enum-item name='CRIME_WITNESS_HANDOFF' since='v0.47.01'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='CRIME_WITNESS_STOLEN' since='v0.47.01'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='CRIME_WITNESS_ITEM_MOVED' since='v0.47.01'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
+        <enum-item name='CRIME_WITNESS_ITEM_MISSING' since='v0.47.01'>
+            <item-attr name='alert_type' value='CRIME'/>
+        </enum-item>
         <enum-item name='MOUNT' since='v0.47.01'/>
         <enum-item name='CANNOT_MOUNT' since='v0.47.01'/>
 
@@ -392,7 +718,9 @@
         <enum-item name='HASTY_MONARCH' since='v0.50.01'/>
         <enum-item name='SATISFIED_MONARCH' since='v0.50.01'/>
         <enum-item name='MOUNTAINHOME' since='v0.50.01'/>
-        <enum-item name='FOOD_WARNING' since='v0.50.01'/>
+        <enum-item name='FOOD_WARNING' since='v0.50.01'>
+            <item-attr name='alert_type' value='DEATH'/>
+        </enum-item>
 
         <enum-item name='UNUSED_46'/>
         <enum-item name='UNUSED_47'/>


### PR DESCRIPTION
Add an enum-attr to `announcement_type` enum to retrieve the relevant `announcement_alert_type` enum associated with it. The relevant switch is found in `FUN_14005e5f0(report *)` for v50.11 win64 Steam.