### PR TITLE
Remove gps "texture" compound

### DIFF
--- a/df.graphics.xml
+++ b/df.graphics.xml
@@ -288,21 +288,20 @@
         <int32_t name='dimx'/>
         <int32_t name='dimy'/>
 
-        <compound name='tileset'>
-            <static-array type-name='long' count='1' name='black_background_texpos'/>
-            <static-array type-name='int32_t' count='120' name='texture_indices1'/>
-            <stl-vector type-name='int32_t' name='texpos_custom_symbol'/>
-            <static-array type-name='int32_t' count='8581' name='texture_indices2'/>
+        -- do NOT put these in a compound, because it will break alignment!
+        <static-array type-name='long' count='1' name='black_background_texpos'/>
+        <static-array type-name='int32_t' count='120' name='texture_indices1'/>
+        <stl-vector type-name='int32_t' name='texpos_custom_symbol'/>
+        <static-array type-name='int32_t' count='8626' name='texture_indices2'/>
 
-            <compound type-name='interface_setst' name='graphical_interface'/>
-            <compound type-name='interface_setst' name='classic_interface'/>
+        <compound type-name='interface_setst' name='graphical_interface'/>
+        <compound type-name='interface_setst' name='classic_interface'/>
 
-            <static-array type-name='int32_t' count='12044' name='texture_indices3'/>
-            <stl-vector type-name='int32_t' name='texpos_boulder'/>
-            <static-array type-name='int32_t' count='3588' name='texture_indices4'/>
-            <stl-vector type-name='int32_t' name='texpos_item_statue_artifact'/>
-            <static-array type-name='int32_t' count='14379' name='texture_indices5'/>
-        </compound>
+        <static-array type-name='int32_t' count='12924' name='texture_indices3'/>
+        <stl-vector type-name='int32_t' name='texpos_boulder'/>
+        <static-array type-name='int32_t' count='3588' name='texture_indices4'/>
+        <stl-vector type-name='int32_t' name='texpos_item_statue_artifact'/>
+        <static-array type-name='int32_t' count='14379' name='texture_indices5'/>
     </struct-type>
 
     <struct-type type-name='interface_setst'>


### PR DESCRIPTION
because its very existence causes alignment errors on Windows.

Also fix the texture_indices lengths so they're hopefully correct.