### PR TITLE
Sync item/material structures to Toady headers

### DIFF
--- a/df.entities.xml
+++ b/df.entities.xml
@@ -1139,12 +1139,12 @@
         <int32_t name='art_image_id'/>
         <int16_t name='art_image_subid'/>
         <int16_t name='image_thread_color' ref-target='descriptor_color'/>
-        <enum base-type='int16_t' name='image_material_class' type-name='entity_material_category'/>
+        <enum name='image_material_class' type-name='entity_material_category'/>
         <int16_t name='maker_race'/>
         <bitfield name="indiv_choice" type-name='uniform_indiv_choice'/>
         <int16_t name="mattype" ref-target='material' aux-value='$$.matindex'/>
         <int32_t name="matindex"/>
-        <enum base-type='int16_t' name="material_class" type-name='entity_material_category'/>
+        <enum name="material_class" type-name='entity_material_category'/>
     </struct-type>
 
     <enum-type type-name='entity_uniform_type' base-type='int16_t'> bay12: EntityUniformType

--- a/df.history.xml
+++ b/df.history.xml
@@ -1033,7 +1033,10 @@
         <int16_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
 
         <int32_t name='impersonated_hf' ref-target='historical_figure' comment="only when Impersonating"/>
-        <int32_t name='originator_hf' ref-target='historical_figure'/>
+        <compound is-union='true' union-tag-attr='id_tag'> bay12: "originator_hfid", yet Toady apparently stores Nemesis IDs here too?
+            <int32_t name='histfig_id' ref-target='historical_figure'/>
+            <int32_t name='nemesis_id' ref-target='nemesis_record'/>
+        </compound>
 
         <enum name='type' type-name='identity_type' base-type='int32_t'/>
 

--- a/df.interaction.xml
+++ b/df.interaction.xml
@@ -1,6 +1,6 @@
 <data-definition>
 
-    <enum-type type-name='interaction_flags'>
+    <enum-type type-name='interaction_flags'> bay12: InteractionFlagType
         <enum-item name='GENERATED'/>
         <enum-item name='EXPERIMENT_ONLY'/>
     </enum-type>
@@ -25,7 +25,8 @@
         <int32_t name='source_enid' ref-target='historical_entity' since='v0.42.01'/>
     </struct-type>
 
-    <enum-type type-name='interaction_effect_type' base-type='int32_t'>
+    <enum-type type-name='interaction_effect_type' base-type='int16_t'> bay12: InteractionEffectType
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='ANIMATE'/>
         <enum-item name='ADD_SYNDROME'/>
         <enum-item name='RESURRECT'/>
@@ -41,7 +42,8 @@
         <enum-item name='CHANGE_ITEM_QUALITY'/>
     </enum-type>
 
-    <enum-type type-name='interaction_effect_location_hint' base-type='int32_t'>
+    <enum-type type-name='interaction_effect_location_hint' base-type='int32_t'> bay12: LocationHintType
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='IN_WATER'/>
         <enum-item name='IN_MAGMA'/>
         <enum-item name='NO_WATER'/>
@@ -50,13 +52,18 @@
         <enum-item name='OUTSIDE'/>
     </enum-type>
 
+    <enum-type type-name='intermittent_frequency_type' base-type='int32_t'> bay12: IntermittentFrequencyType
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='WEEKLY'/>
+    </enum-type>
+
     <class-type type-name='interaction_effect' original-name='interaction_effectst'>
         <int32_t name='index' comment='index of the effect within the parent interaction.effects'/>
         <stl-vector name='targets' pointer-type='stl-string'/>
         <stl-vector name='targets_index' type-name='int32_t' comment='for each target used in this effect, list the index of that target within the parent interaction.targets'/>
-        <int32_t name='intermittent' comment='IE_INTERMITTENT, 0 = weekly'/>
+        <enum name='intermittent' type-name='intermittent_frequency_type'/>
         <stl-vector name='locations' type-name='interaction_effect_location_hint' comment='IE_LOCATION'/>
-        <bitfield name='flags' base-type='uint32_t'>
+        <bitfield name='flags' base-type='uint32_t'> bay12: INTERACTION_EFFECT_FLAG_*
             <flag-bit name='IMMEDIATE' comment='IE_IMMEDIATE'/>
         </bitfield>
         <int32_t name='interaction_id' ref-target='interaction'/>
@@ -72,53 +79,63 @@
             <vmethod is-destructor='true'/>
             <vmethod name='activateOnUnit'>
                 <pointer name='target' type-name='unit'/>
-                <pointer comment='has pointer-vector at offset 0x10'/>
-                <bool comment='only used by animate'/>
+                <pointer name='instance' type-name='interaction_instance'/>
+                <bool name='new_unit'/>
             </vmethod>
             <vmethod name='activateOnItem'><pointer name='target' type-name='item'/></vmethod>
-            <vmethod name='parseRaws'><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/></vmethod>
-            <vmethod name='finalize'><int32_t/></vmethod>
-            <vmethod name='applySyndromes'/>
-            <vmethod>
-                <pointer/>
-                <pointer/>
-                <bool/>
+            <vmethod name='parseRaws' ret-type='bool'>
+                <pointer name='token' type-name='stl-string'/>
+                <pointer name='pos' type-name='int32_t'/>
+                <pointer name='curstr' type-name='stl-string'/>
+                <pointer name='context'/>
+                <bool name='allow_internal_tokens'/>
+            </vmethod>
+            <vmethod name='finalize'><int32_t name='idx'/></vmethod>
+            <vmethod name='applySyndromes' comment='init_material_information'/>
+            <vmethod name='activateOnHistfig'>
+                <pointer name='hf' type-name='historical_figure'/>
+                <pointer name='instance' type-name='interaction_instance'/>
+                <bool name='worldgen'/>
             </vmethod>
             <vmethod name='hasSyndrome' ret-type='bool'><pointer type-name='syndrome'/></vmethod>
         </virtual-methods>
     </class-type>
 
-    <class-type type-name='interaction_effect_animatest' inherits-from='interaction_effect'>
-        <int32_t name='unk_1'/>
+    <struct-type type-name='creature_interactionst'>
         <stl-vector name='syndrome' pointer-type='syndrome'/>
+    </struct-type>
+
+    <class-type type-name='interaction_effect_animatest' inherits-from='interaction_effect'>
+        <uint32_t name='spec_flags'/>
+        <compound name='creature_interaction' type-name='creature_interactionst'/>
     </class-type>
 
     <class-type type-name='interaction_effect_add_syndromest' inherits-from='interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='syndrome' pointer-type='syndrome'/>
+        <uint32_t name='spec_flags'/>
+        <compound name='creature_interaction' type-name='creature_interactionst'/>
     </class-type>
 
     <class-type type-name='interaction_effect_resurrectst' inherits-from='interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='syndrome' pointer-type='syndrome'/>
+        <uint32_t name='spec_flags'/>
+        <compound name='creature_interaction' type-name='creature_interactionst'/>
     </class-type>
 
     <class-type type-name='interaction_effect_cleanst' inherits-from='interaction_effect'>
+        <uint32_t name='spec_flags'/>
         <int32_t name='grime_level' comment='IE_GRIME_LEVEL'/>
         <bitfield name='syndrome_tag' type-name='syndrome_flags' comment='IE_SYNDROME_TAG'/>
-        <int32_t name='unk_1'/>
     </class-type>
 
     <class-type type-name='interaction_effect_contactst' inherits-from='interaction_effect'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
     </class-type>
 
     <class-type type-name='interaction_effect_material_emissionst' inherits-from='interaction_effect'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
     </class-type>
 
     <class-type type-name='interaction_effect_hidest' inherits-from='interaction_effect'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
     </class-type>
 
     <class-type type-name='interaction_effect_change_item_qualityst' inherits-from='interaction_effect'>
@@ -127,17 +144,18 @@
     </class-type>
 
     <class-type type-name='interaction_effect_change_weatherst' inherits-from='interaction_effect'>
-        <int32_t name='unk_1'/>
-        <int32_t name='unk_2'/>
+        <uint32_t name='spec_flags'/>
+        <int16_t name='add_weather_flag'/>
+        <int16_t name='remove_weather_flag'/>
     </class-type>
 
     <class-type type-name='interaction_effect_raise_ghostst' inherits-from='interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='syndrome' pointer-type='syndrome' comment='assumed based on vmethod reference'/>
+        <uint32_t name='spec_flags'/>
+        <compound name='creature_interaction' type-name='creature_interactionst'/>
     </class-type>
 
     <class-type type-name='interaction_effect_create_itemst' inherits-from='interaction_effect'>
-        <enum name='item_type' type-name='item_type' comment='IE_ITEM'/>
+        <enum name='item_type' type-name='item_type' base-type='int16_t' comment='IE_ITEM'/>
         <int16_t name='item_subtype' comment='IE_ITEM'/>
         <int16_t name='mat_type' comment='IE_ITEM'/>
         <int32_t name='mat_index' init-value='-1' comment='IE_ITEM'/>
@@ -145,36 +163,41 @@
         <int16_t name='quantity' comment='IE_ITEM'/>
         <int32_t name='quality_min' comment='IE_ITEM_QUALITY'/>
         <int32_t name='quality_max' comment='IE_ITEM_QUALITY'/>
-        <int32_t name='create_artifact' comment='IE_ITEM_QUALITY:ARTIFACT'/>
-        <stl-string name='unk_1' comment='these five are probably item1:item2:mat1:mat2:mat3'/>
-        <stl-string name='unk_2'/>
-        <stl-string name='unk_3'/>
-        <stl-string name='unk_4'/>
-        <stl-string name='unk_5'/>
+        <bitfield name='spec_flags' base-type='uint32_t'> bay12: INTERACTION_EFFECT_CREATE_ITEM_FLAG_*
+            <flag-bit name='named_artifact'/>
+            <flag-bit name='crafts'/>
+        </bitfield>
+        <stl-string name='item_str1'/>
+        <stl-string name='item_str2'/>
+        <stl-string name='mat_str1'/>
+        <stl-string name='mat_str2'/>
+        <stl-string name='mat_str3'/>
     </class-type>
 
     <class-type type-name='interaction_effect_propel_unitst' inherits-from='interaction_effect'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
         <int32_t name='propel_force' comment='IE_PROPEL_FORCE'/>
     </class-type>
 
     <class-type type-name='interaction_effect_summon_unitst' inherits-from='interaction_effect'>
-        <int32_t name='make_pet' comment='IE_MAKE_PET_IF_POSSIBLE'/>
+        <bitfield name='spec_flags' base-type='uint32_t'> bay12: INTERACTION_EFFECT_SUMMON_UNIT_FLAG_*
+            <flag-bit name='make_pet_if_possible'/>
+        </bitfield>
         <stl-string name='race_str' comment='CREATURE'/>
         <stl-string name='caste_str' comment='CREATURE'/>
-        <stl-vector name='unk_1' type-name='int32_t' comment="seen 4 bytes allocated"/>
-        <stl-vector name='unk_2' type-name='int16_t' comment="seen 2 bytes allocate"/>
+        <stl-vector name='races' type-name='int32_t' ref-target='creature_raw'/>
+        <stl-vector name='castes' type-name='int16_t'/>
         <stl-vector type-name='int32_t' name='required_creature_flags' comment='contains indexes of flags in creature_raw_flags, IE_CREATURE_FLAG'/>
         <stl-vector type-name='int32_t' name='forbidden_creature_flags' comment='contains indexes of flags in creature_raw_flags, IE_FORBIDDEN_CREATURE_FLAG'/>
         <stl-vector type-name='int32_t' name='required_caste_flags' comment='contains indexes of flags in caste_raw_flags, IE_CREATURE_CASTE_FLAG'/>
         <stl-vector type-name='int32_t' name='forbidden_caste_flags' comment='contains indexes of flags in caste_raw_flags, IE_FORBIDDEN_CREATURE_CASTE_FLAG'/>
-        <int32_t name='unk_3' init-value='-1'/>
-        <int32_t name='unk_4' init-value='-1'/>
+        <int32_t name='min_gait_speed' init-value='-1' comment='effortless gaits only'/>
+        <int32_t name='max_gait_speed' init-value='-1'/>
         <int32_t name='time_range_min' comment='IE_TIME_RANGE'/>
         <int32_t name='time_range_max' comment='IE_TIME_RANGE'/>
     </class-type>
 
-    <enum-type type-name='interaction_source_type'>
+    <enum-type type-name='interaction_source_type' base-type='int16_t'> bay12: InteractionSourceType
         <enum-item name='REGION'/>
         <enum-item name='SECRET'/>
         <enum-item name='DISTURBANCE'/>
@@ -208,15 +231,21 @@
                 <enum name='loadversion' type-name='save_version'/>
             </vmethod>
             <vmethod is-destructor='true'/>
-            <vmethod name='parseRaws'><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/></vmethod>
-            <vmethod><int32_t/><int32_t/></vmethod>
-            <vmethod ret-type='bool'><int32_t/></vmethod>
-            <vmethod ret-type='bool'><int32_t/></vmethod>
+            <vmethod name='parseRaws' ret-type='bool'>
+                <pointer name='token' type-name='stl-string'/>
+                <pointer name='pos' type-name='int32_t'/>
+                <pointer name='curstr' type-name='stl-string'/>
+                <pointer name='context'/>
+                <bool name='allow_internal_tokens'/>
+            </vmethod>
+            <vmethod name='finalize'><int32_t name='idx'/></vmethod>
+            <vmethod name='subregion_match' ret-type='bool'><pointer name='sr' type-name='world_region'/></vmethod>
+            <vmethod name='sphere_match_all' ret-type='bool'><pointer name='spheres'><stl-vector><enum type-name='sphere_type' base-type='int16_t'/></stl-vector></pointer></vmethod>
         </virtual-methods>
     </class-type>
 
     <class-type type-name='interaction_source_regionst' inherits-from='interaction_source'>
-        <bitfield name='region_flags' base-type='uint32_t'>
+        <bitfield name='region_flags' base-type='uint32_t'> bay12: INTERACTION_SOURCE_REGION_FLAG_*
             <flag-bit name='NORMAL_ALLOWED'/>
             <flag-bit name='EVIL_ALLOWED'/>
             <flag-bit name='GOOD_ALLOWED'/>
@@ -229,27 +258,25 @@
     </class-type>
 
     <class-type type-name='interaction_source_secretst' inherits-from='interaction_source'>
-        <bitfield name='learn_flags' base-type='uint32_t'>
+        <bitfield name='learn_flags' base-type='uint32_t'> bay12: IS_SECRET_FLAG_*
             <flag-bit name='SUPERNATURAL_LEARNING_POSSIBLE'/>
             <flag-bit name='MUNDANE_RESEARCH_POSSIBLE'/>
             <flag-bit name='MUNDANE_RECORDING_POSSIBLE'/>
             <flag-bit name='MUNDANE_TEACHING_POSSIBLE'/>
         </bitfield>
-        <stl-vector name='spheres'>
-            <enum base-type='int16_t' type-name='sphere_type'/>
-        </stl-vector>
+        <stl-vector name='spheres' type-name='sphere_type'/>
         <stl-vector name='goals' type-name='goal_type'/>
         <stl-string name='book_title_filename'/>
         <stl-string name='book_name_filename'/>
-        <int32_t name='unk_1'/>
-        <int32_t name='unk_2'/>
+        <int32_t name='book_title_idx'/>
+        <int32_t name='book_name_idx'/>
     </class-type>
 
     <class-type type-name='interaction_source_disturbancest' inherits-from='interaction_source'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
     </class-type>
 
-    <enum-type type-name='interaction_source_usage_hint' base-type='int32_t'>
+    <enum-type type-name='interaction_source_usage_hint' base-type='int32_t'> bay12: UsageHintType
         <enum-item name='MAJOR_CURSE'/>
         <enum-item name='GREETING'/>
         <enum-item name='CLEAN_SELF'/>
@@ -266,36 +293,36 @@
     </enum-type>
 
     <class-type type-name='interaction_source_deityst' inherits-from='interaction_source'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
         <stl-vector name='usage_hint' type-name='interaction_source_usage_hint' comment='IS_USAGE_HINT'/>
     </class-type>
 
     <class-type type-name='interaction_source_attackst' inherits-from='interaction_source'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
     </class-type>
 
     <class-type type-name='interaction_source_ingestionst' inherits-from='interaction_source'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
     </class-type>
 
     <class-type type-name='interaction_source_creature_actionst' inherits-from='interaction_source'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
     </class-type>
 
     <class-type type-name='interaction_source_underground_specialst' inherits-from='interaction_source'/>
 
     <class-type type-name='interaction_source_experimentst' inherits-from='interaction_source'>
-        <int32_t name='unk_1'/>
+        <uint32_t name='spec_flags'/>
     </class-type>
 
-    <enum-type type-name='interaction_target_type'>
+    <enum-type type-name='interaction_target_type' base-type='int16_t'> bay12: InteractionTargetType
         <enum-item name='CORPSE'/>
         <enum-item name='CREATURE'/>
         <enum-item name='MATERIAL'/>
         <enum-item name='LOCATION'/>
     </enum-type>
 
-    <enum-type type-name='interaction_target_location_type'>
+    <enum-type type-name='interaction_target_location_type' base-type='int32_t'> bay12: TargetLocationType
         <enum-item name='CONTEXT_NONE' value='-1'/>
         <enum-item name='CONTEXT_REGION'/>
         <enum-item name='CONTEXT_CREATURE'/>
@@ -321,19 +348,25 @@
                 <enum name='loadversion' type-name='save_version'/>
             </vmethod>
             <vmethod is-destructor='true'/>
-            <vmethod name='parseRaws'><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/></vmethod>
-            <vmethod><int32_t/></vmethod>
-            <vmethod ret-type='bool'><int32_t/><int32_t/></vmethod>
-            <vmethod ret-type='bool'><int32_t/><int32_t/></vmethod>
-            <vmethod ret-type='bool'>
-                <pointer type-name='historical_figure'/>
-                <pointer type-name='interaction'/>
+            <vmethod name='parseRaws' ret-type='bool'>
+                <pointer name='token' type-name='stl-string'/>
+                <pointer name='pos' type-name='int32_t'/>
+                <pointer name='curstr' type-name='stl-string'/>
+                <pointer name='context'/>
+                <bool name='allow_internal_tokens'/>
             </vmethod>
-            <vmethod ret-type='bool'><int32_t/><int32_t/></vmethod>
+            <vmethod name='finalize'><int32_t name='idx'/></vmethod>
+            <vmethod name='affects_body_component' ret-type='bool'><pointer name='bodypart' type-name='item_body_component'/><pointer name='interaction' type-name='interaction'/></vmethod>
+            <vmethod name='affects_unit' ret-type='bool'><int32_t/><pointer name='interaction' type-name='interaction'/></vmethod>
+            <vmethod name='affects_histfig' ret-type='bool'>
+                <pointer name='histfig' type-name='historical_figure'/>
+                <pointer name='interaction' type-name='interaction'/>
+            </vmethod>
+            <vmethod name='affects_race' ret-type='bool'><int32_t name='race'/><int16_t name='Caste'/></vmethod>
         </virtual-methods>
     </class-type>
 
-    <struct-type type-name='interaction_target_info'>
+    <struct-type type-name='interaction_target_info' original-name='interaction_target_creature_informationst'>
         <static-array name='affected_creature_str' count='2'><stl-vector pointer-type='stl-string'/></static-array>
         <stl-vector name='affected_creature' type-name='int32_t' comment='IT_AFFECTED_CREATURE'/>
         <stl-vector name='affected_class' pointer-type='stl-string' comment='IT_AFFECTED_CLASS'/>
@@ -342,12 +375,12 @@
         <stl-vector name='immune_creature' type-name='int32_t' comment='IT_IMMUNE_CREATURE'/>
         <stl-vector name='immune_class' pointer-type='stl-string' comment='IT_IMMUNE_CLASS'/>
         <stl-vector name='forbidden_syndrome_class' pointer-type='stl-string'/>
