### PR TITLE
Further updates for 50.15

### DIFF
--- a/df.graphics.xml
+++ b/df.graphics.xml
@@ -299,9 +299,13 @@
 
         <static-array type-name='int32_t' count='12924' name='texture_indices3'/>
         <stl-vector type-name='int32_t' name='texpos_boulder'/>
-        <static-array type-name='int32_t' count='3588' name='texture_indices4'/>
+        <static-array type-name='int32_t' count='3181' name='texture_indices4'/>
+        <static-array name='texpos_item_barrel_top' count='7'><stl-vector type-name='int32_t'/></static-array>
+        <static-array type-name='int32_t' count='128' name='texture_indices5'/>
+        <static-array name='texpos_item_bin_top' count='21'><stl-vector type-name='int32_t'/></static-array>
+        <static-array type-name='int32_t' count='279' name='texture_indices6'/>
         <stl-vector type-name='int32_t' name='texpos_item_statue_artifact'/>
-        <static-array type-name='int32_t' count='14379' name='texture_indices5'/>
+        <static-array type-name='int32_t' count='14379' name='texture_indices7'/>
     </struct-type>
 
     <struct-type type-name='interface_setst'>


### PR DESCRIPTION
`graphicst` should now be size 0x37520 (226592) on Windows.