### PR TITLE
add enum for work order condition change type

### DIFF
--- a/df.ui-menus.xml
+++ b/df.ui-menus.xml
@@ -825,6 +825,13 @@
         <enum-item name='ERASE'/>
     </enum-type>
 
+    <enum-type type-name='work_order_condition_change_type' base-type='int32_t'>
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='TYPE'/>
+        <enum-item name='MATERIAL'/>
+        <enum-item name='ADJECTIVE'/>
+    </enum-type>
+
     <class-type type-name='markup_text_box_widget' inherits-from='widget'>
         <int32_t name='scroll'/>
         <int32_t name='num_visible'/>
@@ -1046,7 +1053,7 @@
 
                 <stl-string name='filter'/>
                 <stl-vector pointer-type='stl-string' name='compare_master'/>
-                <int32_t name='change_type'/>
+                <enum name='change_type' type-name='work_order_condition_change_type'/>
                 <pointer name='change_wqc' type-name='manager_order_condition_item'/>
                 <int32_t name='scroll_position_change'/>
                 <int8_t name='scrolling_change'/>


### PR DESCRIPTION
so we can use it for focus string generation

This enum is represented by a bare int32_t in the DF headers, but has enum-like semantics in actual usage. I'm representing it as an enum for convenience and clarity.