### PR TITLE
unit.appearance.colors ref target

### DIFF
--- a/df.units.xml
+++ b/df.units.xml
@@ -961,7 +961,7 @@
 
             <compound name='genes' type-name='unit_genes'/>
 
-            <stl-vector name='colors' type-name='int32_t'/>
+            <stl-vector name='colors' type-name='int32_t' comment='colors[i] refers to caste_raw.color_modifiers[i].pattern_index'/>
         </compound>
 
         <stl-vector name='actions' pointer-type='unit_action'/>


### PR DESCRIPTION
`unit.appearance.colors[i]` refers to the unit's `caste_raw.color_modifiers[i].pattern_index`, based on Stonesense code.

That is, `caste_raw.color_modifiers[i].pattern_index[colors[i]]` will get you the index of the relevant `df.descriptor_pattern`.