-        <int32_t name='requires_1' comment='IT_REQUIRES'/>
-        <int32_t name='requires_2' comment='IT_REQUIRES'/>
-        <int32_t name='forbidden_1' comment='IT_FORBIDDEN'/>
-        <int32_t name='forbidden_2' comment='IT_FORBIDDEN'/>
-        <bitfield name='restrictions' base-type='uint32_t'>
-            <flag-bit name='CANNOT_TARGET_IF_ALREADY_AFFECTED'/>
+        <bitfield name='required_property' type-name='cie_add_tag_mask2'/>
+        <bitfield name='required_flag' type-name='cie_add_tag_mask1'/>
+        <bitfield name='forbidden_property' type-name='cie_add_tag_mask2'/>
+        <bitfield name='forbidden_flag' type-name='cie_add_tag_mask1'/>
+        <bitfield name='restrictions' base-type='uint32_t'> bay12: ITCI_FLAG_*
+            <flag-bit name='CANNOT_TARGET_IF_ALREADY_AFFECTED' comment='CHECK_FOR_EXISTING_SYNDROME'/>
         </bitfield>
     </struct-type>
 
@@ -359,7 +392,7 @@
         <compound name='target_info' type-name='interaction_target_info'/>
     </class-type>
 
-    <enum-type type-name='breath_attack_type' base-type='int16_t'>
+    <enum-type type-name='breath_attack_type' base-type='int16_t'> bay12: BreathAttackType
         <enum-item name='TRAILING_DUST_FLOW'/>
         <enum-item name='TRAILING_VAPOR_FLOW'/>
         <enum-item name='TRAILING_GAS_FLOW'/>
@@ -390,21 +423,25 @@
         <static-array name='material_str' type-name='stl-string' count='3'/>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int16_t name='parent_interaction_index'/>
+        <enum name='mat_state' type-name='matter_state'/>
         <enum type-name='breath_attack_type' name='breath_attack_type'/>
-        <bitfield name='restrictions' base-type='uint32_t'>
+        <bitfield name='restrictions' base-type='uint32_t'> bay12: INTERACTION_TARGET_MATERIAL_FLAG_*
             <flag-bit name='CONTEXT_MATERIAL'/>
         </bitfield>
     </class-type>
 
-    <class-type type-name='interaction_target_locationst' inherits-from='interaction_target'>
-    </class-type>
+    <class-type type-name='interaction_target_locationst' inherits-from='interaction_target'/>
 
-    <struct-type type-name='interaction_instance' instance-vector='$global.world.interaction_instances.all' key-field='id'>
+    <struct-type type-name='interaction_instance' original-name='interaction_instancest' instance-vector='$global.world.interaction_instances.all' key-field='id'>
         <int32_t name='id'/>
         <int32_t name='interaction_id' ref-target='interaction'/>
-        <int32_t name='unk_1'/>
-        <int32_t name='region_index'/>
+        <compound name='source_context'> bay12: interaction_instance_contextst
+            <enum name='type' base-type='int32_t'> bay12: IIContextType
+                <enum-item name='NONE' value='-1'/>
+                <enum-item name='SUBREGION'/>
+            </enum>
+            <int32_t name='region_index' comment='presumably matches the type above'/>
+        </compound>
         <stl-vector name='affected_units' type-name='int32_t' ref-target='unit' comment='IDs of units affected by the regional interaction'/>
     </struct-type>
 

--- a/df.item-raws.xml
+++ b/df.item-raws.xml
@@ -1,5 +1,5 @@
 <data-definition>
-    <enum-type type-name='item_type' base-type='int16_t'>
+    <enum-type type-name='item_type' base-type='int16_t'> bay12: ItemType
         <enum-attr name='caption'/>
         <enum-attr name='is_rawable' type-name='bool'/>
         <enum-attr name='is_stackable' type-name='bool'/>
@@ -411,7 +411,7 @@
         </enum-item>
     </enum-type>
 
-    <struct-type type-name='weapon_attack'>
+    <struct-type type-name='weapon_attack' original-name='itemdef_attackst'>
         <bool name='edged'/>
         <int32_t name='contact'/>
         <int32_t name='penetration'/>
@@ -421,14 +421,32 @@
         <stl-string name='noun'/>
         <int32_t name="prepare" since='v0.40.01'/>
         <int32_t name="recover" since='v0.40.01'/>
-        <bitfield name='flags' since='v0.40.01'>
+        <bitfield name='flags' base-type='uint32_t' since='v0.40.01'> bay12: ITEMDEF_ATTACK_FLAG_*
             <flag-bit name='independent_multiattack'/>
             <flag-bit name='bad_multiattack'/>
         </bitfield>
     </struct-type>
 
-    <enum-type type-name='itemdef_flags'>
+    <enum-type type-name='itemdef_flags'> bay12: ItemDefFlagType
         <enum-item name='GENERATED'/>
+    </enum-type>
+
+    <enum-type type-name='itemdef_type' base-type='int32_t'> bay12: ItemDefType
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='WEAPON'/>
+        <enum-item name='TOY'/>
+        <enum-item name='TOOL'/>
+        <enum-item name='INSTRUMENT'/>
+        <enum-item name='TRAPCOMP'/>
+        <enum-item name='ARMOR'/>
+        <enum-item name='AMMO'/>
+        <enum-item name='SIEGEAMMO'/>
+        <enum-item name='GLOVES'/>
+        <enum-item name='SHOES'/>
+        <enum-item name='SHIELD'/>
+        <enum-item name='HELM'/>
+        <enum-item name='PANTS'/>
+        <enum-item name='FOOD'/>
     </enum-type>
 
     <class-type type-name='itemdef' original-name='itemdefst'>
@@ -440,28 +458,29 @@
         <int32_t name='source_hfid' ref-target='historical_figure' since='v0.40.01'/>
         <int32_t name='source_enid' ref-target='historical_entity' since='v0.42.01'/>
         <stl-vector name='raw_strings' pointer-type='stl-string'/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='statue_texpos_top'/>
+        <int32_t name='statue_texpos_bottom'/>
 
         <code-helper name='describe'>$.id</code-helper>
 
         <virtual-methods>
-            <vmethod/>
-            <vmethod name='parseRaws'>
-                <pointer/>
-                <pointer/>
-                <pointer/>
-                <pointer/>
-                <pointer/>
+            <vmethod name='getType' ret-type='itemdef_type'/>
+
+            <vmethod name='parseRaws' ret-type='bool'>
+                <pointer name='context'/>
+                <pointer name='str' type-name='stl-string'/>
+                <pointer name='maintok' type-name='stl-string'/>
+                <int32_t name='pos'/>
+                <bool name='can_use_internal'/>
             </vmethod>
             <vmethod name='categorize' comment='add to world.raws.itemdefs.whatever'/>
             <vmethod name='finalize' comment='calculate stuff like base value'/>
-            <vmethod/>
+            <vmethod name='init_material_information'/>
             <vmethod is-destructor='true'/>
         </virtual-methods>
     </class-type>
 
-    <enum-type type-name='ammo_flags'>
+    <enum-type type-name='ammo_flags'> bay12: ItemDefAmmoFlagType
         <enum-item name='HAS_EDGE_ATTACK'/>
     </enum-type>
 
@@ -479,12 +498,12 @@
 
         <stl-vector name="attacks" pointer-type='weapon_attack'/>
 
-        <static-array type-name='int32_t' count='16'/>
-        <stl-vector comment='items pointed to are 8 bytes'/>
+        <static-array name='texpos' type-name='int32_t' count='16'/>
+        <stl-vector name='graphics_info' comment='itemdef_ammo_graphics_infost'/>
 
     </class-type>
 
-    <enum-type type-name='armor_general_flags'>
+    <enum-type type-name='armor_general_flags'> bay12: ClothingDefFlagType
         <enum-item name='SOFT'/>
         <enum-item name='HARD'/>
         <enum-item name='METAL'/>
@@ -499,15 +518,22 @@
         <enum-item name='STRUCTURAL_ELASTICITY_CHAIN_ALL'/>
     </enum-type>
 
-    <struct-type type-name='armor_properties'>
+    <enum-type type-name='clothing_layer_type'> bay12: ClothingLayer, does NOT have matching typedef so use compiler default
+        <enum-item name='UNDER'/>
+        <enum-item name='OVER'/>
+        <enum-item name='ARMOR'/>
+        <enum-item name='COVER'/>
+    </enum-type>
+
+    <struct-type type-name='armor_properties' original-name='clothingdefst'>
         <df-flagarray name='flags' index-enum='armor_general_flags'/>
-        <int32_t name="layer"/>
+        <enum name="layer" type-name='clothing_layer_type'/>
         <int16_t name="layer_size"/>
         <int16_t name="layer_permit"/>
         <int16_t name="coverage"/>
     </struct-type>
 
-    <enum-type type-name='armor_flags'>
+    <enum-type type-name='armor_flags'> bay12: ItemDefArmorFlagType
         <enum-item name='METAL_ARMOR_LEVELS'/>
     </enum-type>
 
@@ -528,9 +554,8 @@
         <compound name='props' type-name='armor_properties'/>
 
         <df-flagarray name='flags' index-enum='armor_flags'/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector comment='items pointed to are 8 bytes'/>
+        <int32_t name='texpos_item'/>
+        <stl-vector name='graphics_info' comment='item_armor_graphics_infost'/>
 
     </class-type>
 
@@ -538,11 +563,11 @@
                 instance-vector='$global.world.raws.itemdefs.food'>
         <stl-string name="name"/>
         <int16_t name="level"/>
-        <int32_t/>
-        <int32_t/>
+        <int32_t name='texpos_item'/>
+        <int32_t name='texpos_food_container_top'/>
     </class-type>
 
-    <enum-type type-name='gloves_flags'>
+    <enum-type type-name='gloves_flags'> bay12: ItemDefGlovesFlagType
         <enum-item name='METAL_ARMOR_LEVELS'/>
     </enum-type>
 
@@ -557,12 +582,11 @@
         <df-flagarray name='flags' index-enum='gloves_flags'/>
         <int32_t name="material_size"/>
         <compound name='props' type-name='armor_properties'/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector comment='items pointed to are 8 bytes'/>
+        <int32_t name='texpos_item'/>
+        <stl-vector name='graphics_info' comment='item_gloves_graphics_infost'/>
     </class-type>
 
-    <enum-type type-name='helm_flags'>
+    <enum-type type-name='helm_flags'> bay12: ItemDefHelmFlagType
         <enum-item name='METAL_ARMOR_LEVELS'/>
     </enum-type>
 
@@ -576,12 +600,11 @@
         <df-flagarray name='flags' index-enum='helm_flags'/>
         <int32_t name="material_size"/>
         <compound name='props' type-name='armor_properties'/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector comment='items pointed to are 8 bytes'/>
+        <int32_t name='texpos_item'/>
+        <stl-vector name='graphics_info' comment='item_helm_graphics_infost'/>
     </class-type>
 
-    <enum-type type-name='instrument_flags'>
+    <enum-type type-name='instrument_flags'> bay12: ItemDefInstrumentFlagType
         <enum-item name='INDEFINITE_PITCH'/>
         <enum-item name='PLACED_AS_BUILDING'/>
         <enum-item name='METAL_MAT'/>
@@ -613,22 +636,24 @@
         <stl-vector type-name='sound_production_type' name="sound_production"/>
         <stl-vector pointer-type='stl-string' name="sound_production_parm1"/>
         <stl-vector pointer-type='stl-string' name="sound_production_parm2"/>
-        <stl-vector type-name='int32_t' name="unk_100"/>
-        <stl-vector type-name='int32_t' name="unk_110"/>
+        <stl-vector type-name='int32_t' name="sound_production_actor_id"/>
+        <stl-vector type-name='int32_t' name="sound_production_target_id"/>
         <stl-vector type-name='pitch_choice_type' name="pitch_choice"/>
         <stl-vector pointer-type='stl-string' name="pitch_choice_parm1"/>
         <stl-vector pointer-type='stl-string' name="pitch_choice_parm2"/>
-        <stl-vector type-name='int32_t' name="unk_150"/>
-        <stl-vector type-name='int32_t' name="unk_160"/>
+        <stl-vector type-name='int32_t' name="pitch_choice_piece_id1"/>
+        <stl-vector type-name='int32_t' name="pitch_choice_piece_id2"/>
         <stl-vector type-name='tuning_type' name="tuning"/>
         <stl-vector pointer-type='stl-string' name="tuning_parm"/>
-        <stl-vector type-name='int32_t' name="unk_190"/>
+        <stl-vector type-name='int32_t' name="tuning_piece_id"/>
+        <!-- <compound name='timbre'> --> bay12: timbre_infost
         <stl-vector pointer-type='instrument_register' name="registers"/>
         <stl-vector type-name='timbre_type' name="timbre"/>
+        <!-- </compound>-->
         <stl-string name="description"/>
     </class-type>
 
-    <enum-type type-name='sound_production_type'>
+    <enum-type type-name='sound_production_type' base-type='int32_t'> bay12: SoundProductionMethodType
         <enum-item name='PLUCKED_BY_BP'/>
         <enum-item name='PLUCKED'/>
         <enum-item name='BOWED'/>
@@ -654,7 +679,7 @@
         <enum-item name='AIR_AGAINST_FIPPLE'/>
     </enum-type>
 
-    <enum-type type-name='pitch_choice_type'>
+    <enum-type type-name='pitch_choice_type' base-type='int32_t'> bay12: PitchChoiceMethodType
         <enum-item name='MEMBRANE_POSITION'/>
         <enum-item name='SUBPART_CHOICE'/>
         <enum-item name='KEYBOARD'/>
@@ -670,7 +695,7 @@
         <enum-item name='FOOT_PEDALS'/>
     </enum-type>
 
-    <enum-type type-name='tuning_type'>
+    <enum-type type-name='tuning_type' base-type='int32_t'> bay12: TuningMethodType
         <enum-item name='PEGS'/>
         <enum-item name='ADJUSTABLE_BRIDGES'/>
         <enum-item name='CROOKS'/>
@@ -678,7 +703,7 @@
         <enum-item name='LEVERS'/>
     </enum-type>
 
-    <enum-type type-name='timbre_type'>
+    <enum-type type-name='timbre_type' base-type='int32_t'> bay12: TimbreType
         <enum-item name='CLEAR'/>
         <enum-item name='NOISY'/>
         <enum-item name='FULL'/>
@@ -751,25 +776,25 @@
         <enum-item name='SPARKLING'/>
     </enum-type>
 
-    <struct-type type-name='instrument_piece'>
+    <struct-type type-name='instrument_piece' original-name='instrument_piece_defst'>
         <stl-string name='type'/>
         <stl-string name='id'/>
         <int32_t name ='index'/>
         <stl-string name="name"/>
         <stl-string name="name_plural"/>
-        <bitfield base-type='uint32_t' name='flags'>
+        <bitfield base-type='uint32_t' name='flags'> bay12: INSTRUMENT_PIECE_DEF_FLAG_*
             <flag-bit name='always_singular'/>
             <flag-bit name='always_plural'/>
         </bitfield>
     </struct-type>
 
-    <struct-type type-name='instrument_register'>
+    <struct-type type-name='instrument_register' original-name='instrument_registerst'>
         <int32_t name ='pitch_range_min'/>
         <int32_t name ='pitch_range_max'/>
         <stl-vector type-name='timbre_type' name='timbres'/>
     </struct-type>
 
-    <enum-type type-name='pants_flags'>
+    <enum-type type-name='pants_flags'> bay12: ItemDefPantsFlagType
         <enum-item name='METAL_ARMOR_LEVELS'/>
     </enum-type>
 
@@ -788,9 +813,9 @@
         <int16_t name="lbstep"/>
 
         <compound name='props' type-name='armor_properties'/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector comment='items pointed to are 8 bytes'/>
+
+        <int32_t name='texpos_item'/>
+        <stl-vector name='graphics_info' comment='item_pants_graphics_infost'/>
     </class-type>
 
     <class-type type-name='itemdef_shieldst' inherits-from='itemdef'
@@ -803,12 +828,12 @@
         <int8_t name='armorlevel'/>
         <int16_t name="upstep"/>
         <int32_t name="material_size"/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector comment='items pointed to are 8 bytes'/>
+        <int32_t name='texpos_item'/>
+        <int32_t name='texpos_item_wooden'/>
+        <stl-vector name='graphics_info' comment='item_shield_graphics_infost'/>
     </class-type>
 
-    <enum-type type-name='shoes_flags'>
+    <enum-type type-name='shoes_flags'> bay12: ItemDefShoesFlagType
         <enum-item name='METAL_ARMOR_LEVELS'/>
     </enum-type>
 
@@ -824,9 +849,9 @@
         <int32_t name="material_size"/>
 
         <compound name='props' type-name='armor_properties'/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector comment='items pointed to are 8 bytes'/>
+        <int32_t name='texpos_item'/>
+        <int32_t name='texpos_item_metal'/>
+        <stl-vector name='graphics_info' comment='item_shoes_graphics_infost'/>
     </class-type>
 
     <class-type type-name='itemdef_siegeammost' inherits-from='itemdef'
@@ -835,11 +860,11 @@
         <stl-string name="name_plural"/>
         <stl-string name="ammo_class"/>
 
-        <static-array type-name='int32_t' count='16'/>
-        <stl-vector comment='items pointed to are 8 bytes'/>
-</class-type>
+        <static-array name='texpos' type-name='int32_t' count='16'/>
+        <stl-vector name='graphics_info' comment='itemdef_siegeammo_graphics_infost'/>
+    </class-type>
 
-    <enum-type type-name='tool_flags'>
+    <enum-type type-name='tool_flags' base-type='int32_t'> bay12: ItemDefToolFlagType
         <enum-item name='HARD_MAT'/>
         <enum-item name='METAL_MAT'/>
         <enum-item name='HAS_EDGE_ATTACK'/>
@@ -860,9 +885,11 @@
         <enum-item name='NO_DEFAULT_JOB'/>
         <enum-item name='INCOMPLETE_ITEM'/>
         <enum-item name='SHEET_MAT'/>
+        <enum-item name='NO_DEFAULT_IMPROVEMENTS'/>
+        <enum-item name='USES_FACE_IMAGE_SET'/>
     </enum-type>
 
-    <enum-type type-name='tool_uses' base-type='int16_t'>
+    <enum-type type-name='tool_uses' base-type='int16_t'> bay12: ItemDefToolUseType
         <enum-item name='NONE' value='-1'/>
         <enum-item name='LIQUID_COOKING'/>
         <enum-item name='LIQUID_SCOOP'/>
@@ -900,14 +927,12 @@
         <int32_t name="value"/>
         <uint8_t name="tile"/>
 
-        <stl-vector name="tool_use">
-            <enum base-type='int16_t' type-name='tool_uses'/>
-        </stl-vector>
+        <stl-vector name="tool_use" type-name='tool_uses'/>
 
         <stl-string name="adjective"/>
         <int32_t name="size"/>
-        <enum base-type="int16_t" type-name="job_skill" name="skill_melee"/>
-        <enum base-type="int16_t" type-name="job_skill" name="skill_ranged"/>
+        <enum type-name="job_skill" name="skill_melee"/>
+        <enum type-name="job_skill" name="skill_ranged"/>
         <stl-string name="ranged_ammo"/>
         <int32_t name="two_handed"/>
         <int32_t name="minimum_size"/>
@@ -924,21 +949,21 @@
         <stl-vector name='shape_category' type-name='int32_t' ref-target='descriptor_shape' since='v0.47.01'/>
         <stl-string name="description" since='v0.42.01'/>
         <stl-vector name="default_improvements" since='v0.42.01'>
-            <pointer>
-                <enum base-type="int32_t" type-name="improvement_type" name="type"/>
+            <pointer> bay12: itemdef_default_improvementst
+                <enum type-name="improvement_type" name="type"/>
                 <enum base-type="int32_t" type-name="itemimprovement_specific_type" name="specific_type"/>
                 <stl-string name="instrument_part"/>
-                <enum base-type="int32_t" type-name="tool_flags" name="restriction"/>
+                <enum type-name="tool_flags" name="restriction"/>
             </pointer>
         </stl-vector>
-        <static-array type-name="int32_t" count="68"/>
-        <stl-vector type-name="int32_t"/>
-        <stl-vector type-name="int32_t"/>
-        <stl-vector/>
-        <stl-vector/>
+        <static-array name='texpos' type-name="int32_t" count="68"/>
+        <stl-vector name='texpos_global_shape_index' type-name="int32_t"/>
+        <stl-vector name='texpos_global_shape_texpos' type-name="int32_t"/>
+        <stl-vector name='graphics_info' comment='item_tool_graphics_infost'/>
+        <stl-vector name='food_container_graphics_info' comment='item_food_container_graphics_infost'/>
     </class-type>
 
