### PR TITLE
Announcement_infost flag indicates sparring; identify unit_action_data_attack flag

### DIFF
--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -1241,7 +1241,7 @@
         <int32_t name='activity_event_id' init-value='-1' comment='same as field in report'/>
         <int32_t name='speaker_id' ref-target='unit'/>
         <bitfield base-type='uint8_t' name='flags'>
-            <flag-bit name='hostile_combat' comment='hunting or combat report, not sparring'/>
+            <flag-bit name='is_sparring'/>
         </bitfield>
     </struct-type>
 </data-definition>

--- a/df.announcements.xml
+++ b/df.announcements.xml
@@ -1241,7 +1241,7 @@
         <int32_t name='activity_event_id' init-value='-1' comment='same as field in report'/>
         <int32_t name='speaker_id' ref-target='unit'/>
         <bitfield base-type='uint8_t' name='flags'>
-            <flag-bit name='is_sparring'/>
+            <flag-bit name='is_sparring' comment='determined by unit_action_data_attack.flags.is_sparring'/>
         </bitfield>
     </struct-type>
 </data-definition>

--- a/df.units.xml
+++ b/df.units.xml
@@ -2260,7 +2260,7 @@
             <flag-bit/>
             <flag-bit name='lightly_tap'/>
             <flag-bit/>
-            <flag-bit/>
+            <flag-bit name='is_sparring'>
             <flag-bit name='spar_report'/>
         </bitfield>
         <enum base-type='int16_t' name='attack_skill' type-name='job_skill'/>

--- a/df.units.xml
+++ b/df.units.xml
@@ -2260,7 +2260,7 @@
             <flag-bit/>
             <flag-bit name='lightly_tap'/>
             <flag-bit/>
-            <flag-bit name='is_sparring'>
+            <flag-bit name='is_sparring'/>
             <flag-bit name='spar_report'/>
         </bitfield>
         <enum base-type='int16_t' name='attack_skill' type-name='job_skill'/>


### PR DESCRIPTION
The check is done around `0x1404A570B` (win64 Steam v50.11) using `unit_action_data_attack.flags & 0x4000` to set a variable that is later used to set the `announcement_infost.flags` bit.

It seems like the `announcement_infost.flags` bit signifies sparring rather than hostile combat, once again. (I'll update this in the GUI announcement functions, as I'm almost done with those.)

Might as well identify the other `unit_action_data_attack.flags`, if we have access to them.