### PR TITLE
canonicalize `unitst::emotions`

### DIFF
--- a/df.unit-thoughts.xml
+++ b/df.unit-thoughts.xml
@@ -1,5 +1,5 @@
 <data-definition>
-    <enum-type type-name='emotion_type' base-type='int32_t'>
+    <enum-type type-name='emotion_type' base-type='int32_t' comment='bay12: Emotion'>
         <enum-attr name='color' type-name='int8_t' default-value='7'/>
         <enum-attr name='divider' type-name='int8_t' default-value='0'/>
 

--- a/df.units.xml
+++ b/df.units.xml
@@ -1922,6 +1922,29 @@
         <int32_t name='unk_v50_2' since='v0.50.01'/>
     </struct-type>
 
+    <struct-type type-name='personality_moodst'>
+        <enum name='type' base-type='int32_t' type-name='emotion_type'/>
+        <int32_t name='strength'/>
+        <int32_t name='relative_strength'/>
+        <enum name='thought' base-type='int32_t' type-name='unit_thought_type' comment='bay12: circumstance'/>
+        <int32_t name='subthought' comment='for certain thoughts; bay12: circumstance_id'/>
+        <int32_t name='severity' comment='bay12: circumstance_value'/>
+        <bitfield name='flags' base-type='int32_t'>
+            <flag-bit name='failed_to_overcome'/>
+            <flag-bit name='was_dream_goal'/>
+            <flag-bit name='vocalized'/>
+            <flag-bit name='started_at_rel_zero'/>
+            <flag-bit name='remembered_longterm' comment='bay12: FROM_LONG_TERM_MEMORY'/>
+            <flag-bit name='remembered_shortterm' comment='bay12: FROM_SHORT_TERM_MEMORY'/>
+            <flag-bit name='remembered_reflected_on' comment='bay12: FROM_CORE_MEMORY'/>
+            <flag-bit name='facet_change'/>
+            <flag-bit name='value_change'/>
+        </bitfield>
+        <int32_t name='next_overcome_timer'/>
+        <int32_t name='year' comment='bay12: last_used_year'/>
+        <int32_t name='year_tick' comment='bay12: last_used_season_count'/>
+    </struct-type>
+
     <struct-type type-name='unit_personality' original-name='unit_personalityst'>
         <stl-vector name='values' since='v0.40.01'>
             <pointer>
@@ -1935,28 +1958,7 @@
                 <enum name='reponse' base-type='int16_t' type-name='ethic_response'/>
             </pointer>
         </stl-vector>
-        <stl-vector name='emotions' since='v0.40.01'>
-            <pointer>
-                <enum name='type' base-type='int32_t' type-name='emotion_type'/>
-                <int32_t name='unk2'/>
-                <int32_t name='strength'/>
-                <enum name='thought' base-type='int32_t' type-name='unit_thought_type'/>
-                <int32_t name='subthought' comment='for certain thoughts'/>
-                <int32_t name='severity'/>
-                <bitfield name='flags' base-type='int32_t'>
-                    <flag-bit name='unk0'/>
-                    <flag-bit name='unk1'/>
-                    <flag-bit name='unk2'/>
-                    <flag-bit name='unk3'/>
-                    <flag-bit name='remembered_longterm'/>
-                    <flag-bit name='remembered_shortterm'/>
-                    <flag-bit name='remembered_reflected_on'/>
-                </bitfield>
-                <int32_t name='unk7'/>
-                <int32_t name='year'/>
-                <int32_t name='year_tick'/>
-            </pointer>
-        </stl-vector>
+        <stl-vector pointer-type='personality_moodst' name='emotions' since='v0.40.01' comment='bay12: mood'/>
         <stl-vector name='dreams' since='v0.40.01'>
             <pointer>
                 <int32_t name='local_id' comment='next_dream_id related'/>


### PR DESCRIPTION
warning: this breaks misery.cpp, add-thought.lua, and export-dt-ini.lua; coordination required

mappings for updating references in the foregoing:
* `unit_personality::T_emotions` -> `personality_moodst`
* `unit_personality::T_emotions::unk2` -> `personality_moodst::strength`
* `unit_personality::T_emotions::strength` -> `personality_moodst::relative_strength`
* `unit_personality::T_emotions::unk7` -> `personality_moodst::next_overcome_timer`

i don't believe any of the flags added by this PR were being used as `unk`s