### PR TITLE
canonicalize widget flag names

### DIFF
--- a/df.viewscreen.xml
+++ b/df.viewscreen.xml
@@ -175,10 +175,10 @@
         <stl-vector name='custom_activated'> <stl-function/> </stl-vector>
         <stl-string name='name'/>
         <bitfield name='flag' base-type='int8_t'> bay12: WidgetFlag
-            <flag-bit name='WIDGET_VISIBILITY_ACTIVE'/>
-            <flag-bit name='WIDGET_VISIBILITY_VISIBLE'/> plus ACTUALLY_VISIBLE for both of the above
-            <flag-bit name='WIDGET_CAN_KEY_ACTIVATE'/>
-            <flag-bit name='WIDGET_GLOBAL_POSITIONING'/>
+            <flag-bit name='VISIBILITY_ACTIVE'/>
+            <flag-bit name='VISIBILITY_VISIBLE'/> plus ACTUALLY_VISIBLE for both of the above
+            <flag-bit name='CAN_KEY_ACTIVATE'/>
+            <flag-bit name='GLOBAL_POSITIONING'/>
         </bitfield>
         <int32_t name='offset_bottom'/>
         <int32_t name='offset_left'/>


### PR DESCRIPTION
I'm not sure how these escaped canonicalization. I thought we had already done this on the 50.14 branch when it was `testing`