### PR TITLE
Rename world_site.is_mountain_halls and world_site.is_fortress

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Template for new versions:
 # Future
 
 ## Structures
+- ``world_site``: rename ``is_mountain_halls`` and ``is_fortress`` to Bay12 names ``min_depth`` and ``max_depth``
 
 # 50.13-r3
 

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -597,8 +597,8 @@
 
         <compound name='location_death' type-name='location_deathst'/>
 
-        <int32_t name='is_mountain_halls' since='v0.40.01' comment='bay12: min_depth'/>
-        <int32_t name='is_fortress' since='v0.40.01' comment='bay12: max_depth'/>
+        <int32_t name='min_depth' since='v0.40.01'/>
+        <int32_t name='max_depth' since='v0.40.01'/>
         <int32_t name='mined_hours' init-value='0' comment="only MountainHalls, but only subset of them"/>
 
         <stl-vector name="architecture_change" pointer-type='site_architecture_changest' since='v0.40.01'/>

--- a/df.world-site.xml
+++ b/df.world-site.xml
@@ -597,8 +597,8 @@
 
         <compound name='location_death' type-name='location_deathst'/>
 
-        <int32_t name='min_depth' since='v0.40.01'/>
-        <int32_t name='max_depth' since='v0.40.01'/>
+        <int32_t name='min_depth' since='v0.40.01' comment='compared to feature_init.end_depth'/>
+        <int32_t name='max_depth' since='v0.40.01' comment='compared to feature_init.start_depth'/>
         <int32_t name='mined_hours' init-value='0' comment="only MountainHalls, but only subset of them"/>
 
         <stl-vector name="architecture_change" pointer-type='site_architecture_changest' since='v0.40.01'/>


### PR DESCRIPTION
Switching to Bay12 names since they make more sense and we aren't using these anywhere.

Related to #443