### PR TITLE
Update structures for 52.05

### DIFF
--- a/df.block.xml
+++ b/df.block.xml
@@ -248,6 +248,8 @@
         <compound name='map_pos' type-name='coord'/>
         <compound name='region_pos' type-name='coord2d'/>
 
+        <size_t name='pool_id'/>
+
         <static-array name='tiletype' count='16'>
             <static-array count='16'>
                 <enum base-type='uint16_t' type-name='tiletype' init-value='OpenSpace'/>


### PR DESCRIPTION
The only structural change was putting `blockst` into an object pool, which gives it a new `size_t pool_id;` field.