### PR TITLE
Add missing original-name attributes

### DIFF
--- a/df.d_init.xml
+++ b/df.d_init.xml
@@ -180,7 +180,7 @@
                       count='356' index-enum='announcement_type'/>
     </struct-type>
 
-    <struct-type type-name='d_init'>
+    <struct-type type-name='d_init' original-name='d_initst'>
         <compound name='display' type-name='d_init_displayst'/>
         <compound name='adventure' type-name='d_init_adventurest'/>
         <compound name='dwarf' type-name='d_init_dwarfst'/>

--- a/df.event.xml
+++ b/df.event.xml
@@ -111,7 +111,7 @@
         <enum-item name='FromColony'/>
     </enum-type>
 
-    <struct-type type-name='vermin' instance-vector='$global.world.event.vermin'>
+    <struct-type type-name='vermin' original-name='event_verminst' instance-vector='$global.world.event.vermin'>
         <int16_t name='race' ref-target='creature_raw'/>
         <int16_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
         <compound name='pos' type-name='coord'/>

--- a/df.history_figure.xml
+++ b/df.history_figure.xml
@@ -103,7 +103,7 @@
         <flag-bit name='gelded'/>
     </bitfield-type>
 
-    <struct-type type-name="body_profilest"> bay12: body_profilest
+    <struct-type type-name="body_profilest">
         <stl-vector name="events" type-name='int32_t' ref-target='history_event'/>
         <stl-bit-vector name="status" comment='missing body parts'>
             <code-helper name='index-refers-to'>

--- a/df.rhythm.xml
+++ b/df.rhythm.xml
@@ -35,14 +35,16 @@
         <bitfield name='flags' base-type='uint32_t' type-name='rhythm_construction_flag'/>
     </struct-type>
 
-    <struct-type type-name='rhythm' instance-vector='$global.world.rhythms.all' key-field='id'>
+    <bitfield-type type-name='rhythm_flag' base-type='uint32_t'> bay12: RHYTHM_FLAG_*
+        <flag-bit name='fundamental_polyrhythm'/>
+        <flag-bit name='fundamental_polymeter'/>
+    </bitfield-type>
+
+    <struct-type type-name='rhythm' original-name='rhythmst' instance-vector='$global.world.rhythms.all' key-field='id'>
         <int32_t name='id'/>
         <stl-vector name='patterns' pointer-type='rhythm_pattern'/>
         <stl-vector name='sub_rhythms' pointer-type='sub_rhythm'/>
-        <bitfield name='flags' base-type='uint32_t'> bay12: RHYTHM_FLAG_*
-            <flag-bit name='fundamental_polyrhythm'/>
-            <flag-bit name='fundamental_polymeter'/>
-        </bitfield>
+        <bitfield name='flags' base-type='uint32_t' type-name='rhythm_flag'/>
     </struct-type>
 
     <struct-type type-name='rhythm_handlerst'>

--- a/df.scale.xml
+++ b/df.scale.xml
@@ -51,7 +51,7 @@
         <flag-bit name='tonic_note_fixed_at_performance' comment='moveable_tonic'/>
     </bitfield-type>
 
-    <struct-type type-name='scale' instance-vector='$global.world.scales.all' key-field='id'>
+    <struct-type type-name='scale' original-name='scalest' instance-vector='$global.world.scales.all' key-field='id'>
         <int32_t name='id'/>
         <bitfield name='flags' base-type='uint32_t' type-name='scale_flag'/>
         <enum name='type' type-name='scale_type' base-type='int32_t'/>

--- a/df.unit.xml
+++ b/df.unit.xml
@@ -2412,7 +2412,7 @@
         <stl-vector name='own_interaction_delay' type-name='int32_t' since='v0.34.01'/>
     </struct-type>
 
-    <struct-type type-name='unit_appearance' comment='physical_formst'>
+    <struct-type type-name='unit_appearance' original-name='physical_formst'>
         <int32_t name='local_id'/>
         <int32_t name='caste_index' refers-to='$global.world.raws.creatures.list_creature[$]' comment='also refers to $global.world.raws.creatures.list_caste[$]'/>
         <int16_t name='favoredgrasp_bp'/>


### PR DESCRIPTION
This has no effect on DFHack - it just ensures that our Ghidra analysis scripts assign the correct class/type names