### PR TITLE
Identify world.status.announcement_alert fields

### DIFF
--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -511,7 +511,9 @@
         <enum base-type='int32_t' type-name='announcement_alert_type' name='type'/>
         <stl-vector name='report_id' type-name='int32_t'/>
         <stl-vector name='unit_id' type-name='int32_t'/>
-        <stl-vector name='combat_type' type-name='int16_t' comment='Combat = 0, Sparring = 1, Hunting = 2'/>
+        <stl-vector name='combat_type'>
+            <enum type-name='unit_report_type'/>
+        </stl-vector>
     </struct-type>
 
     <struct-type type-name='announcement_infost' comment='allocated on the stack, included in df-structures to assist with disassembly'>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -507,6 +507,13 @@
         <bool name='bright' init-value='true'/>
     </struct-type>
 
+    <struct-type type-name='announcement_alertst'>
+        <enum base-type='int32_t' type-name='announcement_alert_type' name='type'/>
+        <stl-vector name='report_id' type-name='int32_t'/>
+        <stl-vector name='unit_id' type-name='int32_t'/>
+        <stl-vector name='combat_type' type-name='int16_t' comment='Combat = 0, Sparring = 1, Hunting = 2'/>
+    </struct-type>
+
     <struct-type type-name='announcement_infost' comment='allocated on the stack, included in df-structures to assist with disassembly'>
         <enum base-type='int16_t' type-name='announcement_type' name='type'/>
         <int16_t name='color'/>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -509,9 +509,9 @@
 
     <struct-type type-name='announcement_alertst'>
         <enum base-type='int32_t' type-name='announcement_alert_type' name='type'/>
-        <stl-vector name='report_id' type-name='int32_t'/>
-        <stl-vector name='unit_id' type-name='int32_t'/>
-        <stl-vector name='combat_type'>
+        <stl-vector name='announcement_id' type-name='int32_t'/>
+        <stl-vector name='report_unid' type-name='int32_t' comment='unit id'/>
+        <stl-vector name='report_unit_announcement_category'>
             <enum type-name='unit_report_type'/>
         </stl-vector>
     </struct-type>

--- a/df.units.xml
+++ b/df.units.xml
@@ -385,7 +385,7 @@
                    comment='Seems to be used as default when not flags1.tame'/>
     </enum-type>
 
-    <enum-type type-name='unit_report_type' base-type='int16_t'>
+    <enum-type type-name='unit_report_type' base-type='int16_t' comment='(UnitAnnouncementCategory)'>
         <enum-item name='Combat'/>
         <enum-item name='Sparring'/>
         <enum-item name='Hunting'/>

--- a/df.units.xml
+++ b/df.units.xml
@@ -385,7 +385,7 @@
                    comment='Seems to be used as default when not flags1.tame'/>
     </enum-type>
 
-    <enum-type type-name='unit_report_type' base-type='int16_t' original-name='UnitAnnouncementCategory'>
+    <enum-type type-name='unit_report_type' base-type='int16_t'>
         <enum-item name='Combat'/>
         <enum-item name='Sparring'/>
         <enum-item name='Hunting'/>

--- a/df.units.xml
+++ b/df.units.xml
@@ -385,7 +385,7 @@
                    comment='Seems to be used as default when not flags1.tame'/>
     </enum-type>
 
-    <enum-type type-name='unit_report_type' base-type='int16_t'>
+    <enum-type type-name='unit_report_type' base-type='int16_t' original-name='UnitAnnouncementCategory'>
         <enum-item name='Combat'/>
         <enum-item name='Sparring'/>
         <enum-item name='Hunting'/>

--- a/df.world.xml
+++ b/df.world.xml
@@ -1069,8 +1069,8 @@
             <stl-vector name='mission_reports' pointer-type='mission_report'/>
             <stl-vector name='spoils_reports' pointer-type='spoils_report' since='v0.44.06'/>
             <stl-vector name='interrogation_reports' pointer-type='interrogation_report' since='v0.47.01'/>
-            <stl-vector name='announcement_alert'/>
-            <stl-vector name='alert_button_announcement_id'/>
+            <stl-vector name='announcement_alert' pointer-type='announcement_alertst'/>
+            <stl-vector name='alert_button_announcement_id' type-name='int32_t'/>
             <int32_t name='display_timer'/>
 
             <compound name='slots'>

--- a/df.world.xml
+++ b/df.world.xml
@@ -1070,7 +1070,7 @@
             <stl-vector name='spoils_reports' pointer-type='spoils_report' since='v0.44.06'/>
             <stl-vector name='interrogation_reports' pointer-type='interrogation_report' since='v0.47.01'/>
             <stl-vector name='announcement_alert' pointer-type='announcement_alertst'/>
-            <stl-vector name='alert_button_announcement_id' type-name='int32_t'/>
+            <stl-vector name='alert_button_announcement_id' type-name='int32_t' comment='entries are report ids'/>
             <int32_t name='display_timer'/>
 
             <compound name='slots'>


### PR DESCRIPTION
Identify `announcement_alert` fields based on use in `make_announcement` (`FUN_1400574e0` v50.11 win64 Steam.) Naming the struct `announcement_alertst` based on convention.

Additionally defined the `alert_button_announcement_id` vector as `int32_t`, since it uses `report.id`.