### PR TITLE
Enum attrs for plant_type

### DIFF
--- a/df.plants.xml
+++ b/df.plants.xml
@@ -2,7 +2,7 @@
     <enum-type type-name='plant_type'> bay12: VegType
         <enum-attr name='watery' type-name='bool' default-value='false' comment='near surface water feature'/>
         <enum-attr name='is_shrub' type-name='bool' default-value='false'/>
-        
+
         <enum-item name='DRY_TREE'>
             <item-attr name='watery' value='false'/>
             <item-attr name='is_shrub' value='false'/>

--- a/df.plants.xml
+++ b/df.plants.xml
@@ -1,9 +1,24 @@
 <data-definition>
     <enum-type type-name='plant_type'> bay12: VegType
-        <enum-item name='DRY_TREE'/>
-        <enum-item name='WET_TREE'/>
-        <enum-item name='DRY_PLANT'/>
-        <enum-item name='WET_PLANT'/>
+        <enum-attr name='watery' type-name='bool' default-value='false' comment='near surface water feature'/>
+        <enum-attr name='is_shrub' type-name='bool' default-value='false'/>
+        
+        <enum-item name='DRY_TREE'>
+            <item-attr name='watery' value='false'/>
+            <item-attr name='is_shrub' value='false'/>
+        </enum-item>
+        <enum-item name='WET_TREE'>
+            <item-attr name='watery' value='true'/>
+            <item-attr name='is_shrub' value='false'/>
+        </enum-item>
+        <enum-item name='DRY_PLANT'>
+            <item-attr name='watery' value='false'/>
+            <item-attr name='is_shrub' value='true'/>
+        </enum-item>
+        <enum-item name='WET_PLANT'>
+            <item-attr name='watery' value='true'/>
+            <item-attr name='is_shrub' value='true'/>
+        </enum-item>
     </enum-type>
 
     <struct-type type-name='plant' original-name='vegst' instance-vector='$global.world.plants.all'>


### PR DESCRIPTION
Enum attrs to restore convenience of `plant.flags`.

I assume it's not possible to have an enum attr that refers to a plant vector? Would be handy otherwise.