-    <enum-type type-name='toy_flags'>
+    <enum-type type-name='toy_flags'> bay12: ItemDefToyFlagType
         <enum-item name='HARD_MAT'/>
     </enum-type>
 
@@ -947,15 +972,15 @@
         <stl-string name="name"/>
         <stl-string name="name_plural"/>
         <df-flagarray name='flags' index-enum='toy_flags'/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <int32_t/>
-        <stl-vector/>
+        <int32_t name='texpos_item'/>
+        <int32_t name='texpos_item_wood'/>
+        <int32_t name='texpos_item_stone'/>
+        <int32_t name='texpos_item_metal'/>
+        <int32_t name='texpos_item_glass'/>
+        <stl-vector name='graphics_info' comment='item_toy_graphics_infost'/>
     </class-type>
 
-    <enum-type type-name='trapcomp_flags'>
+    <enum-type type-name='trapcomp_flags'> bay12: ItemDefTrapCompFlagType
         <enum-item name='IS_SCREW'/>
         <enum-item name='IS_SPIKE'/>
         <enum-item name='WOOD'/>
@@ -977,11 +1002,11 @@
         <df-flagarray name='flags' index-enum='trapcomp_flags'/>
 
         <stl-vector name="attacks" pointer-type='weapon_attack'/>
-        <static-array type-name='int32_t' count='22'/>
-        <stl-vector/>
+        <static-array name='texpos' type-name='int32_t' count='22'/>
+        <stl-vector name='graphics_info' comment='itemdef_trapcomp_graphics_infost'/>
     </class-type>
 
-    <enum-type type-name='weapon_flags'>
+    <enum-type type-name='weapon_flags'> bay12: ItemDefWeaponFlagType
         <enum-item name='CAN_STONE'/>
         <enum-item name='HAS_EDGE_ATTACK'/>
         <enum-item name='TRAINING'/>
@@ -994,8 +1019,8 @@
         <stl-string name="adjective"/>
         <int32_t name="size"/>
         <int32_t name="value"/>
-        <enum base-type="int16_t" type-name="job_skill" name="skill_melee"/>
-        <enum base-type="int16_t" type-name="job_skill" name="skill_ranged"/>
+        <enum type-name="job_skill" name="skill_melee"/>
+        <enum type-name="job_skill" name="skill_ranged"/>
         <stl-string name="ranged_ammo"/>
         <int32_t name="two_handed"/>
         <int32_t name="minimum_size"/>
@@ -1004,8 +1029,8 @@
         <stl-vector name="attacks" pointer-type='weapon_attack'/>
         <int32_t name="shoot_force"/>
         <int32_t name="shoot_maxvel"/>
-        <static-array type-name='int32_t' count='26'/>
-        <stl-vector/>
+        <static-array name='texpos' type-name='int32_t' count='25'/>
+        <stl-vector name='graphics_info' comment='itemdef_weapon_graphics_infost'/>
     </class-type>
 </data-definition>
 

--- a/df.item-vectors.xml
+++ b/df.item-vectors.xml
@@ -710,7 +710,7 @@
 
         <enum-item name='ANY_RECENTLY_DROPPED'/>
         <enum-item name='ANY_MELT_DESIGNATED'/>
-        <enum-item comment='TEMP_SAVEi, should never actually be used'/>
+        <enum-item comment='TEMP_SAVE, should never actually be used'/>
 
         -- 90
 

--- a/df.item-vectors.xml
+++ b/df.item-vectors.xml
@@ -15,7 +15,7 @@
         <enum-item name='WEAPON'>
             <item-attr name='item' value='WEAPON'/>
         </enum-item>
-        <enum-item name='ANY_WEAPON'>
+        <enum-item name='ANY_WEAPON' comment='trapcomp, also weapons'>
             <item-attr name='generic_item' value='WEAPON'/>
             <item-attr name='generic_item' value='TRAPCOMP'/>
         </enum-item>
@@ -121,7 +121,7 @@
             <item-attr name='generic_item' value='LIQUID_MISC'/>
             <item-attr name='generic_item' value='GLOB'/>
         </enum-item>
-        <enum-item name='ANY_GENERIC24'>
+        <enum-item name='ANY_EXTRACTABLE'>
             <item-attr name='generic_item' value='CAGE'/>
             <item-attr name='generic_item' value='ANIMALTRAP'/>
             <item-attr name='generic_item' value='FISH_RAW'/>
@@ -175,7 +175,7 @@
         </enum-item>
 
         <enum-item name='ANY_DEAD_DWARF'/>
-        <enum-item name='ANY_GENERIC36'>
+        <enum-item name='ANY_GOES_IN_CHEST'>
             <item-attr name='generic_item' value='BAR'/>
             <item-attr name='generic_item' value='SMALLGEM'/>
             <item-attr name='generic_item' value='BLOCKS'/>
@@ -206,19 +206,19 @@
             <item-attr name='generic_item' value='TOOL'/>
             <item-attr name='generic_item' value='BOOK'/>
         </enum-item>
-        <enum-item name='ANY_GENERIC37'>
+        <enum-item name='ANY_GOES_IN_CABINET'>
             <item-attr name='generic_item' value='ARMOR'/>
             <item-attr name='generic_item' value='SHOES'/>
             <item-attr name='generic_item' value='HELM'/>
             <item-attr name='generic_item' value='GLOVES'/>
             <item-attr name='generic_item' value='PANTS'/>
         </enum-item>
-        <enum-item name='ANY_GENERIC38'>
+        <enum-item name='ANY_GOES_IN_WEAPONRACK'>
             <item-attr name='generic_item' value='WEAPON'/>
             <item-attr name='generic_item' value='TRAPCOMP'/>
             <item-attr name='generic_item' value='SIEGEAMMO'/>
         </enum-item>
-        <enum-item name='ANY_GENERIC39'>
+        <enum-item name='ANY_GOES_IN_ARMORSTAND'>
             <item-attr name='generic_item' value='ARMOR'/>
             <item-attr name='generic_item' value='SHOES'/>
             <item-attr name='generic_item' value='SHIELD'/>
@@ -395,7 +395,7 @@
             <item-attr name='generic_item' value='TOOL'/>
             <item-attr name='generic_item' value='EGG'/>
         </enum-item>
-        <enum-item name='ANY_GENERIC84' comment='sand-containing?'>
+        <enum-item name='ANY_GLASSABLE'>
             <item-attr name='generic_item' value='BOX'/>
         </enum-item>
 
@@ -545,7 +545,7 @@
         <enum-item name='GLOVES'>
             <item-attr name='item' value='GLOVES'/>
         </enum-item>
-        <enum-item name='ANY_GENERIC128'>
+        <enum-item name='POSSIBLE_CONTAINER'>
             <item-attr name='generic_item' value='FLASK'/>
             <item-attr name='generic_item' value='GOBLET'/>
             <item-attr name='generic_item' value='CAGE'/>
@@ -574,7 +574,7 @@
 
     </enum-type>
 
-    <enum-type type-name='job_item_vector_id' base-type='int16_t'>
+    <enum-type type-name='job_item_vector_id' base-type='int16_t'> bay12: ItemArrayType
         <enum-attr name='other' type-name='items_other_id'
                    default-value='ANY' use-key-name='true'/>
 
@@ -599,9 +599,7 @@
         <enum-item name='ANY_ARMOR_PANTS'/>
         <enum-item name='QUIVER'/>
         <enum-item name='SPLINT'/>
-        <enum-item name='ANY_14' comment='supposed to be ORTHOPEDIC_CAST'>
-            <item-attr name='other' value='ANY'/>
-        </enum-item>
+        <enum-item name='ORTHOPEDIC_CAST'/>
         <enum-item name='CRUTCH'/>
 
         <enum-item name='BACKPACK'/>
@@ -615,7 +613,7 @@
         <enum-item name='ANY_REFUSE'/>
         <enum-item name='ANY_GOOD_FOOD'/>
         <enum-item name='ANY_AUTO_CLEAN'/>
-        <enum-item name='ANY_GENERIC24' comment='vermin cage?'/>
+        <enum-item name='ANY_EXTRACTABLE'/>
         <enum-item name='ANY_BUTCHERABLE'/>
 
         <enum-item name='ANY_FURNITURE'/>
@@ -632,10 +630,10 @@
         <enum-item name='ANY_MURDERED'/>
         <enum-item name='ANY_DEAD_DWARF'/>
 
-        <enum-item name='ANY_GENERIC36'/>
-        <enum-item name='ANY_GENERIC37'/>
-        <enum-item name='ANY_GENERIC38'/>
-        <enum-item name='ANY_GENERIC39'/>
+        <enum-item name='ANY_GOES_IN_CHEST'/>
+        <enum-item name='ANY_GOES_IN_CABINET'/>
+        <enum-item name='ANY_GOES_IN_WEAPONRACK'/>
+        <enum-item name='ANY_GOES_IN_ARMORSTAND'/>
         <enum-item name='DOOR'/>
 
         -- 41
@@ -700,7 +698,7 @@
 
         <enum-item name='POWDER_MISC'/>
         <enum-item name='ANY_COOKABLE'/>
-        <enum-item name='ANY_GENERIC84'/>
+        <enum-item name='ANY_GLASSABLE'/>
         <enum-item name='VERMIN'/>
         <enum-item name='PET'/>
 
@@ -712,7 +710,7 @@
 
         <enum-item name='ANY_RECENTLY_DROPPED'/>
         <enum-item name='ANY_MELT_DESIGNATED'/>
-        <enum-item/>
+        <enum-item comment='TEMP_SAVEi, should never actually be used'/>
 
         -- 90
 
@@ -769,28 +767,22 @@
         <enum-item name='HELM'/>
         <enum-item name='GLOVES'/>
 
-        <enum-item name='ANY_124' comment='supposed to be TOOL'>
-            <item-attr name='other' value='ANY'/>
-        </enum-item>
-        <enum-item name='ANY_125' comment='supposed to be SLAB'>
-            <item-attr name='other' value='ANY'/>
-        </enum-item>
+        <enum-item name='TOOL'/>
+        <enum-item name='SLAB'/>
 
         <enum-item name='EGG'/>
 
-        <enum-item name='ANY_127' comment='supposed to be FOOD_STORAGE'>
-            <item-attr name='other' value='ANY'/>
-        </enum-item>
+        <enum-item name='POSSIBLE_CONTAINER'/>
 
         <enum-item name='ANY_CORPSE'/>
         <enum-item name='BOOK'/>
-        <enum-item since='v0.47.01'/>
+        <enum-item name='FOOD_STORAGE'/>
 
         -- 131
-        <enum-item/>
+        <enum-item name='INSTRUMENT_STATIONARY'/>
         <enum-item name='SHEET'/>
         <enum-item name='BRANCH'/>
-
+        <enum-item name='BAG'/>
     </enum-type>
 
     <df-other-vectors-type type-name='items_other' index-enum='items_other_id' item-type='item'>

--- a/df.itemimprovements.xml
+++ b/df.itemimprovements.xml
@@ -1,5 +1,5 @@
 <data-definition>
-    <enum-type type-name='improvement_type'>
+    <enum-type type-name='improvement_type' base-type='int32_t'> bay12: ItemImprovementType
         <enum-item name='NONE' value='-1'/>
         <enum-item name="ART_IMAGE"/>
         <enum-item name="COVERED"/>
@@ -17,14 +17,14 @@
         <enum-item name="IMAGE_SET"/>
     </enum-type>
 
-    <struct-type type-name='dye_info'>
+    <struct-type type-name='dye_info' comment='not actually a real structure'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
         <int32_t name='dyer' ref-target='historical_figure'/>
         <enum base-type='int16_t' name='quality' type-name='item_quality'/>
         <enum base-type='int16_t' name="skill_rating" type-name='skill_rating'
               comment='at the moment of creation'/>
-        <int32_t name='unk_1'/>
+        <int32_t name='age_counter'/>
     </struct-type>
 
     <class-type type-name='itemimprovement' original-name='itemimprovementst'>
@@ -35,7 +35,7 @@
         <enum base-type='int16_t' name='quality' type-name='item_quality'/>
         <enum base-type='int32_t' name="skill_rating" type-name='skill_rating'
               comment='at the moment of creation'/>
-        <int32_t name='unk_1'/>
+        <int32_t name='age_counter'/>
 
         <virtual-methods>
             <vmethod name='getImage'><pointer type-name='item'/>
@@ -44,7 +44,7 @@
             <vmethod name='getColorAndShape'>
                 <pointer name='colors'><stl-vector type-name='int16_t'/></pointer>
                 <pointer name='shapes'><stl-vector type-name='int16_t'/></pointer>
-                <pointer/>
+                <pointer name='item' type-name='item'/>
             </vmethod>
             <vmethod name='clone'>
                 <ret-type><pointer type-name='itemimprovement'/></ret-type>
@@ -56,7 +56,7 @@
             </vmethod>
 
             <vmethod ret-type='improvement_type' name='getType'/>
-            <vmethod ret-type='bool' name='isDecoration'/> excludes thread, cloth, and base-quality instrument pieces
+            <vmethod ret-type='bool' name='isDecoration' comment='displayed_improvement'/>
             <vmethod is-destructor='true'/>
             <vmethod ret-type='int32_t' name='getDyeValue'>
                 <pointer type-name='caravan_state' name='caravan'/>
@@ -72,7 +72,7 @@
     </class-type>
 
     <class-type type-name='itemimprovement_coveredst' inherits-from='itemimprovement'>
-        <bitfield name='cover_flags'>
+        <bitfield name='cover_flags' base-type='uint32_t'> bay12: ITEMIMPROVEMENT_COVERED_FLAG_*
             <flag-bit name='glazed'/>
         </bitfield>
         <int32_t name='shape' ref-target='descriptor_shape'/>
@@ -86,9 +86,11 @@
 
     <class-type type-name='itemimprovement_spikesst' inherits-from='itemimprovement'/>
 
-    <enum-type type-name='itemimprovement_specific_type'>
+    <enum-type type-name='itemimprovement_specific_type' base-type='int32_t'> bay12: ItemSpecificImprovementType
         <enum-item name='HANDLE'/>
         <enum-item name='ROLLERS'/>
+        <enum-item name='TRACTION_BENCH_ROPE'/>
+        <enum-item name='TRACTION_BENCH_CHAIN'/>
     </enum-type>
 
     <class-type type-name='itemimprovement_itemspecificst' inherits-from='itemimprovement'>
@@ -102,11 +104,12 @@
     <class-type type-name='itemimprovement_clothst' inherits-from='itemimprovement'/>
 
     <class-type type-name='itemimprovement_sewn_imagest' inherits-from='itemimprovement'>
+        none of these are actual compounds - beware of potential alignment/padding issues
         <compound name='image' type-name='art_image_ref'/>
         <compound name='cloth'>
-            <int32_t name='unit_id' ref-target='historical_figure'/>
+            <int32_t name='maker_hf' ref-target='historical_figure'/>
             <int16_t name='quality'/>
-            <int16_t name='unk_1'/>
+            <int16_t name='skill_rating'/>
         </compound>
         <compound name='dye' type-name='dye_info'/>
     </class-type>
@@ -118,7 +121,7 @@
 
     <class-type type-name='itemimprovement_illustrationst' inherits-from='itemimprovement'>
         <compound name='image' type-name='art_image_ref'/>
-        <int32_t name='unk_2' since='v0.34.01'/>
+        <int32_t name='page_number' since='v0.34.01'/> bay12: III_PAGE_* for several special negative values
     </class-type>
 
     <class-type type-name='itemimprovement_instrument_piecest' inherits-from='itemimprovement'>
@@ -133,7 +136,7 @@
         <int32_t name='image_set_id' init-value='-1' ref-target='image_set'/>
     </class-type>
 
-    <enum-type type-name='written_content_type' base-type='int32_t'> bay12: WritingForm
+    <enum-type type-name='written_content_type' base-type='int32_t'> bay12: WritingFormType
         <enum-item name='NONE' value='-1'/>
         <enum-item name='Manual'/>
         <enum-item name='Guide'/>
@@ -163,7 +166,7 @@
         <enum-item name='Atlas'/>
     </enum-type>
 
-    <enum-type type-name='written_content_style' base-type='int32_t'>
+    <enum-type type-name='written_content_style' base-type='int32_t'> bay12: WritingStyleType
         <enum-item name='Meandering'/>
         <enum-item name='Cheerful'/>
         <enum-item name='Depressing'/>
@@ -184,24 +187,45 @@
         <enum-item name='Ranting'/>
     </enum-type>
 
-    <struct-type type-name='written_content' instance-vector='$global.world.written_contents.all' key-field='id'>
+    <enum-type type-name='writing_style_modifier_type' base-type='int32_t'> bay12: WritingStyleModifierType
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='Thorough'/>
+        <enum-item name='Somewhat'/>
+        <enum-item name='Hint'/>
+    </enum-type>
+
+    <enum-type type-name='writing_role_type' base-type='int32_t'> bay12: WritingRoleType
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='Subject'/>
+        <enum-item name='Narrator'/>
+        <enum-item name='Character'/>
+        <enum-item name='Writer'/>
+        <enum-item name='Recipient'/>
+        <enum-item name='Chapter'/>
+        <enum-item name='MoralLesson'/>
+        <enum-item name='AssociatedPoem' comment='from MusicalComposition'/>
+        <enum-item name='AssociatedMusicalComposition' comment='from Choreography'/>
+        <enum-item name='ValueAgenda'/>
+    </enum-type>
+
+    <struct-type type-name='written_content' original-name='written_contentst' instance-vector='$global.world.written_contents.all' key-field='id'>
         <int32_t name='id'/>
         <stl-string name='title'/>
         <int32_t name='page_start'/>
         <int32_t name='page_end'/>
         <stl-vector name='refs' pointer-type='general_ref' comment='interactions learned'/>
-        <stl-vector name='ref_aux' type-name='int32_t' comment='if nonzero, corresponding ref is ignored'/>
-        <int32_t name='unk1' init-value='-1'/>
-        <int32_t name='unk2' init-value='-1'/>
+        <stl-vector name='ref_aux' type-name='writing_role_type'/>
+        <int32_t name='chapter_number' init-value='-1'/>
+        <int32_t name='section_number' init-value='-1'/>
         <enum type-name='written_content_type' name='type'/>
-        <int32_t name='poetic_form' since='v0.42.01' ref-target='poetic_form'/>
+        <int32_t name='poetic_form' since='v0.42.01' ref-target='poetic_form' comment='or musical composition or dance'/>
         <stl-vector name='styles' type-name='written_content_style'/>
-        <stl-vector name='style_strength' type-name='int32_t' comment='0 = maximum, 1 = significant, 2 = partial'/>
+        <stl-vector name='style_strength' type-name='writing_style_modifier_type'/>
         <int32_t name='author' ref-target='historical_figure'/>
-        <int32_t name='author_roll' init-value='-1'/>
+        <int32_t name='author_roll' init-value='-1' comment='skill roll for quality'/>
     </struct-type>
 
-    <bitfield-type type-name='engraving_flags' base-type='uint32_t'>
+    <bitfield-type type-name='engraving_flags' base-type='uint32_t'> bay12: EVENTDETAILFLAG_*
         <flag-bit name='floor'/>
         <flag-bit name='west'/>
         <flag-bit name='east'/>
@@ -214,19 +238,20 @@
         <flag-bit name='southeast'/>
     </bitfield-type>
 
-    <struct-type type-name='engraving' instance-vector='$global.world.engravings'>
+    <struct-type type-name='engraving' original-name='event_detailst' instance-vector='$global.world.engravings'>
         <int32_t name='artist' ref-target='historical_figure'/>
         <int32_t name='masterpiece_event' ref-target='history_event'/>
         <enum base-type='int32_t' name="skill_rating" type-name='skill_rating'
               comment='at the moment of creation'/>
         <compound name='pos' type-name='coord'/>
         <bitfield name='flags' type-name='engraving_flags'/>
