### PR TITLE
don't publicly export structs and unions that have no names

### DIFF
--- a/StructFields.pm
+++ b/StructFields.pm
@@ -38,7 +38,7 @@ sub with_struct_block(&$;$%) {
 
     my $is_union = is_attr_true($tag,'is-union');
     my $kwd = ($is_union ? "union" : "struct");
-    my $exp = $export_prefix; #$flags{-export} ? $export_prefix : '';
+    my $exp = $name ? $export_prefix : '';
     header_ref("Export.h");
     header_ref("DataDefs.h");
     my $prefix = $kwd.' '.$exp.($name ? $name.' ' : '');

--- a/df.advmode.xml
+++ b/df.advmode.xml
@@ -427,7 +427,7 @@
         <enum name='type' type-name='talk_choice_type'/>
         <pointer type-name='entity_event' name='rumor'/>
         <pointer type-name='witness_incidentst' name='witness_incident'/>
-        <compound name='var1' is-union='true'>
+        <compound is-union='true'>
             <int32_t name='variable1'/>
             <enum name="adventure_desire" type-name='adventure_desire_state_type'/>
             <enum name="opinion" type-name='opinion_type'/>
@@ -447,7 +447,7 @@
             <enum name="squad_order_type" type-name='squad_order_type'/>
             <int32_t name='belief_system_id'/>
         </compound>
-        <compound name='var2' is-union='true'>
+        <compound is-union='true'>
             <int32_t name='variable2'/>
             <enum name="reason" type-name='history_event_reason'/>
             <int32_t name='site_id2' ref-target='world_site'/>
@@ -467,7 +467,7 @@
             <int32_t name='story_index'/>
             <int32_t name='question_identity_id'/>
         </compound>
-        <compound name='var3' is-union='true'>
+        <compound is-union='true'>
             <int32_t name='variable3'/>
             <int32_t name='banter_entity_id' ref-target='historical_entity'/>
             <int32_t name='agreement_subject_id'/>
@@ -477,7 +477,7 @@
             <int32_t name='squad_order_target_stid' ref-target='world_site'/>
             <int32_t name='story_frame_index'/>
         </compound>
-        <compound name='var4' is-union='true'>
+        <compound is-union='true'>
             <int32_t name='variable4'/>
             <int32_t name='circumstance_value'/>
             <int32_t name='occupation_unid' ref-target='unit'/>

--- a/df.advmode.xml
+++ b/df.advmode.xml
@@ -429,11 +429,68 @@
         <pointer type-name='witness_incidentst' name='witness_incident'/>
         <compound is-union='true'>
             <int32_t name='variable1'/>
+            <enum name="adventure_desire" type-name='adventure_desire_state_type'/>
+            <enum name="opinion" type-name='opinion_type'/>
             <pointer name='sleep_permission_zone' comment='building_civzonest but the pointer is only valid for specific conversation topics'/>
+            <!--
+            <int32_t name='main_relevant_id'/>
+            <int32_t name='banter_item_id' ref-target='item'/>
+            <enum name="trouble_type" type-name='conversation_trouble_type'/>
+            <int32_t name='squad_id' ref-target='squad'/>
+            <int32_t name='agreement_id' ref-target='agreement'/>
+            <int32_t name='giver_entity_id' ref-target='historical_entity'/>
+            <int32_t name='asker_entity_id' ref-target='historical_entity'/>
+            <enum name="emotion" type-name='emotion_type'/>
+            <int32_t name='position_entity_id' ref-target='historical_entity'/>
+            <int32_t name='invocation_target_hfid' ref-target='historical_figure'/>
+            <int32_t name='service_order_id'/>
+            <enum name="value_type" type-name='value_type'/>
+            <enum name="squad_order_type" type-name='squad_order_type'/>
+            <int32_t name='belief_system_id'/>
+            -->
         </compound>
-        <int32_t name='variable2'/>
-        <int32_t name='variable3'/>
-        <int32_t name='variable4'/>
+        <compound is-union='true'>
+            <int32_t name='variable2'/>
+            <!--
+            <enum name="reason" type-name='history_event_reason'/>
+            <int32_t name='site_id2' ref-target='world_site'/>
+            <int32_t name='banter_bld_id'/>
+            <int32_t name='trouble_amount'/>
+            <int32_t name='dipstate_holder_enid' ref-target='historical_entity'/>
+            <int32_t name='squad_joiner_unid' ref-target='unit'/>
+            <int32_t name='taker_entity_id' ref-target='historical_entity'/>
+            <int32_t name='considerer_entity_id' ref-target='historical_entity'/>
+            <enum name="circumstance" type-name='unit_thought_type'/>
+            <enum name="witness" type-name='witness_type'/>
+            <int32_t name='position_profile_id'/>
+            <int32_t name='invocation_target_identity_id'/>
+            <int32_t name='service_order_occid'/>
+            <int32_t name='value_level'/>
+            <int32_t name='squad_order_target_hfid' ref-target='historical_figure'/>
+            <int32_t name='story_index'/>
+            <int32_t name='question_identity_id'/>
+            -->
+        </compound>
+        <compound is-union='true'>
+            <int32_t name='variable3'/>
+            <!--
+            <int32_t name='banter_entity_id' ref-target='historical_entity'/>
+            <int32_t name='agreement_subject_id'/>
+            <int32_t name='order_squad_id' ref-target='squad'/>
+            <int32_t name='circumstance_id'/>
+            <enum name="occupation_type" type-name='occupation_type'/>
+            <int32_t name='squad_order_target_stid' ref-target='world_site'/>
+            <int32_t name='story_frame_index'/>
+            -->
+        </compound>
+        <compound is-union='true'>
+            <int32_t name='variable4'/>
+            <!--
+            <int32_t name='circumstance_value'/>
+            <int32_t name='occupation_unid' ref-target='unit'/>
+            <int32_t name='squad_order_target_enid' ref-target='historical_entity'/>
+            -->
+        </compound>
         <int32_t name='value' init-value='-1'/>
     </struct-type>
 

--- a/df.advmode.xml
+++ b/df.advmode.xml
@@ -427,12 +427,11 @@
         <enum name='type' type-name='talk_choice_type'/>
         <pointer type-name='entity_event' name='rumor'/>
         <pointer type-name='witness_incidentst' name='witness_incident'/>
-        <compound is-union='true'>
+        <compound name='var1' is-union='true'>
             <int32_t name='variable1'/>
             <enum name="adventure_desire" type-name='adventure_desire_state_type'/>
             <enum name="opinion" type-name='opinion_type'/>
             <pointer name='sleep_permission_zone' comment='building_civzonest but the pointer is only valid for specific conversation topics'/>
-            <!--
             <int32_t name='main_relevant_id'/>
             <int32_t name='banter_item_id' ref-target='item'/>
             <enum name="trouble_type" type-name='conversation_trouble_type'/>
@@ -447,11 +446,9 @@
             <enum name="value_type" type-name='value_type'/>
             <enum name="squad_order_type" type-name='squad_order_type'/>
             <int32_t name='belief_system_id'/>
-            -->
         </compound>
-        <compound is-union='true'>
+        <compound name='var2' is-union='true'>
             <int32_t name='variable2'/>
-            <!--
             <enum name="reason" type-name='history_event_reason'/>
             <int32_t name='site_id2' ref-target='world_site'/>
             <int32_t name='banter_bld_id'/>
@@ -469,11 +466,9 @@
             <int32_t name='squad_order_target_hfid' ref-target='historical_figure'/>
             <int32_t name='story_index'/>
             <int32_t name='question_identity_id'/>
-            -->
         </compound>
-        <compound is-union='true'>
+        <compound name='var3' is-union='true'>
             <int32_t name='variable3'/>
-            <!--
             <int32_t name='banter_entity_id' ref-target='historical_entity'/>
             <int32_t name='agreement_subject_id'/>
             <int32_t name='order_squad_id' ref-target='squad'/>
@@ -481,15 +476,12 @@
             <enum name="occupation_type" type-name='occupation_type'/>
             <int32_t name='squad_order_target_stid' ref-target='world_site'/>
             <int32_t name='story_frame_index'/>
-            -->
         </compound>
-        <compound is-union='true'>
+        <compound name='var4' is-union='true'>
             <int32_t name='variable4'/>
-            <!--
             <int32_t name='circumstance_value'/>
             <int32_t name='occupation_unid' ref-target='unit'/>
             <int32_t name='squad_order_target_enid' ref-target='historical_entity'/>
-            -->
         </compound>
         <int32_t name='value' init-value='-1'/>
     </struct-type>


### PR DESCRIPTION
This prevents linkage errors on Windows where multiple anonymous structs or unions are declared in the same namespace. These symbols weren't useful to export anyway (AFAICT).