### PR TITLE
`soundst`: `struct`, not `class`

### DIFF
--- a/df.raws.xml
+++ b/df.raws.xml
@@ -25,7 +25,7 @@
         </virtual-methods>
     </class-type>
 
-    <class-type type-name='soundst'>
+    <struct-type type-name='soundst'>
         <stl-string name='token'/>
         <int32_t name='index'/>
         <stl-vector name='current_definition' pointer-type='stl-string'/>
@@ -36,7 +36,7 @@
         <stl-vector name='announcement' comment='sound can be selected for these announcement types'>
             <enum type-name='announcement_type'/>
         </stl-vector>
-    </class-type>
+    </struct-type>
 
     <struct-type type-name='world_raws'>
         !! in bay12 each of these is its own compound and some of them are classes with their own methods !!


### PR DESCRIPTION
`class-type` is _only_ to be used for compounds that have a vtable

closes dfhack/dfhack#4229