-        <int8_t name='tile'/>
+        <uint8_t name='tile'/>
+        can't use "art_image_ref" here because Toady put the "quality" field in the middle
         <int32_t name='art_id' ref-target='art_image_chunk'/>
         <int16_t name='art_subid' ref-target='art_image' aux-value='$$.art_id'/>
         <enum base-type='int16_t' name='quality' type-name='item_quality'/>
-        <int32_t name='unk1' init-value='-1' since='v0.34.06'/>
-        <int32_t name='unk2' init-value='-1' since='v0.34.06'/>
+        <int32_t name='art_civ' ref-target='historical_entity' since='v0.34.06'/>
+        <int32_t name='art_site' ref-target='world_site' since='v0.34.06'/>
     </struct-type>
 
 </data-definition>

--- a/df.items.xml
+++ b/df.items.xml
@@ -1,7 +1,7 @@
 <data-definition>
     -- MISC TYPES
 
-    <bitfield-type type-name='item_flags'>
+    <bitfield-type type-name='item_flags' base-type='uint32_t'> bay12: ITEMFLAG_*
         <flag-bit name='on_ground' comment='Item on ground'/>
         <flag-bit name='in_job' comment='Item currently being used in a job'/>
         <flag-bit name='hostile' comment='Item owned by hostile'/>
@@ -43,7 +43,7 @@
         <flag-bit name='from_worldgen' comment='bay12: DO_NOT_RETAIN_IN_CREATION_ZONE'/>
     </bitfield-type>
 
-    <bitfield-type type-name='item_flags2'>
+    <bitfield-type type-name='item_flags2' base-type='uint32_t'> bay12: ITEMFLAG2_*
         <flag-bit name='has_rider' comment='vehicle with a rider'/>
         <flag-bit name='forbid_on_unretire'/>
         <flag-bit name='grown'/>
@@ -52,23 +52,29 @@
         <flag-bit name='might_contain_artifact'/>
     </bitfield-type>
 
-    <enum-type type-name='item_magicness_type' base-type='int16_t'>
-        <enum-item name='Sparkle'/>
-        <enum-item name='AirWarped'/>
-        <enum-item name='Whistle'/>
-        <enum-item name='OddlySquare'/>
-        <enum-item name='SmallBumps'/>
-        <enum-item name='EarthSmell'/>
-        <enum-item name='Lightning'/>
-        <enum-item name='GrayHairs' comment='with value of 10 or higher, creatures that look at the item cannot think negative thoughts'/>
-        <enum-item name='RustlingLeaves'/>
+    <enum-type type-name='item_magicness_type'> bay12: ItemPowers, no base type
+        <enum-item name='Sparkle' comment='Speed'/>
+        <enum-item name='AirWarped' comment='Storage'/>
+        <enum-item name='Whistle' comment='Add Damage'/>
+        <enum-item name='OddlySquare' comment='Add DamBlock'/>
+        <enum-item name='SmallBumps' comment='Resist Pierce'/>
+        <enum-item name='EarthSmell' comment='Resist Bludgeon'/>
+        <enum-item name='Lightning' comment='Resist Slash'/>
+        <enum-item name='GrayHairs' comment='Resist Gore; with value of 10 or higher, creatures that look at the item cannot think negative thoughts'/>
+        <enum-item name='RustlingLeaves' comment='Thorn Burst'/>
     </enum-type>
 
-    <struct-type type-name='item_magicness'>
+    <struct-type type-name='item_magicness' original-name='item_powerst'>
         <enum base-type='int16_t' name="type" type-name='item_magicness_type'/>
         <int16_t name='value' comment='boosts item value by 50*this'/>
-        <int16_t name='unk_1'/>
-        <int32_t name='flags' comment='1=does not show up in item description or alter item value'/>
+        <int16_t name='gloss'/>
+        <bitfield name='flags' base-type='uint32_t'> bay12: MAGICALPOWERFLAG_
+            <flag-bit name='inactive'/>
+        </bitfield>
+    </struct-type>
+
+    <struct-type type-name='item_magicalst'>
+        <stl-vector name='power' pointer-type='item_magicness'/>
     </struct-type>
 
     <struct-type type-name='temperaturest'> seems like a convenient name
@@ -76,27 +82,32 @@
         <int16_t name='fraction' init-value='0'/>
     </struct-type>
 
-    <struct-type type-name='spatter_common'>
+    <struct-type type-name='massst'>
+        <int32_t name='whole' comment='kilograms'/>
+        <int32_t name='fraction' comment='milligrams'/>
+    </struct-type>
+
+    <struct-type type-name='spatter_common' original-name='contaminantst'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
         <enum type-name='matter_state' base-type='int16_t' name='mat_state'/>
         <compound name='temperature' type-name='temperaturest'/>
         <int32_t name='size' comment='1-24=spatter, 25-49=smear, 50-* = coating'/>
-        <bitfield base-type='uint16_t' name='base_flags' since='v0.40.13'>
+        <bitfield base-type='uint16_t' name='base_flags' since='v0.40.13'> bay12: CONTAMINANT_FLAG_*
             <flag-bit name='evaporates' comment='does not contaminate tile when washed away'/>
         </bitfield>
-        <padding name='pad_1' size='2' comment='needed for proper alignment of spatter on gcc'/>
     </struct-type>
 
-    <struct-type type-name='spatter' inherits-from='spatter_common'>
+    <struct-type type-name='spatter' original-name='item_contaminantst'>
+        <compound name='base' type-name='spatter_common'/> sub-element, NOT subclass!
         <int16_t name='body_part_id'
                  refers-to='$$._global._parent._global.body.body_plan.body_parts[$]'/>
-        <bitfield base-type='uint16_t' name='flags'>
-            <flag-bit name='water_soluble'/>
+        <bitfield base-type='uint16_t' name='flags'> bay12: ITEM_CONTAMINANT_FLAG_
+            <flag-bit name='water_soluble' comment='bay12: EXTERNAL'/>
         </bitfield>
     </struct-type>
 
-    <enum-type type-name='item_quality' base-type='int16_t'>
+    <enum-type type-name='item_quality' base-type='int16_t'> DFHack-only
         <enum-item name='Ordinary'/>
         <enum-item name='WellCrafted'/>
         <enum-item name='FinelyCrafted'/>
@@ -106,7 +117,7 @@
         <enum-item name='Artifact'/>
     </enum-type>
 
-    <enum-type type-name='slab_engraving_type' base-type='int16_t'> bay12: EngravingIntent/EngravingIntentType
+    <enum-type type-name='slab_engraving_type' base-type='int16_t'> bay12: EngravingIntentType
         <enum-item name='Slab' value='-1'/>
         <enum-item name='Memorial'/>
         <enum-item name='CraftShopSign' comment='STORE_CRAFTS'/>
@@ -137,7 +148,7 @@
         <enum-item name='DemonIdentity' comment='when a demon assumes identity? (TRUE_NAME)'/>
     </enum-type>
 
-    <enum-type type-name='trade_good_purpose' base-type='int16_t'>
+    <enum-type type-name='trade_good_purpose' base-type='int16_t'> bay12: TradeGoodPurposeType
         <enum-item name='NONE' value='-1'/>
         <enum-item name='MERCHANT'/>
         <enum-item name='TRAVELER'/>
@@ -158,6 +169,12 @@
         <enum-item name='PILLAGE'/>
     </enum-type>
 
+    <enum-type type-name='article_type'> bay12: Article, no base type
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='INDEFINITE' comment='a'/>
+        <enum-item name='DEFINITE' comment='the'/>
+    </enum-type>
+
     -- CORE ITEM
 
     <class-type type-name='item' original-name='itemst'
@@ -176,12 +193,11 @@
         <int32_t name='world_data_id' ref-target='world_object_data' since='v0.34.01'/>
         <int32_t name='world_data_subid' init-value='-1' since='v0.34.01'/>
 
-        <uint8_t name='stockpile_countdown' comment='-1 per 50 frames; then check if needs moving'/>
-        <uint8_t name='stockpile_delay' comment='used to reset countdown; randomly varies'/>
+        <int8_t name='stockpile_countdown' comment='-1 per 50 frames; then check if needs moving'/>
+        <int8_t name='stockpile_delay' comment='used to reset countdown; randomly varies'/>
 
-        <int16_t name='unk2'/>
-        <int32_t name='base_uniform_score'/>
-        <int16_t name='walkable_id' comment='from map_block.walkable'/>
+        <int32_t name='base_uniform_score' comment='temporary_32'/>
+        <int16_t name='walkable_id' comment='temporary_16; from map_block.walkable'/>
         <uint16_t name='spec_heat'/>
         <uint16_t name='ignite_point'/>
         <uint16_t name='heatdam_point'/>
@@ -190,8 +206,7 @@
         <uint16_t name='melting_point'/>
         <uint16_t name='fixed_temp'/>
 
-        <int32_t name='weight' comment='if flags.weight_computed'/>
-        <int32_t name='weight_fraction' comment='1e-6'/>
+        <compound name='weight' type-name='massst' comment='if flags.weight_computed'/>
 
         <virtual-methods>
             <vmethod ret-type='item_type' name='getType'/>
@@ -219,7 +234,7 @@
             <vmethod name='setGrowthPrint' since='v0.40.01'><int32_t name='print'/></vmethod>
             <vmethod ret-type='int32_t' name='getDimension' since='v0.40.01'/>
 
-            <vmethod ret-type='int32_t' name='getTotalDimension'/>
+            <vmethod ret-type='int32_t' name='getTotalDimension' comment='get_item_search_contribution'/>
             <vmethod name='setDimension'> <int32_t name='amount'/> </vmethod>
             <vmethod ret-type='bool' name='subtractDimension'> <int32_t name='amount'/> </vmethod>
 
@@ -230,17 +245,17 @@
 
             <vmethod ret-type='bool' name='isWheelbarrow'/>
             <vmethod ret-type='int32_t' name='getVehicleID'/>
-            <vmethod ret-type='bool' name='isAmmo'/>
+            <vmethod ret-type='bool' name='isCrafted'/>
             <vmethod name='getStockpile'>
                 <ret-type><pointer type-name='item_stockpile_ref'/></ret-type>
             </vmethod>
             <vmethod ret-type='bool' name='containsPlaster'/>
 
             <vmethod ret-type='bool' name='isPlaster'/>
-            <vmethod ret-type='bool' name='getColorOverride'> <pointer/> </vmethod>
+            <vmethod ret-type='bool' name='getColorOverride'> <int16_t name='bg'/> </vmethod>
 
             <vmethod name='getHistoryInfo'>
-                <ret-type><pointer><pointer type-name='item_history_info'/></pointer></ret-type>
+                <ret-type><pointer type-name='item_profilest'/></ret-type>
             </vmethod>
             <vmethod ret-type='bool' name='hasToolUse'> <enum base-type='int16_t' type-name='tool_uses' name='use'/> </vmethod>
             <vmethod ret-type='bool' name='hasInvertedTile'/>
@@ -255,7 +270,7 @@
 
             <vmethod ret-type='bool' name='isMetalOre'> <int16_t name='matIndex'/> </vmethod>
             <vmethod name='clearLastTempUpdateTS'/>
-            <vmethod name='listNotableKills'> <pointer type-name='stl-string' name='string_ptr'/> </vmethod>
+            <vmethod name='listNotableKills'> <pointer type-name='stl-string' name='string_ptr'/> <uint32_t name='flag'/></vmethod>
             <vmethod ret-type='uint16_t' name='getSpecHeat'/>
             <vmethod ret-type='uint16_t' name='getIgnitePoint'/>
 
@@ -272,29 +287,29 @@
             <vmethod ret-type='uint16_t' name='getTemperature'/>
             <vmethod ret-type='bool' name='adjustTemperature'>
                 <uint16_t name='target'/>
-                <int32_t name='unk'/>
+                <int32_t name='amp'/>
             </vmethod>
-            <vmethod comment='initialization for body components?'/>
+            <vmethod name='evaluate_corpse_flags' comment='initialization for body components'/>
 
             -- 50
 
-            <vmethod name='extinguish'/>
+            <vmethod name='set_placement_information'/>
             <vmethod ret-type='int8_t' name='getGloveHandedness'/>
-            <vmethod name='setGloveHandedness'> <int8_t/> </vmethod>
+            <vmethod name='setGloveHandedness'> <uint32_t name='flag'/> </vmethod>
             <vmethod ret-type='bool' name='isSpike'/>
             <vmethod ret-type='bool' name='isScrew'/>
 
             <vmethod ret-type='bool' name='isBuildMat'/>
             <vmethod ret-type='bool' name='isTemperatureSafe'> <int8_t comment='1 fire, 2 magma'/> </vmethod>
             <vmethod name='setRandSubtype'> <int32_t name='entity_id'/> </vmethod>
-            <vmethod ret-type='int8_t' name='getWeaponSize' comment='weapon racks have capacity 5'/>
+            <vmethod ret-type='int32_t' name='getWeaponSize' comment='weapon racks have capacity 5'/>
             <vmethod ret-type='int16_t' name='getWear'/>
 
             - 60
 
             <vmethod name='setWear'> <int16_t/> </vmethod>
             <vmethod ret-type='int32_t' name='getMaker'/>
-            <vmethod name='setMaker'> <int32_t name='unit_id'/> </vmethod>
+            <vmethod name='setMaker'> <int32_t name='hf_id' ref-target='historical_figure'/> </vmethod>
             <vmethod name='getCorpseInfo'>
                 <pointer type-name='int16_t' name='prace'/>
                 <pointer type-name='int16_t' name='pcaste'/>
@@ -307,10 +322,10 @@
             <vmethod name='getItemShapeDesc' comment='a statue/figurine of "string goes here"'>
                 <ret-type><pointer type-name='stl-string'/></ret-type>
             </vmethod>
-            <vmethod comment='returns null except for statues; for statues returns pointer to unk_110'>
+            <vmethod name='get_art_graphics_type_ptr'>
                 <ret-type><pointer type-name='int32_t'/></ret-type>
             </vmethod>
-            <vmethod comment='returns null except for statues; for statues returns pointer to unk_114'>
+            <vmethod name='get_art_graphics_id_ptr'>
                 <ret-type><pointer type-name='int32_t'/></ret-type>
             </vmethod>
             <vmethod ret-type='bool' name='isMatchingAmmoItem'> <pointer type-name='item_filter_spec'/> </vmethod>
@@ -318,8 +333,8 @@
             -- 70
 
             <vmethod name='getImageRef'>
-                <pointer name='id'><pointer type-name='int32_t'/></pointer>
-                <pointer name='subid'><pointer type-name='int16_t'/></pointer>
+                <pointer name='id' pointer-type='int32_t'/> pointer-to-ref
+                <pointer name='subid' pointer-type='int16_t'/>
             </vmethod>
             <vmethod name='getImageCivSite'>
                 <pointer type-name='int32_t' name='civ_id' ref-target='historical_entity'/>
@@ -329,7 +344,7 @@
                 <int32_t name='civ_id' ref-target='historical_entity'/>
                 <int32_t name='site_id' ref-target='world_site'/>
             </vmethod>
-            <vmethod name='setSeedsPlantSkillLevel'> <int32_t name='level'/> </vmethod>
+            <vmethod name='setSeedsPlantSkillLevel'> <int16_t name='level'/> </vmethod>
             <vmethod ret-type='int16_t' name='getCorpseSize' comment='size_info.size_cur'/>
 
             <vmethod ret-type='bool' name='ageItem'><int32_t name='amount'/></vmethod>
@@ -342,9 +357,9 @@
 
             <vmethod name='setRotTimer'> <int32_t name='val'/> </vmethod>
             <vmethod name='incrementRotTimer'/>
-            <vmethod ret-type='bool' name='isBogeymanCorpse'/>
-            <vmethod ret-type='bool' name='testMaterialFlag' comment='return true if item satisfies flag'>
-                <enum base-type='int32_t' type-name='material_flags' name='mat_flag'/>
+            <vmethod ret-type='bool' name='instantRot'/>
+            <vmethod ret-type='bool' name='fitsCivRequestTab'>
+                <enum base-type='int16_t' type-name='entity_sell_category' name='civ_request_tab'/>
             </vmethod>
             <vmethod name='getAmmoType'>
                 <ret-type><pointer type-name='stl-string'/></ret-type>
@@ -357,32 +372,25 @@
             <vmethod ret-type='int32_t' name='getVolume' comment='for putting in containers, building clutter'/>
             <vmethod name='addImprovementFromJob'>
                 <ret-type><pointer type-name='itemimprovement'/></ret-type>
-                <enum base-type='int32_t' type-name='improvement_type' name='imp_type'/>
+                <enum type-name='improvement_type' name='imp_type'/>
                 <pointer type-name='job' name='job'/>
                 <pointer type-name='unit' name='unit'/>
                 <int16_t name='mat_type'/>
                 <int32_t name='mat_index'/>
                 <int32_t name='shape' ref-target='descriptor_shape'/>
-                <int16_t name='force_quality'/>
+                <int32_t name='force_quality'/>
                 <pointer type-name='historical_entity' name='civ'/>
                 <pointer type-name='world_site' name='site'/>
                 <enum type-name='trade_good_purpose' name='tradegoodpurpose'/>
                 <bool name='suppress_shaping'/>
                 <bool name='use_roll'/>
                 <int32_t name='roll'/>
-                <comment>
-                virtual itemimprovementst *improve(
-                    ItemImprovement imp,jobst *jbp,unitst *un,Material mat,MatGloss mg,int32_t shape,
-                    int32_t force_quality,entityst *civ,sitest *st,TradeGoodPurpose tradegoodpurpose,
-                    bool suppress_shaping,bool use_roll,RollResult roll
-                )
-                </comment>
             </vmethod>
 
             -- 90
 
-            <vmethod ret-type='bool' name='isWeapon'/>
-            <vmethod ret-type='bool' name='isArmorNotClothing'/>
+            <vmethod ret-type='bool' name='isWeapon' comment='rackitem, goes in weapon racks'/>
+            <vmethod ret-type='bool' name='isArmorNotClothing' comment='standitem, goes in armor stands'/>
             <vmethod ret-type='bool' name='isMillable'/>
             <vmethod ret-type='bool' name='isProcessableThread'/>
             <vmethod ret-type='bool' name='isProcessableVial'/>
@@ -390,19 +398,13 @@
             <vmethod ret-type='bool' name='isProcessableBarrel'/>
             <vmethod ret-type='bool' name='isEdiblePlant'/>
             <vmethod ret-type='bool' name='isEdibleRaw'> <int32_t name='hunger'/> </vmethod>
-            <vmethod ret-type='bool' name='isEdibleCarnivore'>
-                <comment>In item_foodst, requires MEAT or FISH ingredient.</comment>
-                <int32_t name='hunger'/>
-            </vmethod>
-            <vmethod ret-type='bool' name='isEdibleBonecarn'>
-                <comment>In item_foodst, requires CORPSEPIECE, MEAT or FISH ingredient.</comment>
-                <int32_t name='hunger'/>
-            </vmethod>
+            <vmethod ret-type='bool' name='isEdibleCarnivore'> <int32_t name='hunger'/> </vmethod>
+            <vmethod ret-type='bool' name='isEdibleBonecarn'> <int32_t name='hunger'/> </vmethod>
 
             -- 100
 
             <vmethod ret-type='bool' name='moveToGround'>
-                <int16_t name='x'/> <int16_t name='y'/> <int16_t name='z'/>
+                <int32_t name='x'/> <int32_t name='y'/> <int32_t name='z'/>
             </vmethod>
             <vmethod name='categorize' comment='Add item to world.items.other.*'> <bool name='in_play'/> </vmethod>
             <vmethod name='uncategorize' comment='Remove item from world.items.other.*'/>
@@ -414,27 +416,25 @@
                 <pointer name='maker' type-name='unit'/>
                 <enum base-type='int16_t' name='job_skill' type-name='job_skill'/>
             </vmethod>
-            <vmethod ret-type='item_quality' name='assignQuality2'> called by assignQuality
+            <vmethod ret-type='item_quality' name='assignQualityRoll'>
                 <pointer name='maker' type-name='unit'/>
                 <enum base-type='int16_t' name='job_skill' type-name='job_skill'/>
                 <int32_t name='skill_roll' comment='preferences add 10 to this, need 55 to roll masterworks'/>
             </vmethod>
             <vmethod name='notifyCreatedMasterwork'>
                 <pointer name='maker' type-name='unit'/>
