### PR TITLE
Add "All" group attr to new unit_action_type enums

### DIFF
--- a/df.units.xml
+++ b/df.units.xml
@@ -2364,21 +2364,27 @@
         </enum-item>
         <enum-item name='HoldItem'>
             <item-attr name='tag' value='holditem'/>
+            <item-attr name='group' value='All'/>
         </enum-item>
         <enum-item name='ReleaseItem'>
             <item-attr name='tag' value='releaseitem'/>
+            <item-attr name='group' value='All'/>
         </enum-item>
         <enum-item name='Mount'>
             <item-attr name='tag' value='mount'/>
+            <item-attr name='group' value='All'/>
         </enum-item>
         <enum-item name='Dismount'>
             <item-attr name='tag' value='dismount'/>
+            <item-attr name='group' value='All'/>
         </enum-item>
         <enum-item name='LeadAnimal'>
             <item-attr name='tag' value='leadanimal'/>
+            <item-attr name='group' value='All'/>
         </enum-item>
         <enum-item name='StopLeadAnimal'>
             <item-attr name='tag' value='stopleadanimal'/>
+            <item-attr name='group' value='All'/>
         </enum-item>
     </enum-type>
 


### PR DESCRIPTION
Add enum attrs so all `unit_action_type` enums are in the `All` `unit_action_type_group`.

They may also need attrs for `Movement`, `MovementFeet`, `Combat`, and/or `Work` (however we decide that).