### PR TITLE
zero-init otherwise uninitialized unions

### DIFF
--- a/StructFields.pm
+++ b/StructFields.pm
@@ -671,7 +671,7 @@ sub emit_struct_fields($$;%) {
         } 'fields-' . $fields_group;
 
         # Needed for unions with fields with non-default ctors (e.g. bitfields)
-        emit "$name(){}";
+        emit "$name(){memset(this, 0, sizeof($name));}";
 
         return;
     }


### PR DESCRIPTION
as per Discord discussion: https://discord.com/channels/793331351645323264/807444047215853578/1241770443371839488

This came up because the new df::job::job_spec union was not getting initialized on construction, even if `init-value` attributes were added to the fields.

This appears to be because the union is a mixture of plain data types (uint32_t) and bitfield types, which have non-default constructors. The end result is that no constructors get called and the resulting value is garbage.

This change zero-inits union structures. Existing code that *does* set the union fields will still work since the fields are set in the constructor for the containing class, which executes after the memset introduced here.