-                <pointer/>
-                <pointer/>
             </vmethod>
             <vmethod name='notifyLostMasterwork'/>
 
             -- 110
 
-            <vmethod name='addMagic'><int32_t/><int32_t/><int32_t/></vmethod>
-            <vmethod name='magic_unk1'><int32_t/><int32_t/></vmethod>
-            <vmethod name='magic_unk2'><int32_t/><int32_t/></vmethod>
-            <vmethod name='magic_unk3'><int32_t/></vmethod>
-            <vmethod name='magic_unk4'><int32_t/><int32_t/><int32_t/></vmethod>
+            <vmethod name='addpower'><enum name='ptype' type-name='item_magicness_type' base-type='int32_t'/><int16_t name='availpower'/><int16_t name='donorpower'/></vmethod>
+            <vmethod name='additempower'><pointer name='item' type-name='item'/><bool name='dwarfmake'/></vmethod>
+            <vmethod name='addimppower'><pointer name='imp' type-name='itemimprovement'/><bool name='dwarfmake'/></vmethod>
+            <vmethod name='addnamepower'><bool name='dwarfmake'/></vmethod>
+            <vmethod name='getavailpower'><static-array name='availpower' count='9' type-name='int16_t' index-enum='item_magicness_type'/><bool name='dwarfmake'/><bool name='subtract_current'/></vmethod>
 
-            <vmethod name='setDisplayColor'><pointer/></vmethod>
+            <vmethod name='setDisplayColor'><int16_t name='bg'/></vmethod>
             <vmethod ret-type='bool' name='isDamagedByHeat'/>
             <vmethod ret-type='bool' name='needTwoHandedWield'> <int32_t/> </vmethod>
 
@@ -448,21 +448,21 @@
             -- 120
 
             <vmethod ret-type='bool' name='isDye'/>
-            <vmethod ret-type='bool' name='isMilkable'><int32_t/><int32_t/></vmethod>
+            <vmethod ret-type='bool' name='isMilkable'><bool name='container_allowed'/><bool name='checkres'/></vmethod>
             <vmethod ret-type='bool' name='isSandBearing'/>
             <vmethod ret-type='bool' name='isLyeBearing'/>
             <vmethod ret-type='bool' name='isAnimalProduct'/>
 
             <vmethod name='getStorageInfo'>
-                <pointer type-name='int16_t' name='item_type'/>
-                <pointer type-name='int16_t' name='material_category'/>
+                <pointer type-name='item_type' name='item_type'/>
+                <pointer name='material_category'><enum type-name='entity_material_category'/></pointer> codegen workaround, enum forward declaration was missing the base-type
             </vmethod>
             <vmethod ret-type='bool' name='addWear'>
-                <int32_t name='delta'/> <bool name='simple'/> <bool name='lose_masterwork'/>
+                <int32_t name='delta'/> <bool name='lose_masterwork'/> <bool name='persist_parts'/>
             </vmethod>
             <vmethod ret-type='bool' name='incWearTimer'> <int32_t name='delta'/> </vmethod>
             <vmethod ret-type='bool' name='checkWearDestroy'>
-                <bool name='simple'/> <bool name='lose_masterwork'/>
+                <bool name='lose_masterwork'/> <bool name='persist_parts'/>
             </vmethod>
             <vmethod name='addContaminant'>
                 <int16_t name='mat_type'/> <int32_t name='mat_index'/>
@@ -486,13 +486,13 @@
             <vmethod name='tradeItemContaminants' comment='calls item.tIC2(this)'>
                 <pointer type-name='item'/>
             </vmethod>
-            <vmethod name='tradeItemContaminants2'>
+            <vmethod name='tradeItemActualContaminants'>
                 <pointer type-name='item_actual'/>
             </vmethod>
 
             <vmethod name='contaminateWound'>
                 <pointer type-name='unit'/> <pointer type-name='unit_wound'/>
-                <uint8_t name='shift'/> <int16_t name='body_part_id'/>
+                <int32_t name='shift'/> <int16_t name='body_part_id'/>
             </vmethod>
             <vmethod name='write_file'> <pointer name='file' type-name='file_compressorst'/> </vmethod>
             <vmethod name='read_file'>
@@ -500,19 +500,19 @@
                 <enum name='loadversion' type-name='save_version'/>
             </vmethod>
             <vmethod name='getWeaponAttacks'>
-                <ret-type><pointer><stl-vector type-name='pointer'/></pointer></ret-type>
+                <ret-type><pointer><stl-vector pointer-type='weapon_attack'/></pointer></ret-type>
             </vmethod>
-            <vmethod ret-type='bool' name='isNotHeld'/>
+            <vmethod ret-type='bool' name='isNotHeld' comment='exitable - allowed to leave the map?'/>
 
             -- 140
 
-            <vmethod ret-type='bool' name='isSplittable' comment='if false, you throw the entire stack at once'/>
+            <vmethod ret-type='bool' name='isActual'/>
             <vmethod name='addDefaultThreadImprovement'><pointer type-name='historical_entity' comment='add default thread improvement to items made of cloth'/></vmethod>
             <vmethod name='addThreadImprovement'><pointer type-name='item'/><pointer type-name='historical_entity' comment='add a specific thread improvement to items made of cloth'/></vmethod>
             <vmethod name='propagateUnitRefs'/> add to unit.owned_items/traded_items
             <vmethod ret-type='bool' name='isSand'/>
 
-            <vmethod ret-type='int32_t' comment='returns item_actual.unk_1'/>
+            <vmethod ret-type='int32_t' name='get_production_zone_id' />
             <vmethod ret-type='int32_t' name='getStackSize'/>
             <vmethod name='addStackSize'> <int32_t name='amount'/> </vmethod>
             <vmethod name='setStackSize'> <int32_t name='amount'/> </vmethod>
@@ -522,14 +522,14 @@
 
             <vmethod ret-type='bool' name='isAutoClean'
                      comment='delete on_ground every season when in ANY_AUTO_CLEAN; default true'/>
-            <vmethod ret-type='bool' name='setTemperatureFromMapTile'>
-                <int32_t name='x'/> <int32_t name='y'/> <int32_t name='z'/>
+            <vmethod name='setTemperatureFromMapTile'>
+                <int16_t name='x'/> <int16_t name='y'/> <int16_t name='z'/>
                 <bool name='local'/> <bool name='contained'/>
             </vmethod>
-            <vmethod ret-type='bool' name='setTemperatureFromMap'>
+            <vmethod name='setTemperatureFromMap'>
                 <bool name='local'/> <bool name='contained'/>
             </vmethod>
-            <vmethod ret-type='bool' name='setTemperature'>
+            <vmethod name='setTemperature'>
                 <uint16_t name='temp'/> <bool name='local'/> <bool name='contained'/>
             </vmethod>
             <vmethod ret-type='bool' name='updateTempFromMap'>
@@ -543,28 +543,30 @@
                 <int32_t name='multiplier'/>
             </vmethod>
             <vmethod ret-type='bool' name='updateFromWeather'/>
-            <vmethod ret-type='bool' name='updateContaminants'/>
+            <vmethod ret-type='bool' name='updateContaminants'>
+                <int16_t name='x'/> <int16_t name='y'/> <int16_t name='z'/>
+            </vmethod>
             <vmethod ret-type='bool' name='checkTemperatureDamage'/>
             <vmethod ret-type='bool' name='checkHeatColdDamage'/>
 
             -- 160
 
             <vmethod ret-type='bool' name='checkMeltBoil'/>
-            <vmethod ret-type='int16_t' name='getMeleeSkill'/>
-            <vmethod ret-type='int16_t' name='getRangedSkill'/>
+            <vmethod ret-type='job_skill' name='getMeleeSkill'/>
+            <vmethod ret-type='job_skill' name='getRangedSkill'/>
             <vmethod name='setQuality'> <int16_t name='quality'/> </vmethod>
             <vmethod ret-type='int16_t' name='getQuality'/>
 
             <vmethod ret-type='int16_t' name='getOverallQuality'/>
             <vmethod ret-type='int16_t' name='getImprovementQuality'/>
-            <vmethod ret-type='int32_t' name='getProjectileSize'/>
+            <vmethod ret-type='int16_t' name='getProjectileSize'/>
             <vmethod ret-type='bool' name='isImprovable'>
                 <pointer type-name='job'/>
                 <int16_t name='mat_type'/> <int32_t name='mat_index'/>
             </vmethod>
             <vmethod name='setSharpness'>
                 <int16_t name='item_quality'/>
-                <int32_t name='unk1' comment='when 0, set item_rockst sharpness to 0'/> might be int8_t or bool
+                <bool name='force_edge'/>
             </vmethod>
 
             -- 170
@@ -572,7 +574,7 @@
             <vmethod ret-type='int32_t' name='getSharpness'/>
             <vmethod ret-type='bool' name='isTotemable'/>
             <vmethod ret-type='bool' name='isDyeable'/>
-            <vmethod ret-type='bool' name='isNotDyed'/>
+            <vmethod ret-type='bool' name='isNotDyed' comment='dyeable_after_fact'/>
             <vmethod ret-type='bool' name='isDyed'/>
 
             <vmethod ret-type='bool' name='canSewImage'/>
@@ -582,7 +584,7 @@
                 <enum base-type='int16_t' name='item_type' type-name='item_type'/>
                 <int16_t name='item_subtype'/>
                 <int16_t name='mat_type'/>
-                <int32_t name='mat_index'/>
+                <int16_t name='mat_index'/> actually int16 here
             </vmethod>
             <vmethod ret-type='int32_t' name='getBlockChance'/>
 
@@ -595,8 +597,8 @@
                     comment="adds 1 if it has [METAL_ARMOR_LEVELS] and it's made of an inorganic mat"/>
             <vmethod ret-type='bool' name='isConstructed'/>
 
-            <vmethod ret-type='bool' name='isItemOrganicCloth'/> only for item_cloth
-            <vmethod ret-type='bool' name='isMadeOfOrganicCloth'/> for all constructed items
+            <vmethod ret-type='bool' name='wantsThreadImprovement'/> only for item_cloth
+            <vmethod ret-type='bool' name='wantsClothImprovement'/> for all constructed items
             <vmethod name='coverWithContaminant' comment='also stops fire; used for rain'>
                 <int16_t name='mat_type'/> <int32_t name='mat_index'/>
                 <enum type-name='matter_state' base-type='int16_t' name='mat_state'/>
@@ -611,7 +613,7 @@
 
             <vmethod ret-type='bool' name='isImproved'/>
             <vmethod name='getMagic'>
-                <ret-type><pointer><stl-vector pointer-type='item_magicness'/></pointer></ret-type>
+                <ret-type><pointer type-name='item_magicalst'/></ret-type>
             </vmethod>
             <vmethod name='getItemDescription'>
                 <pointer type-name='stl-string'/>
@@ -619,7 +621,7 @@
             </vmethod>
             <vmethod name='getItemDescriptionPrefix' comment='"a " or "the "'>
                 <pointer type-name='stl-string'/>
-                <int8_t name='mode'/>
+                <enum name='mode' type-name='article_type'/>
             </vmethod>
             <vmethod name='getItemBasicName' comment='usually just "item"'>
                 <pointer type-name='stl-string'/>
@@ -634,12 +636,12 @@
             -- 200
 
             <vmethod ret-type='int32_t' name='getWeightShiftBits'/>
-            <vmethod ret-type='bool' name='isCollected'/>
+            <vmethod ret-type='bool' name='isCollected' comment='is_bin_item'/>
             <vmethod ret-type='bool' name='isEdibleVermin'/>
             <vmethod ret-type='uint8_t' name='drawSelf'/>
             <vmethod ret-type='bool' name='isRangedWeapon'/>
 
-            <vmethod ret-type='bool' name='isClothing'/>
+            <vmethod ret-type='bool' name='isClothing' comment='cabinetitem'/>
             <vmethod ret-type='bool' name='isWet'/>
             <vmethod ret-type='int32_t' name='getCurrencyValue' comment='that is, value of coins'>
                 <pointer type-name='historical_entity' name='appraiser'/>
@@ -660,19 +662,19 @@
                 <pointer name='u' type-name='unit'/>
                 <pointer name='j' type-name='job'/>
             </vmethod>
-            <vmethod name='addImprovement'>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
-                <int32_t/>
+            <vmethod name='addImprovement' comment='use_image'>
+                <int32_t name='art_chunk_id'/>
+                <int16_t name='art_chunk_offse'/>
+                <int32_t name='art_civ'/>
+                <int32_t name='art_site'/>
                 <int16_t name='material'/>
                 <int32_t name='matgloss'/>
-                <int16_t/>
-                <int32_t/>
-                <int32_t/>
-                <int8_t/>
-                <int16_t/>
-                <int32_t/>
+                <int16_t name='dye_material'/>
+                <int32_t name='dye_matgloss'/>
+                <pointer name='item' type-name='item'/>
+                <int8_t name='quality'/>
+                <int16_t name='skill_level'/>
+                <int32_t name='artist_hf'/>
             </vmethod>
 
             <vmethod name='copyImprovementsFrom'><pointer type-name='item'/></vmethod>
@@ -689,37 +691,37 @@
             <vmethod ret-type='int32_t' name='calcUniformScore'>
                 <pointer type-name='squad_uniform_spec'/>
                 <bool name='exact_match'/>
-                <enum base-type='int16_t' type-name='job_skill' name='best_any'/>
-                <enum base-type='int16_t' type-name='job_skill' name='best_melee'/>
-                <enum base-type='int16_t' type-name='job_skill' name='best_ranged'/>
+                <enum type-name='job_skill' name='best_any'/>
+                <enum type-name='job_skill' name='best_melee'/>
+                <enum type-name='job_skill' name='best_ranged'/>
             </vmethod>
             <vmethod ret-type='int32_t' name='calcBaseUniformScore'/>
-            <vmethod ret-type='int32_t'> <int32_t name='race_id'/><int32_t name='caste_id'/><int32_t name='maximum'/></vmethod>
-            <vmethod ret-type='bool'/>
-            <vmethod ret-type='bool'/>
+            <vmethod ret-type='int32_t' name='get_attack_clothing_size'> <int32_t name='race_id'/><int32_t name='caste_id'/><int32_t name='maximum'/></vmethod>
+            <vmethod ret-type='bool' name='is_structurally_elastic'/>
+            <vmethod ret-type='bool' name='is_woven'/>
 
-            <vmethod><int32_t/><int32_t/></vmethod> related to history_info
-            <vmethod><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/><int32_t/></vmethod> also history_info
-            <vmethod/> history_info
-            <vmethod/> history_info
+            <vmethod name='add_hf_kill'><int32_t name='kill_event'/><int32_t name='slayer_hf'/></vmethod>
+            <vmethod name='add_non_hf_kill'><int16_t name='race'/><int16_t name='caste'/><int32_t name='subregion'/><int32_t name='feature_layer'/><int32_t name='site'/><int16_t name='kill_flag'/><int32_t name='slayer_hf'/><int32_t name='quantity'/></vmethod>
+            <vmethod name='add_block_parry_deflect'/>
+            <vmethod name='add_strike'/>
             <vmethod name='getSlabEngravingType'>
-                <ret-type><enum base-type='int16_t' type-name='slab_engraving_type'/></ret-type>
+                <ret-type><enum type-name='slab_engraving_type'/></ret-type>
             </vmethod>
 
             -- 230
 
             <vmethod ret-type='int32_t' name='getAbsorption'/>
-            <vmethod ret-type='bool'/>
-            <vmethod ret-type='bool' name='isGemMaterial'/>
+            <vmethod ret-type='bool' name='isGlazed'/>
+            <vmethod ret-type='bool' name='isGemShapeable'/>
             <vmethod name='setGemShape'> <int32_t name='shape' ref-target='descriptor_shape'/> </vmethod>
-            <vmethod ret-type='bool' name='hasGemShape'/>
+            <vmethod ret-type='bool' name='isStoneShapeable'/>
 
             <vmethod name='getGemShape'>
                 <ret-type><int32_t ref-target='descriptor_shape'/></ret-type>
             </vmethod>
-            <vmethod ret-type='bool' since='v0.40.01'/>
+            <vmethod ret-type='int32_t' name='getFaceUp' since='v0.47.01'/>
+            <vmethod ret-type='bool' name='isStrappable' since='v0.40.01'/>
             <vmethod ret-type='bool' name='hasWriting'/>
-            <vmethod ret-type='bool' since='v0.47.01'/>
             <vmethod is-destructor='true'/>
         </virtual-methods>
     </class-type>
@@ -750,10 +752,14 @@
         <stl-vector name="slayer_kill_counts" type-name='int32_t'/> naming weight 1
     </struct-type>
 
-    <struct-type type-name='item_history_info'>
+    <struct-type type-name='item_history_info' original-name='item_profile_combatst'>
         <pointer name='kills' type-name='item_kill_info'/>
         <int32_t name='attack_counter' comment='increments by 1 each time the item is fired, thrown or used in an attack'/> naming weight 0.001
         <int32_t name='defence_counter' comment='increments by 1 each time the item is used in an attempt to block or parry'/> naming weight 0.01
+    </struct-type>
+
+    <struct-type type-name='item_profilest'>
+        <pointer name='combat' type-name='item_history_info'/>
     </struct-type>
 
     <class-type type-name='item_actual' inherits-from='item' original-name='item_actualst'>
@@ -764,13 +770,9 @@
             (if (> $.wear 0) (fmt "wear: ~A" $.wear))
         </code-helper>
 
-        <pointer name='history_info'>
-            <pointer type-name='item_history_info'/>
-        </pointer>
+        <pointer name='history_info' type-name='item_profilest'/>
 
-        <pointer name='magic'>
-            <stl-vector pointer-type='item_magicness'/>
-        </pointer>
+        <pointer name='magic' type-name='item_magicalst'/>
 
         <pointer name='contaminants'>
             <stl-vector pointer-type='spatter'/>
@@ -781,7 +783,7 @@
         <int16_t name='wear'/>
         <int32_t name='wear_timer' comment='counts up to 806400'/>
 
-        <int32_t name='unk_1' init-value='-1' since='v0.34.01'/>
+        <int32_t name='production_zone_id' init-value='-1' since='v0.34.01'/>
         <int32_t name='temp_updated_frame' init-value='-1'/>
     </class-type>
 
@@ -850,7 +852,7 @@
         <flag-bit name='leaking'/>
     </bitfield-type>
 
-    <struct-type type-name='body_component_info'>
+    <struct-type type-name='body_component_info' comment='not a real structure'>
         <stl-vector name='body_part_status' type-name='body_part_status'
                     index-refers-to='$$._global._upglobal.caste.ref-target.body_info.body_parts[$]'/>
 
@@ -874,7 +876,7 @@
                     index-refers-to='$$._global._upglobal.caste.ref-target.body_info.layer_idx[$].refers-to'/>
     </struct-type>
 
-    <struct-type type-name='body_size_info'>
+    <struct-type type-name='body_size_info' comment='not a real structure'>
         <int32_t name='size_cur'/>
         <int32_t name='size_base'/>
         <int32_t name='area_cur' comment='size_cur^0.666'/>
@@ -883,14 +885,14 @@
         <int32_t name='length_base' comment='(size_base*10000)^0.333'/>
     </struct-type>
 
-    <enum-type type-name='corpse_material_type'>
+    <enum-type type-name='corpse_material_type' base-type='int16_t'> bay12: ItemBodyComponentMaterialType
         <enum-item name='Plant'/>
         <enum-item name='Silk'/>
         <enum-item name='Leather'/>
         <enum-item name='Bone'/>
         <enum-item name='Shell'/>
 
-        <enum-item/>
+        <enum-item name='Wood'/>
         <enum-item name='Soap'/>
         <enum-item name='Tooth'/>
         <enum-item name='Horn'/>
@@ -912,12 +914,12 @@
         <int16_t name='normal_caste' ref-target='caste_raw' aux-value='$$.normal_race' comment='unit.enemy.normal_caste'/>
 
         <int32_t name='rot_timer'/>
-        <int8_t name='unk_8c' comment='if zero, item is a generic instance of its race and caste; do not process unit id'/>
+        <int8_t name='from_custom_body'/>
 
