### PR TITLE
remove fake `curse` compound in `unitst`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Template for new versions:
 # Future
 
 ## Structures
+- removed fake ``curse`` compound in ``unitst`` to resolve an alignment issue
 
 # 51.07-r1
 

--- a/df.unit.xml
+++ b/df.unit.xml
@@ -2823,44 +2823,42 @@
             <uint32_t name='dizziness'/>
         </compound>
 
-        <compound name='curse'> not a compound
-            <uint32_t name='flags' comment='moved from end of counters in 0.43.05'/>
+        <uint32_t name='uwss_flag' comment='moved from end of counters in 0.43.05'/>
 
-            <bitfield name='add_tags1' type-name='cie_add_tag_mask1'/>
-            <bitfield name='rem_tags1' type-name='cie_add_tag_mask1'/>
-            <bitfield name='add_tags2' type-name='cie_add_tag_mask2'/>
-            <bitfield name='rem_tags2' type-name='cie_add_tag_mask2'/>
+        <bitfield name='uwss_add_caste_flag' type-name='cie_add_tag_mask1'/>
+        <bitfield name='uwss_remove_caste_flag' type-name='cie_add_tag_mask1'/>
+        <bitfield name='uwss_add_property' type-name='cie_add_tag_mask2'/>
+        <bitfield name='uwss_remove_property' type-name='cie_add_tag_mask2'/>
 
-            <bool name='name_visible' since='v0.34.01'/>
-            <stl-string name='name' since='v0.34.01'/>
-            <stl-string name='name_plural' since='v0.34.01'/>
-            <stl-string name='name_adjective' since='v0.34.01'/>
+        <bool name='uwss_use_display_name' since='v0.34.01'/>
+        <stl-string name='uwss_display_name_sing' since='v0.34.01'/>
+        <stl-string name='uwss_display_name_plur' since='v0.34.01'/>
+        <stl-string name='uwss_display_name_adj' since='v0.34.01'/>
 
-            <uint8_t name='display_tile'/>
-            <int8_t name='display_f'/>
-            <int8_t name='display_b'/>
-            <int8_t name='display_br'/>
-            <uint8_t name='flash_tile'/>
-            <int8_t name='flash_f'/>
-            <int8_t name='flash_b'/>
-            <int8_t name='flash_br'/>
-            <uint32_t name='flash_period' since='v0.34.01'/>
-            <uint32_t name='flash_time2' since='v0.34.01'/>
+        <uint8_t name='uwss_display_tile'/>
+        <int8_t name='uwss_display_color_f'/>
+        <int8_t name='uwss_display_color_b'/>
+        <int8_t name='uwss_display_color_br'/>
+        <uint8_t name='uwss_flash_tile'/>
+        <int8_t name='uwss_flash_color_f'/>
+        <int8_t name='uwss_flash_color_b'/>
+        <int8_t name='uwss_flash_color_br'/>
+        <uint32_t name='uwss_alt_period' since='v0.34.01'/>
+        <uint32_t name='uwss_alt_on_period' since='v0.34.01'/>
 
-            <stl-vector name='body_appearance' type-name='int32_t'
-                        index-refers-to='$$._global.caste.ref-target.body_appearance_modifiers[$]'/>
-            <stl-vector name='bp_appearance' type-name='int32_t' since='v0.34.01' comment='guess!'
-                        index-refers-to='$$._global.caste.ref-target.bp_appearance.modifier_idx[$].refers-to'/>
+        <stl-vector name='uwss_body_modifier' type-name='int32_t'
+                    index-refers-to='$$._global.caste.ref-target.body_appearance_modifiers[$]'/>
+        <stl-vector name='uwss_bp_modifer' type-name='int32_t' since='v0.34.01' comment='guess!'
+                    index-refers-to='$$._global.caste.ref-target.bp_appearance.modifier_idx[$].refers-to'/>
 
-            <uint32_t name='speed_add' since='v0.34.01'/>
-            <uint32_t name='speed_mul_percent' since='v0.34.01' init-value='100'/>
+        <uint32_t name='uwss_speed_add' since='v0.34.01'/>
+        <uint32_t name='uwss_speed_perc' since='v0.34.01' init-value='100'/>
 
-            <pointer name='attr_change' type-name='curse_attr_change' since='v0.34.01'/>
-            <uint32_t name='luck_mul_percent' since='v0.34.01' init-value='100'/>
-            <int32_t name='erratic_level' since='v0.42.01'/>
+        <pointer name='uwss_att_change' type-name='curse_attr_change' since='v0.34.01'/>
+        <uint32_t name='uwss_skill_role_adjust' since='v0.34.01' init-value='100'/>
+        <int32_t name='uwss_erratic_level' since='v0.42.01'/>
 
-            <compound name='interaction' type-name='unit_usable_interactionst'/>
-        </compound>
+        <compound name='usable_interaction' type-name='unit_usable_interactionst'/>
 
         <compound name='counters2'> not a compound
             <uint32_t name='paralysis'/>


### PR DESCRIPTION
resolves an alignment problem in `unitst`

will break builds - coordinate change required