### PR TITLE
update remaining structures for 51.01-beta20

### DIFF
--- a/df.graphics.xml
+++ b/df.graphics.xml
@@ -299,7 +299,7 @@
         <static-array type-name='long' count='1' name='black_background_texpos'/>
         <static-array type-name='int32_t' count='120' name='texture_indices1'/>
         <stl-vector type-name='int32_t' name='texpos_custom_symbol'/>
-        <static-array type-name='int32_t' count='10807' name='texture_indices2'/>
+        <static-array type-name='int32_t' count='10871' name='texture_indices2'/>
 
         <compound type-name='interface_setst' name='graphical_interface'/>
         <compound type-name='interface_setst' name='classic_interface'/>
@@ -409,7 +409,7 @@
         <static-array count='5' name='texpos_short_subsubtab'><static-array type-name='int32_t' count='2'/></static-array>
         <static-array count='5' name='texpos_short_subsubtab_selected'><static-array type-name='int32_t' count='2'/></static-array>
         <int32_t name='texpos_interface_background'/>
-        <static-array count='696' name='texpos_button_main'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array>
+        <static-array count='698' name='texpos_button_main'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array>
         <static-array count='13' name='texpos_button_small'><static-array count='2'><static-array type-name='int32_t' count='2'/></static-array></static-array>
         <static-array count='4' name='texpos_button_horizontal_option_left_ornament'><static-array type-name='int32_t' count='3'/></static-array>
         <static-array count='3' name='texpos_button_horizontal_option_active'><static-array type-name='int32_t' count='3'/></static-array>
@@ -437,11 +437,18 @@
         <static-array type-name='int32_t' count='3' name='texpos_type_filter_left'/>
         <static-array type-name='int32_t' count='3' name='texpos_type_filter_right'/>
         <static-array type-name='int32_t' count='3' name='texpos_type_filter_text'/>
+        <static-array type-name='int32_t' count='2' name='texpos_pinned'/>
+        <static-array type-name='int32_t' count='2' name='texpos_not_pinned'/>
         <static-array type-name='int32_t' count='3' name='texpos_button_wrestle_right'/>
         <static-array type-name='int32_t' count='3' name='texpos_button_wrestle_equal'/>
         <static-array type-name='int32_t' count='3' name='texpos_button_wrestle_left'/>
         <static-array count='4' name='texpos_button_adventure_tactical_mode_on'><static-array type-name='int32_t' count='2'/></static-array>
         <static-array count='4' name='texpos_button_adventure_tactical_mode_off'><static-array type-name='int32_t' count='2'/></static-array>
+
+        <static-array count='3' name='texpos_adventure_log_pinned_active'><static-array type-name='int32_t' count='3'/></static-array>
+        <static-array count='3' name='texpos_adventure_log_pinned_inactive'><static-array type-name='int32_t' count='3'/></static-array>
+        <static-array count='3' name='texpos_adventure_log_item_active'><static-array type-name='int32_t' count='3'/></static-array>
+        <static-array count='3' name='texpos_adventure_log_item_inactive'><static-array type-name='int32_t' count='3'/></static-array>
 
         <static-array count='3' name='texpos_button_announcement_open_all_announcements'><static-array type-name='int32_t' count='3'/></static-array>
         <static-array count='9' name='texpos_button_announcement_not_pausing_on_new_report' type-name='int32_t'/>

--- a/df.jobs.xml
+++ b/df.jobs.xml
@@ -302,6 +302,7 @@
         <flag-bit name='woven'/>
         <flag-bit name='gem'/>
         <flag-bit name='empty_or_water'/>
+        <flag-bit name='grown_not_crafted'/>
     </bitfield-type>
 
     <struct-type type-name='job_item' original-name='job_req_elementst'>

--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -2072,6 +2072,12 @@
         <pointer name='find_metal_ore'><stl-vector type-name='int16_t' ref-target='inorganic_raw'/></pointer>
         <pointer name='skip_metal_ore'><stl-vector type-name='int16_t' ref-target='inorganic_raw'/></pointer>
         <int32_t name='highlight_site_id' ref-target='world_site'/>
+
+        <int32_t name='line_start_x'/>
+        <int32_t name='line_start_y'/>
+        <int32_t name='line_end_x'/>
+        <int32_t name='line_end_y'/>
+        <bool name='draw_entire_line'/>
     </struct-type>
 
     <struct-type type-name='rpd_indicator_datast'>
@@ -2153,7 +2159,7 @@
 
         <stl-vector type-name='int32_t' name='mission_report_index'/>
         <stl-vector type-name='int32_t' name='tribute_report_index'/>
-        <int32_t name='croll_position_report'/>
+        <int32_t name='scroll_position_report'/>
         <bool name='scrolling_report'/>
 
         <pointer name='active_mission_report' type-name='mission_report'/>


### PR DESCRIPTION
This does not include viewscreen_adventure_logst because we don't actually have that screen right now.

Do not merge until we've compared the new size of `graphic[st]` to what's in the EXE's global table entry for `gps`.