-        <compound name='body'>
+        <compound name='body'> not a compound
             <stl-vector name='wounds' pointer-type='unit_wound'/>
 
-            <static-array name='unk_100' type-name='int32_t' count='10' comment='unit.body.unk_39c'/>
+            <static-array name='systemic_wound_id' type-name='int32_t' count='10' index-enum='wound_effect_type'/>
             <int32_t name='wound_next_id'/>
 
             <compound name='components' type-name='body_component_info'/>
@@ -946,10 +948,10 @@
         <int32_t name="death_year"/>
         <int32_t name="death_time"/>
 
-        <compound name='appearance'>
+        <compound name='appearance'> not a compound
             <stl-vector name='colors' type-name='int32_t'/>
 
-            <stl-vector name='tissue_style' type-name='int16_t'/>
+            <stl-vector name='tissue_style' type-name='tissue_style_type'/>
             <stl-vector name='tissue_style_civ_id' type-name='int32_t'/>
             <stl-vector name='tissue_style_id' type-name='int32_t'/>
             <stl-vector name='tissue_style_type' type-name='int32_t'/>
@@ -963,46 +965,45 @@
         <int32_t name='undead_unit_id' ref-target='unit' since='v0.34.01'/>
         <int32_t name='unit_id2' ref-target='unit'/>
 
-        <bitfield name='corpse_flags'>
+        <bitfield name='corpse_flags'> bay12: ITEM_BODY_COMPONENT_FLAG_*
             <flag-bit name='unbutchered'/>
             <flag-bit name='plant'/>
             <flag-bit name='silk'/>
             <flag-bit name='leather'/>
             <flag-bit name='bone'/>
             <flag-bit name='shell'/>
-            <flag-bit/>
+            <flag-bit name='wood'/>
             <flag-bit name='soap'/>
 
             <flag-bit name='tooth'/>
             <flag-bit name='horn'/>
             <flag-bit name='pearl'/>
-            <flag-bit name='skull1'/>
-            <flag-bit name='skull2'/>
-            <flag-bit name='separated_part' comment='?'/>
+            <flag-bit name='rottable'/>
+            <flag-bit name='skull'/>
+            <flag-bit name='use_blood_color'/>
             <flag-bit name='hair_wool'/>
             <flag-bit name='yarn'/>
+            <flag-bit name='must_rot_body'/>
+            <flag-bit name='must_refresh_texture'/>
         </bitfield>
 
         <static-array name='material_amount' type-name='int32_t'
                       count='19' index-enum='corpse_material_type'/>
 
-        <compound name='bone1'>
+        <compound name='largest_tissue'>
             <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
             <int32_t name='mat_index'/>
         </compound>
-        <compound name='bone2'>
+        <compound name='largest_unrottable_tissue'>
             <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
             <int32_t name='mat_index'/>
         </compound>
     </class-type>
 
     <class-type type-name='item_corpsest' inherits-from='item_body_component'>
-        <pointer name='unused_380'/>
-        <pointer name='unused_388'/>
-        <pointer name='unused_390'/>
-        <int32_t name='unused_398'/>
-        <int16_t name='unused_39c'/>
-        <int32_t name='unused_3a0'/>
+        <static-array name='texpos' count='3'><static-array count='2' type-name='int32_t'/></static-array>
+        <static-array name='texpos_currently_in_use' count='3'><static-array count='2' type-name='bool'/></static-array>
+        <int32_t name='sheet_icon_texpos'/>
     </class-type>
 
     <class-type type-name='item_corpsepiecest' inherits-from='item_body_component'/>
@@ -1019,32 +1020,22 @@
 
     -- LIQUID/POWER
 
-    <bitfield-type type-name='item_matstate'>
-        <flag-bit name='no_auto_clean' comment='isAutoClean returns false'/>
-        <flag-bit name='pressed'/>
-        <flag-bit name='paste'/>
-    </bitfield-type>
-
     <class-type type-name='item_liquipowder' inherits-from='item_actual'
                 original-name='item_liquipowderst'>
-        <bitfield name='mat_state' type-name='item_matstate'/>
+        <bitfield name='lp_flags' base-type='uint32_t'> bay12: ITEMFLAG_LIQUIPOWDER_*
+            <flag-bit name='no_auto_clean'/>
+        </bitfield>
         <int32_t name='dimension' init-value='150'/>
     </class-type>
 
-    <class-type type-name='item_liquid' inherits-from='item_liquipowder' original-name='item_liquidst'>
-        <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
-        <int32_t name='mat_index'/>
-    </class-type>
+    <class-type type-name='item_liquid' inherits-from='item_liquipowder' original-name='item_liquidst'/>
 
-    <class-type type-name='item_powder' inherits-from='item_liquipowder' original-name='item_powderst'>
-        <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
-        <int32_t name='mat_index'/>
-    </class-type>
+    <class-type type-name='item_powder' inherits-from='item_liquipowder' original-name='item_powderst'/>
 
     -- MISC
 
     <class-type type-name='item_barst' inherits-from='item_actual'>
-        <int16_t name='subtype'/>
+        <int16_t name='subtype' comment='supposedly used for coal'/>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
         <int32_t name='dimension' init-value='150'/>
@@ -1080,7 +1071,10 @@
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
         <int32_t name='sharpness'/>
-        <int32_t name='unk_84'/>
+        <bitfield name='rock_flag' base-type='uint32_t'> bay12: ITEM_ROCK_FLAG_*
+            <flag-bit name='scraper'/>
+            <flag-bit name='chisel'/>
+        </bitfield>
     </class-type>
 
     <class-type type-name='item_seedsst' inherits-from='item_actual'>
@@ -1093,7 +1087,7 @@
     <class-type type-name='item_skin_tannedst' inherits-from='item_actual'>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
-        <int32_t name='unk_80'/>
+        <int32_t name='rot_timer' comment='even though leather does not rot'/>
     </class-type>
 
     <class-type type-name='item_meatst' inherits-from='item_actual'>
@@ -1122,7 +1116,11 @@
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
         <int32_t name='rot_timer'/>
-        <bitfield name='mat_state' type-name='item_matstate'/>
+        <bitfield name='glob_flags' base-type='uint32_t'> bay12: ITEMFLAG_GLOB_*
+            <flag-bit name='no_auto_clean'/>
+            <flag-bit name='pressed'/>
+            <flag-bit name='paste'/>
+        </bitfield>
         <int32_t name='dimension'/>
     </class-type>
     <class-type type-name='item_remainsst' inherits-from='item_actual'>
@@ -1146,16 +1144,18 @@
         <int32_t name='entity' ref-target='historical_entity'/>
         <int16_t name='recipe_id'/>
         <stl-vector name='ingredients'>
-            <pointer>
-                <int16_t name='unk_1'/>
+            <pointer> bay12: food_ingredientst
+                <enum name='mixtype' base-type='int16_t'> bay12: FoodIngredient
+                    <enum-item name='MINCED'/>
+                </enum>
                 <enum base-type='int16_t' name='item_type' type-name='item_type'/>
-                <int16_t name='unk_4' init-value='-1'/>
+                <int16_t name='item_subtype' init-value='-1'/>
                 <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
                 <int32_t name='mat_index' init-value='-1'/>
                 <int32_t name='maker' ref-target='historical_figure'/>
                 <enum base-type='int16_t' name='quality' type-name='item_quality'/>
-                <int32_t name='unk_14'/>
-                <int32_t name='unk_18'/>
+                <int32_t name='skill_level'/>
+                <int32_t name='masterpiece_event' ref-target='history_event'/>
             </pointer>
         </stl-vector>
         <int32_t name='rot_timer'/>
@@ -1164,15 +1164,27 @@
     <class-type type-name='item_verminst' inherits-from='item_critter'/>
     <class-type type-name='item_petst' inherits-from='item_critter'>
         <int32_t name='owner_id' ref-target='unit'/>
-        <bitfield name='pet_flags'>
+        <bitfield name='pet_flags' base-type='uint32_t'> bay12: ITEM_PET_FLAG_*
             <flag-bit name='available_for_adoption'/>
         </bitfield>
     </class-type>
 
-    <class-type type-name='item_drinkst' inherits-from='item_liquid'/>
-    <class-type type-name='item_powder_miscst' inherits-from='item_powder'/>
+    <class-type type-name='item_drinkst' inherits-from='item_liquid'>
+        <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
+        <int32_t name='mat_index'/>
+    </class-type>
+
+    <class-type type-name='item_powder_miscst' inherits-from='item_powder'>
+        <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
+        <int32_t name='mat_index'/>
+    </class-type>
+
     <class-type type-name='item_liquid_miscst' inherits-from='item_liquid'>
-        <int32_t name='unk_88'/>
+        <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
+        <int32_t name='mat_index'/>
+        <bitfield name='liquid_misc_flags' base-type='uint32_t'> bay12: LIQUID_MISC_FLAG_*
+            <flag-bit name='paste'/>
+        </bitfield>
     </class-type>
 
     <class-type type-name='item_threadst' inherits-from='item_actual'>
@@ -1183,9 +1195,9 @@
         <int32_t name='dyer' ref-target='historical_figure'/>
         <int32_t name='dye_masterpiece_event' ref-target='history_event'/>
         <int16_t name='dye_quality'/>
-        <int16_t name='unk_92'/>
-        <int32_t name='unk_94'/>
-        <int8_t name='unk_98'/>
+        <int16_t name='dye_skill'/>
+        <int32_t name='dye_age'/>
+        <bool name='is_thick'/>
         <int32_t name='dimension' init-value='15000'/>
     </class-type>
 
@@ -1195,8 +1207,9 @@
         <int32_t name='rot_timer'/>
         <compound name='egg_materials' type-name='material_vec_ref'/>
 
-        <bitfield name='egg_flags'>
+        <bitfield name='egg_flags'> bay12: ITEM_EGG_FLAG_*
             <flag-bit name='fertile' comment='allows the incubation_counter to be checked/incremented'/>
+            <flag-bit name='make_nemesis'/>
         </bitfield>
 
         <int32_t name='incubation_counter' init-value='0'
@@ -1206,19 +1219,17 @@
                  comment='hatchlings will have this civ_id'/>
         <int32_t name='hatchling_population_id' ref-target='entity_population'
                  comment='hatchlings will have this population_id'/>
-        <int32_t name='hatchling_unit_unk_c0' init-value='-1'
-                 comment='hatchlings will have this unit.unk_c0 value'/>
-
-        <int32_t name='unk_2' since='v0.40.01'/> position uncertain
+        <int32_t name='hatchling_breed_id' ref-target='breed'/>
+        <int32_t name='hatchling_cultural_identity_id' ref-target='cultural_identity' since='v0.40.01'/>
 
         <pointer name='mothers_genes' type-name='unit_genes' comment='object owned by egg item'/>
         <int16_t name='mothers_caste' ref-target='caste_raw' aux-value='$$.race'/>
-        <int32_t name='unk_3' since='v0.40.01'/>
+        <int32_t name='mother_hf' ref-target='historical_figure' since='v0.40.01'/>
 
         <pointer name='fathers_genes' type-name='unit_genes' comment='object owned by egg item'/>
         <int16_t name='fathers_caste' ref-target='caste_raw' aux-value='$$.race'
                  comment='-1 if no father genes'/>
-        <int32_t name='unk_4' since='v0.40.01'/>
+        <int32_t name='father_hf' ref-target='historical_figure' since='v0.40.01'/>
 
         <bitfield name='hatchling_flags1' type-name='unit_flags1'
                   comment='used primarily for bit_flag:tame'/>
@@ -1226,10 +1237,10 @@
                   comment='used primarily for bit_flag:roaming_wilderness_population_source'/>
         <bitfield name='hatchling_flags3' type-name='unit_flags3'
                   comment='not normally used, most/all do not stick'/>
+        <bitfield name='hatchling_flags4' type-name='unit_flags4'
+                  comment='not normally used, most/all do not stick'/>
 
-        <int32_t name='unk_v42_1' since='v0.42.01'/>
-
-        <enum name='hatchling_training_level' base-type='int32_t'
+        <enum name='hatchling_training_level'
               type-name='animal_training_level' init-value='WildUntamed'/>
 
         <compound name='hatchling_animal_population' type-name='world_population_ref'/>
@@ -1296,9 +1307,13 @@
     <class-type type-name='item_helmst' inherits-from='item_constructed'>
         <pointer name='subtype' type-name='itemdef_helmst'/>
     </class-type>
+    <enum-type type-name='glove_handedness'> bay12: ItemGloveFlagType, no base type
+        <enum-item name='RIGHT'/>
+        <enum-item name='LEFT'/>
+    </enum-type>
     <class-type type-name='item_glovesst' inherits-from='item_constructed'>
         <pointer name='subtype' type-name='itemdef_glovesst'/>
-        <df-flagarray name='handedness' comment='1 right, 2 left'/>
+        <df-flagarray name='handedness' index-enum='glove_handedness'/>
     </class-type>
     <class-type type-name='item_pantsst' inherits-from='item_constructed'>
         <pointer name='subtype' type-name='itemdef_pantsst'/>
@@ -1324,11 +1339,11 @@
         <int32_t name='sharpness'/>
         <compound name='stockpile' type-name='item_stockpile_ref'/>
         <int32_t name='vehicle_id' ref-target='vehicle' since='v0.34.08'/>
-        <int32_t name='unk_2' since='v0.47.01' init-value='-1'/>
-        <int32_t name='unk_3' since='v0.47.01' init-value='-1'/>
+        <int32_t name='shape' since='v0.47.01' ref-target='descriptor_shape'/>
+        <int32_t name='face_up' since='v0.47.01' init-value='-1'/>
     </class-type>
 
-    <struct-type type-name='item_stockpile_ref'>
+    <struct-type type-name='item_stockpile_ref' original-name='stockpile_item_infost'>
         <int32_t name='id' ref-target='building'/>
         <int16_t name='x'/>
         <int16_t name='y'/>
@@ -1348,8 +1363,8 @@
     <class-type type-name='item_statuest' inherits-from='item_constructed'>
         <compound name='image' type-name='art_image_ref'/>
         <stl-string name='description'/>
-        <int32_t name='unk_110'/>
-        <int32_t name='unk_114'/>
+        <int32_t name='art_graphics_type'/>
+        <int32_t name='art_graphics_id'/>
     </class-type>
     <class-type type-name='item_figurinest' inherits-from='item_constructed'>
         <compound name='image' type-name='art_image_ref'/>
@@ -1358,8 +1373,8 @@
 
     <class-type type-name='item_slabst' inherits-from='item_constructed'>
         <stl-string name='description'/>
-        <int32_t name='topic' ref-target='historical_figure' comment='or interaction id for secrets?'/>
-        <enum base-type='int16_t' type-name='slab_engraving_type' name='engraving_type'/>
+        <int32_t name='topic' ref-target='historical_figure' comment='or interaction id for secrets'/>
+        <enum type-name='slab_engraving_type' name='engraving_type'/>
     </class-type>
 
     <class-type type-name='item_orthopedic_castst' inherits-from='item_constructed'>
@@ -1393,7 +1408,10 @@
 
     <class-type type-name='item_sheetst' inherits-from='item_constructed'>
         <int32_t name='dimension'/>
-        <int32_t name='unk_2'/>
+        <bitfield name='sheet_flags' base-type='uint32_t'> bay12: ITEMFLAG_SHEET_*
+            <flag-bit name='paste'/>
+            <flag-bit name='pressed'/>
+        </bitfield>
     </class-type>
 </data-definition>
 

--- a/df.materials.xml
+++ b/df.materials.xml
@@ -55,7 +55,7 @@
         </enum-item>
     </enum-type>
 
-    <enum-type type-name='builtin_mats'>
+    <enum-type type-name='builtin_mats' base-type='int16_t'> bay12: MaterialType
         <enum-item name='INORGANIC'/>
         <enum-item name='AMBER'/>
         <enum-item name='CORAL'/>
@@ -75,9 +75,13 @@
         <enum-item name='FILTH_Y'/>
         <enum-item name='UNKNOWN_SUBSTANCE'/>
         <enum-item name='GRIME'/>
+        CREATURE_1 thru CREATURE_200
+        HIST_FIG_1 thru HIST_FIG_200
+        PLANT_1 thru PLANT_200
+        UNUSED01 thru UNUSED40
     </enum-type>
 
-    <enum-type type-name='material_flags'>
+    <enum-type type-name='material_flags'> bay12: MaterialDefinitionFlagType
         <enum-attr name='type' type-name='craft_material_class' default-value='None'/>
 
         <enum-item name='BONE'>
@@ -140,7 +144,7 @@
         <enum-item name='LIQUID_MISC'/>
         <enum-item name='STRUCTURAL_PLANT_MAT'/>
         <enum-item name='SEED_MAT'/>
-        <enum-item name='LEAF_MAT'/> now named STOCKPILE_PLANT_GROWTH
+        <enum-item name='STOCKPILE_PLANT_GROWTH'/>
         <enum-item name='CHEESE'/>
 
         <enum-item name='ENTERS_BLOOD'/>
@@ -190,7 +194,7 @@
         <enum-item name='SPIT_MAP_DESCRIPTOR'/>
 
         <enum-item name='EVAPORATES'/>
-        <enum-item/>
+        <enum-item name='STOCKPILE_PLANT'/>
         <enum-item name='IS_CERAMIC'/>
         <enum-item name='CARTILAGE'/> new in 50.0x
         <enum-item name='FEATHER'/>
@@ -202,7 +206,7 @@
         <enum-item name='ANTLER'/>
     </enum-type>
 
-    <enum-type type-name='matter_state' base-type='int16_t'>
+    <enum-type type-name='matter_state' base-type='int16_t'> bay12: MaterialStateType
         <enum-item name='None' value='-1'/>
         <enum-item name='Solid'/>
         <enum-item name='Liquid'/>
@@ -212,7 +216,7 @@
         <enum-item name='Pressed'/>
     </enum-type>
 
-    <enum-type type-name='strain_type'>
+    <enum-type type-name='strain_type' base-type='int16_t'> bay12: PhysicalForceType
         <enum-item name='BENDING'/>
         <enum-item name='SHEAR'/>
         <enum-item name='TORSION'/>
@@ -221,13 +225,29 @@
         <enum-item name='COMPRESSIVE'/>
     </enum-type>
 
-    <struct-type type-name='material_common'>
+    <enum-type type-name='meat_category_type' base-type='int32_t'> bay12: MeatCategoryType
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='STANDARD'/>
+        <enum-item name='EYE'/>
+        <enum-item name='LUNG'/>
+        <enum-item name='HEART'/>
+        <enum-item name='INTESTINES'/>
+        <enum-item name='LIVER'/>
+        <enum-item name='STOMACH'/>
+        <enum-item name='PANCREAS'/>
+        <enum-item name='SPLEEN'/>
+        <enum-item name='KIDNEY'/>
+        <enum-item name='BRAIN'/>
+        <enum-item name='GIZZARD'/>
+    </enum-type>
+
+    <struct-type type-name='material_common' comment='not a real structure'>
         <stl-string name='id'/>
         <stl-string name='gem_name1'/>
         <stl-string name='gem_name2'/>
         <stl-string name='stone_name'/>
 
-        <compound name='heat'>
+        <compound name='heat'> not a compound
             <uint16_t name='spec_heat'/>
             <uint16_t name='heatdam_point'/>
             <uint16_t name='colddam_point'/>
@@ -248,7 +268,7 @@
         <static-array name='state_adj' type-name='stl-string'
                       count='6' index-enum='matter_state'/>
 
-        <compound name='strength'>
+        <compound name='strength'> not a compound
             <int32_t name='absorption'/>
 
             <static-array name='yield' type-name='int32_t'
@@ -265,17 +285,17 @@
 
         <df-flagarray name='flags' index-enum='material_flags'/>
 
-        <enum base-type='int16_t' name='extract_storage' type-name='item_type'/>
-        <enum base-type='int16_t' name='butcher_special_type' type-name='item_type'/>
+        <enum name='extract_storage' type-name='item_type'/>
+        <enum name='butcher_special_type' type-name='item_type'/>
         <int16_t name='butcher_special_subtype' refers-to='(item-subtype-target $$._parent.butcher_special_type $)'/>
 
         <static-array name='meat_name' type-name='stl-string' count='3'/>
