### PR TITLE
add codegen support for `stl-fs-path`

### DIFF
--- a/SYNTAX.rst
+++ b/SYNTAX.rst
@@ -239,7 +239,15 @@ Primitive fields can be classified as following:
 
     These tags correspond to ``char[bytes]``, ``char*``, and ``std::string``.
 
-4)  File Stream::
+5)  Path::
+
+        <stl-fs-path name='id'.../>
+
+    This tag corresponds to ``std::filesystem::path`` and is used to
+    abstractly represent a path to a filesystem object in an
+    architecture-independent manner.
+
+6)  File Stream::
 
         <stl-fstream name='id'/>
 

--- a/StructFields.pm
+++ b/StructFields.pm
@@ -115,10 +115,18 @@ my %custom_primitive_handlers = (
     'stl-mutex' => sub { header_ref("mutex"); return "std::mutex"; },
     'stl-condition-variable' => sub { header_ref("condition_variable"); return "std::condition_variable"; },
     'stl-future' => sub { header_ref("future"); return "std::future<void>"; },
+    'stl-fs-path' => sub { header_ref("filesystem"); return "std::filesystem::path"; },
 );
 
 my %custom_primitive_inits = (
     'stl-string' => sub {
+        if (defined $cur_init_value) {
+            $cur_init_value =~ s/\\/\\\\/g;
+            $cur_init_value =~ s/\"/\\\"/g;
+            add_simple_init "\"$cur_init_value\"";
+        }
+    },
+    'stl-fs-path' => sub {
         if (defined $cur_init_value) {
             $cur_init_value =~ s/\\/\\\\/g;
             $cur_init_value =~ s/\"/\\\"/g;

--- a/data-definition.xsd
+++ b/data-definition.xsd
@@ -232,6 +232,7 @@
             <xs:element name="stl-weak-ptr" type="StlWeakPtrField" />
             <xs:element name="stl-function" type="StlFunctionField" />
             <xs:element name="stl-variant" type="StlVariantField" />
+            <xs:element name="stl-fs-path" type="StlPathField" />
             <xs:element name="df-linked-list" type="DfLinkedListField" />
             <xs:element name="df-array" type="DfArrayField" />
             <xs:element name="df-flagarray" type="DfFlagArrayField" />
@@ -374,6 +375,12 @@
         </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="StlStringField">
+        <xs:complexContent>
+            <xs:extension base="SimpleFieldType">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="StlPathField">
         <xs:complexContent>
             <xs:extension base="SimpleFieldType">
             </xs:extension>

--- a/lower-1.xslt
+++ b/lower-1.xslt
@@ -218,9 +218,10 @@ Error: field <xsl:value-of select='$enum-key'/> corresponds to an enum value of 
         <prim-type ld:meta='primitive' ld:subtype='stl-mutex'/>
         <prim-type ld:meta='primitive' ld:subtype='stl-condition-variable'/>
         <prim-type ld:meta='primitive' ld:subtype='stl-future'/>
+        <prim-type ld:meta='primitive' ld:subtype='stl-fs-path'/>
     </ld:primitive-types>
 
-    <xsl:template match='int8_t|uint8_t|int16_t|uint16_t|int32_t|uint32_t|int64_t|uint64_t|size_t|ssize_t|long|ulong|bool|flag-bit|s-float|d-float|padding|static-string|ptr-string|stl-string|stl-fstream|stl-mutex|stl-condition-variable|stl-future'>
+    <xsl:template match='int8_t|uint8_t|int16_t|uint16_t|int32_t|uint32_t|int64_t|uint64_t|size_t|ssize_t|long|ulong|bool|flag-bit|s-float|d-float|padding|static-string|ptr-string|stl-string|stl-fstream|stl-mutex|stl-condition-variable|stl-future|stl-fs-path'>
         <xsl:param name='level' select='-1'/>
         <ld:field>
             <xsl:apply-templates select='@*'/>


### PR DESCRIPTION
This adds codegen support for `stl-fs-path`, representing `std::filesystem::path`

This can be applied immediately as there is no change in behavior for structure definitions that do not actually use `stl-fs-path`