### PR TITLE
Prevent codegen comments from being duplicated

### DIFF
--- a/lower-2.xslt
+++ b/lower-2.xslt
@@ -58,7 +58,7 @@
                         <xsl:apply-templates select='@key-field'/>
                         <xsl:apply-templates select='ld:field|text()'/>
                     </ld:item>
-                    <xsl:apply-templates select='node()[not(self::ld:field)]'/>
+                    <xsl:apply-templates select='node()[not(self::ld:field|self::text())]'/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:element>


### PR DESCRIPTION
This PR prevents dangling text nodes from making their way into `codegen.out.xml`. Some free-form comments would be duplicated and left dangling, making it slightly more difficult to parse "real" comments for the Lua annotations. Cheers.

Here is a git-diff of the XML output: [codegen.diff.txt](https://github.com/DFHack/df-structures/files/14815162/codegen.diff.txt)