-        <int32_t name='meat_organ' comment='used for texture selection'/>
+        <enum name='meat_organ' type-name='meat_category_type' comment='used for texture selection'/>
         <static-array name='block_name' type-name='stl-string' count='2'/>
 
-        <compound name='reaction_product'>
+        <compound name='reaction_product'> not a compound
             <stl-vector name='id' pointer-type='stl-string'/>
-            <stl-vector name='item_type' type-name='int16_t'/>
+            <stl-vector name='item_type' type-name='item_type'/>
             <stl-vector name='item_subtype' type-name='int16_t'/>
             <compound name='material' type-name='material_vec_ref'/>
 
@@ -284,7 +304,7 @@
             </static-array>
         </compound>
 
-        <compound name='hardens_with_water'>
+        <compound name='hardens_with_water'> not a compound
             <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
             <int32_t name='mat_index'/>
 
@@ -292,11 +312,6 @@
         </compound>
 
         <stl-vector name='reaction_class' pointer-type='stl-string'/>
-    </struct-type>
-
-    <struct-type type-name='material' inherits-from='material_common' custom-methods='true'>
-        <code-helper name='find-instance'>(material-by-id $ $$)</code-helper>
-        <code-helper name='describe'> (describe-material $) </code-helper>
 
         <uint8_t name='tile'/>
 
@@ -305,17 +320,22 @@
         <static-array name='tile_color' type-name='int16_t' count='3'/>
 
         <uint8_t name='item_symbol'/>
+    </struct-type>
 
-        <int32_t/><int32_t/><int32_t/> 0.50.01
+    <struct-type type-name='material' original-name='material_definitionst' inherits-from='material_common' custom-methods='true' comment='does not actually inherit'>
+        <code-helper name='find-instance'>(material-by-id $ $$)</code-helper>
+        <code-helper name='describe'> (describe-material $) </code-helper>
+
+        <static-array name='mat_rgb' count='3' type-name='s-float'/>
 
         <int16_t name='powder_dye'/> // color token index
         <int16_t name='temp_diet_info'/>
 
-        <stl-vector name='syndrome' pointer-type='syndrome'/>
+        <compound name='syndrome' type-name='creature_interactionst'/>
 
         <int32_t name='soap_level'/>
 
-        <stl-vector name='unk_41c' type-name='int16_t' since='v0.40.01'/>
+        <stl-vector name='sphere' type-name='sphere_type' since='v0.40.01'/>
 
         <stl-string name='prefix'/>
 
@@ -335,7 +355,7 @@
         <int32_t name='bar_texpos'/>
         <int32_t name='cheese_texpos1'/>
         <int32_t name='cheese_texpos2'/>
-        <int32_t/> 0.50.01
+        <uint32_t name='texflag'/>
 
         <custom-methods>
             <cmethod name='isGem'/>
@@ -350,34 +370,26 @@
         <stl-vector name='mat_index' type-name='int32_t'/>
     </struct-type>
 
-    <struct-type type-name='material_template' inherits-from='material_common'>
+    <struct-type type-name='material_template' original-name='material_templatest' inherits-from='material_common' comment='does not actually inherit'>
         <code-helper name='describe'> (describe-material $) </code-helper>
-
-        <uint8_t name='tile'/>
-
-        <static-array name='basic_color' type-name='int16_t' count='2'/>
-        <static-array name='build_color' type-name='int16_t' count='3'/>
-        <static-array name='tile_color' type-name='int16_t' count='3'/>
-
-        <uint8_t name='item_symbol'/>
 
         <int16_t name='powder_dye'/> // color token index
         <int16_t name='temp_diet_info'/>
 
-        <stl-vector name='syndrome' pointer-type='syndrome'/>
+        <compound name='syndrome' type-name='creature_interactionst'/>
 
         <int32_t name='soap_level'/>
 
-        <stl-vector name='unk_41c' type-name='int16_t' since='v0.40.01'/>
+        <stl-vector name='sphere' type-name='sphere_type' since='v0.40.01'/>
 
         <stl-string name='powder_dye_str' comment='temporary'/>
         <static-array name='state_color_str' type-name='stl-string' count='6' index-enum='matter_state'/>
     </struct-type>
 
-    <enum-type type-name='inorganic_flags'>
+    <enum-type type-name='inorganic_flags'> bay12: InorganicFlagType
         <enum-item name='LAVA'/>
         <enum-item name='GENERATED'/>
-        <enum-item name='ENVIRONMENT_NON_SOIL_OCEAN' comment='is METAMORPHIC, or has ENVIRONMENT with anything but SOIL_OCEAN'/>
+        <enum-item name='CAN_OCCUR_ON_SURFACE'/>
         <enum-item name='SEDIMENTARY'/>
         <enum-item name='SEDIMENTARY_OCEAN_SHALLOW'/>
         <enum-item name='IGNEOUS_INTRUSIVE'/>
@@ -397,7 +409,7 @@
         <enum-item name='SOIL'/>
         <enum-item name='DEEP_SPECIAL'/>
         <enum-item name='DIVINE'/>
-        <enum-item/>
+        <enum-item/> these are all UNUSED
         <enum-item/>
         <enum-item/>
         <enum-item/>
@@ -412,7 +424,7 @@
         <enum-item/>
     </enum-type>
 
-    <enum-type type-name='environment_type' base-type='int16_t'>
+    <enum-type type-name='environment_type'> bay12: StoneEnvironment, no base type
         <enum-item name='SOIL'/>
         <enum-item name='SOIL_OCEAN'/>
         <enum-item name='SOIL_SAND'/>
@@ -423,15 +435,15 @@
         <enum-item name='ALLUVIAL'/>
     </enum-type>
 
-    <enum-type type-name='inclusion_type' base-type='int16_t'>
-        <enum-item comment='unused'/>
+    <enum-type type-name='inclusion_type'> bay12: InclusionType, no base type
+        <enum-item name='TOTAL'/>
         <enum-item name='VEIN'/>
         <enum-item name='CLUSTER'/>
         <enum-item name='CLUSTER_SMALL'/>
         <enum-item name='CLUSTER_ONE'/>
     </enum-type>
 
-    <struct-type type-name='inorganic_raw' instance-vector='$global.world.raws.inorganics' custom-methods='true'>
+    <struct-type type-name='inorganic_raw' original-name='inorganic_material_definitionst' instance-vector='$global.world.raws.inorganics' custom-methods='true'>
         <stl-string name='id'/>
 
         <stl-vector name='str' since='v0.34.01' pointer-type='stl-string'/>
@@ -441,9 +453,9 @@
         <df-flagarray name='flags' index-enum='inorganic_flags'/>
 
         <int32_t name='source_hfid' ref-target='historical_figure'/>
-        <int32_t name='unk_v4201_1' init-value='-1' since='v0.42.01'/>
+        <int32_t name='source_enid' ref-target='historical_entity' since='v0.42.01'/>
 
-        <compound name='metal_ore'>
+        <compound name='metal_ore'> not a compound
             <stl-vector name='str' comment='only during parsing' pointer-type='stl-string'/>
             <stl-vector name='mat_index'>
                 <int16_t ref-target='inorganic_raw'/>
@@ -451,7 +463,7 @@
             <stl-vector type-name='int16_t' name='probability'/>
         </compound>
 
-        <compound name='thread_metal'>
+        <compound name='thread_metal'> not a compound
             <stl-vector name='str' comment='only during parsing' pointer-type='stl-string'/>
             <stl-vector name='mat_index'>
                 <int16_t ref-target='inorganic_raw'/>
@@ -461,7 +473,7 @@
 
         <stl-vector type-name='int32_t' name='economic_uses' ref-target='reaction'/>
 
-        <compound name='environment_spec'>
+        <compound name='environment_spec'> not a compound
             <stl-vector name='str' comment='only during parsing' pointer-type='stl-string'/>
             <stl-vector name='mat_index'>
                 <int16_t ref-target='inorganic_raw'/>
@@ -472,7 +484,7 @@
             <stl-vector type-name='int8_t' name='probability'/>
         </compound>
 
-        <compound name='environment'>
+        <compound name='environment'> not a compound
             <stl-vector name='location'>
                 <enum base-type='int16_t' type-name='environment_type'/>
             </stl-vector>
@@ -482,8 +494,8 @@
             <stl-vector type-name='int8_t' name='probability'/>
         </compound>
 
-        <uint16_t name='times_used_land'/>
-        <uint16_t name='times_used_ocean'/>
+        <int16_t name='times_used_land'/>
+        <int16_t name='times_used_ocean'/>
 
         <compound name='material' type-name='material'/>
         <custom-methods>
@@ -491,7 +503,7 @@
         </custom-methods>
     </struct-type>
 
-    <enum-type type-name='organic_mat_category'>
+    <enum-type type-name='organic_mat_category' base-type='int16_t'> bay12: StockpileIndexType
         <enum-item name='Meat'/>
         <enum-item name='Fish'/>
         <enum-item name='UnpreparedFish'/>
@@ -502,7 +514,7 @@
         <enum-item name='PlantCheese'/>
         <enum-item name='CreatureCheese'/>
         <enum-item name='Seed'/>
-        <enum-item name='Leaf'/>
+        <enum-item name='PlantGrowth'/>
         <enum-item name='PlantPowder'/>
         <enum-item name='CreaturePowder'/>
         <enum-item name='Glob'/>
@@ -524,7 +536,7 @@
         <enum-item name='CookableLiquid'/>
         <enum-item name='CookablePowder'/>
         <enum-item name='CookableSeed'/>
-        <enum-item name='CookableLeaf'/>
+        <enum-item name='CookablePlantGrowth'/>
         <enum-item name='Paste'/>
         <enum-item name='Pressed'/>
         <enum-item name='Yarn'/>
@@ -533,14 +545,14 @@
         <enum-item name='Parchment'/>
     </enum-type>
 
-    <struct-type type-name='special_mat_table'>
+    <struct-type type-name='special_mat_table' original-name='material_infost'>
         <static-array name='organic_types' count='39' index-enum='organic_mat_category'>
             <stl-vector type-name='int16_t' index-refers-to='(food-mat-by-idx $$._key $)'/>
         </static-array>
         <static-array name='organic_indexes' count='39' index-enum='organic_mat_category'>
             <stl-vector type-name='int32_t'/>
         </static-array>
-        <static-array name='organic_unknown' count='39' comment='everything 0'
+        <static-array name='organic_temp' count='39' comment='everything 0'
                       index-enum='organic_mat_category'>
             <stl-vector type-name='int32_t'/>
         </static-array>
@@ -548,6 +560,8 @@
         <static-array name='builtin' count='659' index-enum='builtin_mats'>
             <pointer type-name='material'/>
         </static-array>
+
+        NOTE: world_raws.syndromes and world_raws.effects should both be directly in here
     </struct-type>
 </data-definition>
 

--- a/df.military.xml
+++ b/df.military.xml
@@ -9,7 +9,7 @@
         <enum base-type='int16_t' name="item_type" type-name='item_type'/>
         <int16_t name="item_subtype" refers-to='(item-subtype-target $$._parent.item_type $)'/>
 
-        <enum base-type='int16_t' name="material_class" type-name='entity_material_category'/>
+        <enum name="material_class" type-name='entity_material_category'/>
 
         <int16_t name='mattype' ref-target='material' aux-value='$$.matindex'/>
         <int32_t name='matindex'/>

--- a/df.plant-raws.xml
+++ b/df.plant-raws.xml
@@ -1,10 +1,10 @@
 <data-definition>
-    <enum-type type-name='plant_raw_flags'>
+    <enum-type type-name='plant_raw_flags'> bay12: PlantFlagType
         <enum-item name='SPRING'/>
         <enum-item name='SUMMER'/>
         <enum-item name='AUTUMN'/>
         <enum-item name='WINTER'/>
-        <enum-item/>
+        <enum-item name='BUNDLE'/>
         <enum-item name='SEED'/>
         <enum-item name='TREE_HAS_MUSHROOM_CAP'/>
         <enum-item name='DRINK'/>
@@ -15,10 +15,10 @@
         <enum-item name='GENERATED'/>
         <enum-item name='THREAD'/>
         <enum-item name='MILL'/>
-        <enum-item/>
-        <enum-item/>
+        <enum-item name='EDIBLE_GROWTH'/>
+        <enum-item name='SOIL_BACKGROUND'/>
 
-        <enum-item/>
+        <enum-item/> unused
         <enum-item/>
         <enum-item/>
         <enum-item/>
@@ -100,7 +100,7 @@
         <enum-item name='TWIGS_BELOW_TRUNK'/>
     </enum-type>
 
-    <struct-type type-name='plant_raw' instance-vector='$global.world.raws.plants.all'>
+    <struct-type type-name='plant_raw' original-name='plant_material_definitionst' instance-vector='$global.world.raws.plants.all'>
         <stl-string name='id'/>
 
         <int32_t name='index' since='v0.40.01'/>
@@ -120,12 +120,11 @@
         <stl-string name='leaves_plural' comment='unused'/>
 
         <int32_t name='source_hfid' ref-target='historical_figure'/>
-        <int32_t name='unk_v4201_1' init-value='-1' since='v0.42.01'/>
+        <int32_t name='source_enid' ref-target='historical_entity' since='v0.42.01'/>
 
-        <uint8_t name='unk1'/>
-        <uint8_t name='unk2'/>
+        <int16_t name='mill_dye_color' ref-target='descriptor_color'/>
 
-        <compound name='tiles'>
+        <compound name='tiles'> not a compound
             <uint8_t name='picked_tile'/>
             <uint8_t name='dead_picked_tile'/>
             <uint8_t name='shrub_tile'/>
@@ -137,13 +136,15 @@
             <static-array type-name='uint8_t' name='grass_tiles' count='16'/>
             <static-array type-name='uint8_t' name='alt_grass_tiles' count='12'/>
             <static-array type-name='uint8_t' name='tree_tiles' count='104'/>
-            <static-array type-name='uint8_t' name='unk_v50_1' count='80'/>
         </compound>
+
+        <static-array type-name='int32_t' name='texpos' count='18'/>
+        <pointer name='tree_texture_info'/> bay12: pmd_tree_texture_infost
 
         <int32_t name='growdur'/>
         <int32_t name='value'/>
 
-        <compound name='colors'>
+        <compound name='colors'> not a compound
             <static-array type-name='int8_t' name='picked_color' count='3'/>
             <static-array type-name='int8_t' name='dead_picked_color' count='3'/>
             <static-array type-name='int8_t' name='shrub_color' count='3'/>
@@ -154,9 +155,9 @@
             <static-array type-name='int8_t' name='sapling_color' count='3'/>
             <static-array type-name='int8_t' name='dead_sapling_color' count='3'/>
 
-            <static-array type-name='int8_t' name='grass_colors_0' count='20'/>
-            <static-array type-name='int8_t' name='grass_colors_1' count='20'/>
-            <static-array type-name='int8_t' name='grass_colors_2' count='20'/>
+            <static-array type-name='int8_t' name='grass_colors_f' count='20'/>
+            <static-array type-name='int8_t' name='grass_colors_b' count='20'/>
+            <static-array type-name='int8_t' name='grass_colors_br' count='20'/>
         </compound>
 
         <static-array type-name='int32_t' name='alt_period' count='2'/>
@@ -171,7 +172,7 @@
 
         <stl-vector name='material' pointer-type='material'/>
 
-        <compound name='material_defs'>
+        <compound name='material_defs'> not a compound
             <static-array name='type' index-enum='plant_material_def'>
                 <int16_t ref-target='material' aux-value='$$._parent.idx[$._key]'/>
             </static-array>
@@ -191,6 +192,7 @@
         <stl-string name='light_branch_name'/>
         <stl-string name='twig_name'/>
         <stl-string name='cap_name'/>
+
         <int32_t name='trunk_period'/>
         <int32_t name='heavy_branch_density'/>
         <int32_t name='light_branch_density'/>
@@ -207,15 +209,22 @@
 
         <stl-vector name='stockpile_growths' type-name='int32_t' refers-to='$$._parent._parent.growths[$]' comment='indices of edible growths that are marked with STOCKPILE_PLANT_GROWTH'/>
         <stl-vector name='stockpile_growth_flags' index-refers-to='$$._parent.stockpile_growths[$].refers-to'>
-            <bitfield base-type='uint32_t'>
+            <bitfield base-type='uint32_t'> bay12: assuming RAS_CROP_FLAG_*; could also be RAS_EXTRACT_FLAG_* or RAS_POWDER_FLAG_*
                 <flag-bit name='EDIBLE_RAW'/>
                 <flag-bit name='EDIBLE_COOKED'/>
+                <flag-bit name='THREAD'/>
+                <flag-bit name='MILLABLE'/>
+                <flag-bit name='EXTRACTABLE_VIAL'/>
+                <flag-bit name='EXTRACTABLE_BARREL'/>
+                <flag-bit name='EXTRACTABLE_STILL_VIAL'/>
+                <flag-bit name='ORCHARD'/>
+                <flag-bit name='GARDEN'/>
+                <flag-bit name='FARMED'/>
             </bitfield>
         </stl-vector>
     </struct-type>
 
-    <enum-type type-name='plant_material_def' base-type='int16_t'>
-        TODO: is this the same as another existing enum?
+    <enum-type type-name='plant_material_def' base-type='int16_t'> bay12: PlantMaterialUseType
         <enum-item name='basic_mat'/>
         <enum-item name='tree'/>
         <enum-item name='drink'/>
@@ -227,7 +236,7 @@
         <enum-item name='extract_still_vial'/>
     </enum-type>
 
-    <struct-type type-name='plant_growth'>
+    <struct-type type-name='plant_growth' original-name='pmd_growthst'>
         <stl-string name='id'/>
 
         <code-helper name='describe'>(fmt "~:(~A ~A~)" $.id_id $.name[0])</code-helper>
@@ -236,19 +245,16 @@
         <stl-string name='name'/>
         <stl-string name='name_plural'/>
         <static-array type-name='stl-string' name='str_growth_item' count='5'/>
-        <enum base-type='int16_t' name='item_type' type-name='item_type'/>
+        <enum name='item_type' type-name='item_type'/>
         <int16_t name='item_subtype'/>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
         <stl-vector name='prints' pointer-type='plant_growth_print'/>
-        <int32_t name='unk_v50_1'/>
-        <int32_t name='unk_v50_2'/>
-        <int32_t name='unk_v50_3'/>
-        <int32_t name='unk_v50_4' init-value='-1'/>
-        <int32_t name='unk_v50_5' init-value='-1'/>
+        <static-array name='texpos_grass' type-name='int32_t' count='4'/>
+        <int32_t name='texpos_picked'/>
         <int32_t name='timing_1'/>
         <int32_t name='timing_2'/>
-        <bitfield name='locations' base-type='uint32_t'>
+        <bitfield name='locations' base-type='uint32_t'> bay12: GROWTH_HOST_TILE_FLAG_*
             <flag-bit name='twigs'/>
             <flag-bit name='light_branches'/>
             <flag-bit name='heavy_branches'/>
@@ -258,16 +264,17 @@
             <flag-bit name='sapling'/>
         </bitfield>
         <int32_t name='density'/>
-        <bitfield name='behavior' base-type='uint32_t'>
+        <bitfield name='behavior' base-type='uint32_t'> bay12: PMD_GROWTH_FLAG_*
             <flag-bit name='drops_off'/>
             <flag-bit name='no_cloud'/>
             <flag-bit name='has_seed'/>
+            <flag-bit count='4' name='graphics_type'/> bay12: PMD_GROWTH_FLAG_GRAPHICS_TYPE_*
         </bitfield>
         <int32_t name='trunk_height_perc_1'/>
         <int32_t name='trunk_height_perc_2'/>
     </struct-type>
 
-    <struct-type type-name='plant_growth_print'>
+    <struct-type type-name='plant_growth_print' original-name='pmd_growth_print_variantst'>
         <int32_t name='priority' comment='final token in list'/>
         <uint8_t name='tile_growth'/>
         <uint8_t name='tile_item'/>

--- a/df.plants.xml
+++ b/df.plants.xml
@@ -1,16 +1,18 @@
 <data-definition>
-    <bitfield-type type-name='plant_flags' base-type='uint16_t' comment='actually an enum relating to plant vectors'>
-        <flag-bit name='watery' comment='Within 2 tiles of pool/river/brook feature'/>
-        <flag-bit name='is_shrub' comment='If it is not a shrub, then it is a tree'/>
-    </bitfield-type>
+    <enum-type type-name='plant_type'> bay12: VegType
+        <enum-item name='DRY_TREE'/>
+        <enum-item name='WET_TREE'/>
+        <enum-item name='DRY_PLANT'/>
+        <enum-item name='WET_PLANT'/>
+    </enum-type>
 
-    <struct-type type-name='plant' instance-vector='$global.world.plants.all'>
-        <bitfield type-name='plant_flags' name='flags'/>
+    <struct-type type-name='plant' original-name='vegst' instance-vector='$global.world.plants.all'>
+        <enum name='type' type-name='plant_type' base-type='int16_t'/>
         <int16_t name='material' ref-target='plant_raw'/>
         <compound name='pos' type-name='coord'/>
 
         <int32_t name='grow_counter'/>
-        <bitfield name='damage_flags'>
+        <bitfield name='damage_flags'> bay12: VEGFLAG_*
             <flag-bit name='unused_01'/>
             <flag-bit name='season_dead'/>
             <flag-bit name='dead'/>
@@ -20,11 +22,11 @@
 
         <int32_t name='site_id' ref-target='world_site'/>
         <int32_t name='srb_id' ref-target='site_realization_building' aux-value='$$.site_id'/>
-        <stl-vector name='contaminants' pointer-type='spatter_common'/>
+        <stl-vector name='contaminants' pointer-type='spatter_common'/> bay12: actually veg_contaminantst
         <pointer name='tree_info' type-name='plant_tree_info' comment='Sapling if NULL'/>
     </struct-type>
 
-    <enum-type type-name='plant_tree_tile_branches_dir' base-type='uint16_t'>
+    <enum-type type-name='plant_tree_tile_branches_dir' base-type='uint16_t'> bay12: MULTI_TILE_FLAG_DIR_BRANCH_*
         <enum-item name='NONE'/>
         <enum-item name='BRANCH_W'/>
         <enum-item name='BRANCH_N'/>
@@ -42,7 +44,7 @@
         <enum-item name='BRANCH_NES'/>
     </enum-type>
 
-    <enum-type type-name='plant_tree_tile_parent_dir' base-type='uint16_t'>
+    <enum-type type-name='plant_tree_tile_parent_dir' base-type='uint16_t'> bay12: MULTI_TILE_FLAG_PARENT_*
         <enum-item name='NONE'/>
         <enum-item name='PARENT_IS_N'/>
         <enum-item name='PARENT_IS_S'/>
@@ -52,30 +54,30 @@
         <enum-item name='PARENT_IS_DOWN'/>
     </enum-type>
 
-    <bitfield-type type-name='plant_tree_tile' base-type='uint16_t'>
+    <bitfield-type type-name='plant_tree_tile' base-type='uint16_t'> bay12: MULTI_TILE_FLAG_*
         <flag-bit name='trunk'/>
-        <flag-bit name='branches_dir' count='4' type-name='plant_tree_tile_branches_dir'/>
-        <flag-bit name='branches'/>
-        <flag-bit name='twigs' comment='leaves'/>
+        <flag-bit name='branches_dir' count='4' type-name='plant_tree_tile_branches_dir'/> upper bit apparently also CAP_WALL?
+        <flag-bit name='branches'/> apparently also CAP_RAMP?
+        <flag-bit name='leaves'/> apparently also CAP_FLOOR?
         <flag-bit name='blocked' comment='e.g. by other tree'/>
         <flag-bit name='parent_dir' count='3' type-name='plant_tree_tile_parent_dir'/>
         <flag-bit name='trunk_is_thick'/>
     </bitfield-type>
 
-    <bitfield-type type-name='plant_root_tile' base-type='uint8_t'>
+    <bitfield-type type-name='plant_root_tile' base-type='uint8_t'> bay12: MULTI_TILE_ROOT_FLAG_*
         <flag-bit name='regular'/>
         <flag-bit count='6' comment='unused'/>
         <flag-bit name='blocked'/>
     </bitfield-type>
 
-    <struct-type type-name='plant_tree_info'>
+    <struct-type type-name='plant_tree_info' original-name='multi_tile_vegst'>
         <pointer name='body' is-array='true' comment='dimension body_height'>
             <pointer type-name='plant_tree_tile' is-array='true' comment='dimension dim_x*dim_y'/>
         </pointer>
-        <pointer name='extent_east' type-name='int16_t' is-array='true' comment='dimension body_height'/>
-        <pointer name='extent_south' type-name='int16_t' is-array='true' comment='dimension body_height'/>
-        <pointer name='extent_west' type-name='int16_t' is-array='true' comment='dimension body_height'/>
-        <pointer name='extent_north' type-name='int16_t' is-array='true' comment='dimension body_height'/>
+        <pointer name='extent_x1' type-name='int16_t' is-array='true' comment='dimension body_height'/>
+        <pointer name='extent_x2' type-name='int16_t' is-array='true' comment='dimension body_height'/>
+        <pointer name='extent_y1' type-name='int16_t' is-array='true' comment='dimension body_height'/>
+        <pointer name='extent_y2' type-name='int16_t' is-array='true' comment='dimension body_height'/>
         <int32_t name='body_height'/>
         <int32_t name='dim_x'/>
         <int32_t name='dim_y'/>

--- a/df.syndrome.xml
+++ b/df.syndrome.xml
@@ -1,5 +1,5 @@
 <data-definition>
-    <enum-type type-name='creature_interaction_effect_type'>
+    <enum-type type-name='creature_interaction_effect_type' base-type='int16_t'> bay12: CreatureInteractionEffectType
         <enum-item name='PAIN'/>
         <enum-item name='SWELLING'/>
         <enum-item name='OOZING'/>
@@ -55,7 +55,7 @@
         <enum-item name='REDUCE_FEVER'/>
     </enum-type>
 
-    <bitfield-type type-name='creature_interaction_effect_flags' base-type='uint32_t'>
+    <bitfield-type type-name='creature_interaction_effect_flags' base-type='uint32_t'> bay12: CREATURE_INTERACTION_EFFECT_FLAG_*
         <flag-bit name='SIZE_DELAYS'/>
         <flag-bit name='SIZE_DILUTES'/>
         <flag-bit name='VASCULAR_ONLY'/>
@@ -113,16 +113,14 @@
         <flag-bit name='FIT_FOR_RESURRECTION'/>
     </bitfield-type>
 
-    <enum-type type-name='creature_interaction_effect_target_mode' base-type='int16_t'>
+    <enum-type type-name='creature_interaction_effect_target_mode' base-type='int16_t'> bay12: BodyPartGroupType
         <enum-item name='BY_TYPE'/>
         <enum-item name='BY_TOKEN'/>
         <enum-item name='BY_CATEGORY'/>
     </enum-type>
 
-    <struct-type type-name='creature_interaction_effect_target'>
-        <stl-vector name='mode'>
-            <enum base-type='int16_t' type-name='creature_interaction_effect_target_mode'/>
-        </stl-vector>
+    <struct-type type-name='creature_interaction_effect_target' comment='not a real structure'>
+        <stl-vector name='mode' type-name='creature_interaction_effect_target_mode'/>
         <stl-vector name='key' pointer-type='stl-string'/>
         <stl-vector name='tissue' pointer-type='stl-string'/>
     </struct-type>
@@ -143,13 +141,13 @@
         <int32_t name="moon_phase_min"/>
         <int32_t name="moon_phase_max"/>
 
-        <compound name='counter_trigger'>
+        <compound name='counter_trigger'> not a compound
             <stl-vector name="counter">
                 <enum base-type='int32_t' type-name='misc_trait_type'/>
             </stl-vector>
             <stl-vector name="minval" type-name='int32_t' comment='?'/>
             <stl-vector name="maxval" type-name='int32_t' comment='?'/>
-            <stl-vector name="required" type-name='int32_t'/>
+            <stl-vector name="required" type-name='uint32_t'/> bay12: CREATURE_INTERACTION_EFFECT_COUNTER_FLAG_*
         </compound>
 
         <virtual-methods>
@@ -170,7 +168,7 @@
             <vmethod name='isUntargeted' ret-type='bool'/>
 
             <vmethod name='getTargetModes'>
-                <ret-type><pointer><stl-vector><enum base-type='int16_t' type-name='creature_interaction_effect_target_mode'/></stl-vector></pointer></ret-type>
+                <ret-type><pointer><stl-vector type-name='creature_interaction_effect_target_mode'/></pointer></ret-type>
             </vmethod>
             <vmethod name='getTargetKeys'>
                 <ret-type><pointer><stl-vector pointer-type='stl-string'/></pointer></ret-type>
@@ -179,24 +177,22 @@
                 <ret-type><pointer><stl-vector pointer-type='stl-string'/></pointer></ret-type>
             </vmethod>
             <vmethod name='checkAddFlag1' ret-type='bool'><uint32_t/></vmethod>
-            <vmethod name='setBodyMatInteractionName'><pointer/></vmethod>
+            <vmethod name='parseLineInteraction'><pointer name='tok' type-name='stl-string'/></vmethod>
 
-            <vmethod name='parseSynAcquireType'><pointer name='type'/></vmethod>
-            <vmethod name='setBodyTransform'><pointer name='race'/><pointer name='caste'/></vmethod>
-            <vmethod name='addPeriodic'><pointer/><pointer/><pointer/></vmethod>
-            <vmethod name='addCounterTrigger'><pointer/><pointer/><pointer/><pointer/></vmethod>
-            <vmethod><pointer/></vmethod>
+            <vmethod name='parseLineSyndromeFlag'><pointer name='tok' type-name='stl-string'/></vmethod>
+            <vmethod name='parseLineCreature'><pointer name='tok1' type-name='stl-string'/><pointer name='tok2' type-name='stl-string'/></vmethod>
+            <vmethod name='parseLineCreatureFlag'><pointer name='tok' type-name='stl-string'/></vmethod>
+            <vmethod name='parseLineForbiddenCreatureFlag'><pointer name='tok' type-name='stl-string'/></vmethod>
+            <vmethod name='parseLineCreatureCasteFlag'><pointer name='tok' type-name='stl-string'/></vmethod>
+            <vmethod name='parseLineForbiddenCreatureCasteFlag'><pointer name='tok' type-name='stl-string'/></vmethod>
 
-            <vmethod/>
-            <vmethod comment='can_do_interaction, returns unk_6c'>
-                <ret-type><pointer><stl-vector/></pointer></ret-type>
-            </vmethod>
-            <vmethod/>
-            <vmethod/>
-            <vmethod/>
-            <vmethod/>
-            <vmethod/>
-            <vmethod/>
+            <vmethod name='parseLineMinGaitSpeed'><int32_t name='speed'/></vmethod>
+            <vmethod name='parseLineMaxGaitSpeed'><int32_t name='speed'/></vmethod>
+            <vmethod name='parseLinePeriodic'><pointer name='tok1' type-name='stl-string'/><pointer name='tok2' type-name='stl-string'/><pointer name='tok3' type-name='stl-string'/></vmethod>
+            <vmethod name='parseLineCounter'><pointer name='tok1' type-name='stl-string'/><pointer name='tok2' type-name='stl-string'/><pointer name='tok3' type-name='stl-string'/><pointer name='tok4' type-name='stl-string'/></vmethod>
+            <vmethod name='applyToHistfig'><pointer name='hf' type-name='historical_figure'/><bool name='worldgen'/></vmethod>
+            <vmethod name='finalize'/>
+            <vmethod name='getCreatureInteraction'><ret-type><pointer type-name='creature_interaction'/></ret-type></vmethod>
         </virtual-methods>
     </class-type>
 
@@ -300,25 +296,27 @@
         <stl-string name='name'/>
         <stl-string name='name_plural'/>
         <stl-string name='name_adj'/>
-        <int32_t name='unk_1'/>
+        <bitfield name='name_flags' base-type='uint32_t'> bay12: CIE_DISPLAY_NAME_FLAG_*
+            <flag-bit name='can_be_hidden'/>
+        </bitfield>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_body_appearance_modifierst'
                 inherits-from='creature_interaction_effect'>
-        <int16_t name="unk_60"/>
-        <int32_t name="unk_64"/>
+        <enum name="appearance_modifier" type-name='appearance_modifier_type'/>
+        <int32_t name="appearance_modifier_value"/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_bp_appearance_modifierst'
                 inherits-from='creature_interaction_effect'>
-        <int16_t name="unk_6c"/>
-        <int32_t name="value"/>
+        <enum name="appearance_modifier" type-name='appearance_modifier_type'/>
+        <int32_t name="appearance_modifier_value"/>
         <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_body_transformationst'
                 inherits-from='creature_interaction_effect'>
-        <int32_t name="chance" comment='%'/>
+        <uint32_t name='bt_flags'/> bay12: flags unknown
         <stl-string name="race_str"/>
         <stl-string name="caste_str"/>
         <stl-vector name='race' type-name='int32_t' ref-target='creature_raw'/>
@@ -327,8 +325,8 @@
         <stl-vector type-name='int32_t' name='forbidden_creature_flags' comment='contains indexes of flags in creature_raw_flags'/>
         <stl-vector type-name='int32_t' name='required_caste_flags' comment='contains indexes of flags in caste_raw_flags'/>
         <stl-vector type-name='int32_t' name='forbidden_caste_flags' comment='contains indexes of flags in caste_raw_flags'/>
-        <int32_t name='unk_1' init-value='-1'/>
-        <int32_t name='unk_2' init-value='-1'/>
+        <int32_t name='minimum_effortless_gait_speed' init-value='-1'/>
+        <int32_t name='maximum_effortless_gait_speed' init-value='-1'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_skill_roll_adjustst'
@@ -339,16 +337,22 @@
 
     <class-type type-name='creature_interaction_effect_display_symbolst'
                 inherits-from='creature_interaction_effect'>
-        <int32_t name="tile"/>
-        <int32_t name="color"/>
+        <uint8_t name="tile"/>
+        <static-array type-name='int8_t' name="sym_color" count='3'/>
+        <bitfield name='tile_flags' base-type='uint32_t'> bay12: CIE_DISPLAY_TILE_FLAG_*
+            <flag-bit name='can_be_hidden'/>
+        </bitfield>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_flash_symbolst'
                 inherits-from='creature_interaction_effect'>
-        <static-array type-name='uint8_t' name="sym_color" count='4'/>
+        <uint8_t name="tile"/>
+        <static-array type-name='int8_t' name="sym_color" count='3'/>
         <int32_t name="period"/>
         <int32_t name="time"/>
-        <int32_t name="unk_78"/>
+        <bitfield name='tile_flags' base-type='uint32_t'> bay12: CIE_DISPLAY_TILE_FLAG_*
+            <flag-bit name='can_be_hidden'/>
+        </bitfield>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_phys_att_changest'
@@ -389,16 +393,16 @@
                 inherits-from='creature_interaction_effect'>
         <stl-string name="interaction_name"/>
         <int32_t name="interaction_id" ref-target='interaction'/>
-        <int32_t name="unk_8c"/>
-        <int32_t name="unk_90"/>
-        <stl-string name="unk_94"/>
+        <uint32_t name="bmi_flag"/>
+        <uint32_t name="cis_flag"/>
+        <stl-string name="mat_token"/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_material_force_adjustst'
                 inherits-from='creature_interaction_effect'>
-        <stl-string name="unk_6c"/>
-        <stl-string name="unk_88"/>
-        <stl-string name="unk_a4"/>
+        <stl-string name="mat_str1"/>
+        <stl-string name="mat_str2"/>
+        <stl-string name="mat_str3"/>
         <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>
         <int32_t name='mat_index'/>
         <int32_t name="fraction_mul"/>
@@ -413,7 +417,7 @@
     <class-type type-name='creature_interaction_effect_sense_creature_classst'
                 inherits-from='creature_interaction_effect'>
         <stl-string name="class_name"/>
-        <int8_t name="tile"/>
+        <uint8_t name="tile"/>
         <int16_t name="color_foreground"/>
         <int16_t name="color_background"/>
         <int16_t name="foreground_brightness"/>
@@ -436,103 +440,78 @@
     </class-type>
 
     <class-type type-name='creature_interaction_effect_close_open_woundsst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
-    </class-type>
-
-    <class-type type-name='creature_interaction_effect_cure_infectionsst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
+        <int32_t name='sev'/>
+        <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_heal_nervesst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
+        <int32_t name='sev'/>
+        <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_heal_tissuesst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
+        <int32_t name='sev'/>
+        <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_dizzinessst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
+        <int32_t name='sev'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_feverst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
+        <int32_t name='sev'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_nauseast' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
+        <int32_t name='sev'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_painst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
+        <int32_t name='sev'/>
+        <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_paralysisst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
+        <int32_t name='sev'/>
+        <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_reduce_swellingst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
+        <int32_t name='sev'/>
+        <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_regrow_partsst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
+        <int32_t name='sev'/>
+        <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_special_attack_interactionst' inherits-from='creature_interaction_effect'>
-        <stl-vector name='unk_1' type-name='int16_t'/>
-        <stl-vector name='unk_2' pointer-type='stl-string'/>
-        <stl-string name='unk_3'/>
+        <stl-vector name='attack_bp' type-name='creature_interaction_effect_target_mode'/>
+        <stl-vector name='attack_target' pointer-type='stl-string'/>
+        <stl-string name='interaction_token'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_stop_bleedingst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
+        <int32_t name='sev'/>
+        <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_cure_infectionst' inherits-from='creature_interaction_effect'>
-        <int32_t name='unk_1'/>
-        <stl-vector name='unk_2'/>
-        <stl-vector name='unk_3'/>
-        <stl-vector name='unk_4'/>
+        <int32_t name='sev'/>
+        <compound type-name='creature_interaction_effect_target' name='target'/>
     </class-type>
 
-    <bitfield-type type-name='syndrome_flags' base-type='uint32_t'>
+    <bitfield-type type-name='syndrome_flags' base-type='uint32_t'> bay12: CREATURE_INTERACTION_SYNDROME_FLAG_*
         <flag-bit name='SYN_INJECTED'/>
         <flag-bit name='SYN_CONTACT'/>
         <flag-bit name='SYN_INHALED'/>
-        <flag-bit/>
+        <flag-bit name='INHERENT'/>
         <flag-bit name='SYN_INGESTED'/>
         <flag-bit name='SYN_NO_HOSPITAL'/>
     </bitfield-type>
 
-    <struct-type type-name='syndrome'
+    <struct-type type-name='syndrome' original-name='creature_interaction_syndromest'
                  instance-vector='$global.world.raws.syndromes.all'>
         <stl-string name='syn_name'/>
 

--- a/df.units.xml
+++ b/df.units.xml
@@ -1509,7 +1509,7 @@
         <stl-vector name='unk4' type-name='int32_t'/>
     </struct-type>
 
-    <enum-type type-name='wound_effect_type' base-type='int16_t'>
+    <enum-type type-name='wound_effect_type' base-type='int16_t'> bay12: WoundDamageType
         <enum-item name='Bruise'/>
         <enum-item name='Burn'/>
         <enum-item name='Frostbite'/>


### PR DESCRIPTION
Note that there are multiple breaking changes in this update:

* Item weight is now `massst`, which will also be used in `caravan_state` once I get to that
* `spatter` now includes `spatter_common` as a member rather than inheriting from it (so that we won't need padding hacks anymore for GCC)
* `itemst::testMaterialFlag` was wrong and has been changed to `itemst::fitsCivRequestTab`
* Any call sites for `itemst::addWear` or `itemst::checkWearDestroy` should be checked, as their parameters were out of order
* `itemst::getItemDescriptionPrefix` now uses an enum for its second parameter
* Anything looking at `item_history_info` previously expected a pointer-to-pointer; now there's an actual structure in between
* Anything still looking for the material flag `LEAF_MAT` will finally need to be updated to use `STOCKPILE_PLANT_GROWTH`, and the same for the `organic_mat_category` values "Leaf" and "CookableLeaf"
* Enough is enough - the `plant_flags` bitfield (watery/shrub) has been changed into the `plant_type` enum, regardless of how closely the current enum values resemble bitflags
* `plant_tree_info` had its `extent_*` fields named incorrectly (east/south/west/north, where Toady had sx/ex/sy/ey) - anything which actually used them should be checked for correctness