### PR TITLE
codegen: generate type_identities as `const`

### DIFF
--- a/Bitfield.pm
+++ b/Bitfield.pm
@@ -91,8 +91,8 @@ sub render_bitfield_core {
             emit "static const bitfield_item_info bits[bit_count];";
         } "template<> struct ${export_prefix}bitfield_$traits_name ", ";";
         emit_block {
-            emit "static bitfield_identity identity;";
-            emit "static bitfield_identity *get() { return &identity; }";
+            emit "static const bitfield_identity identity;";
+            emit "static const bitfield_identity *get() { return &identity; }";
         } "template<> struct ${export_prefix}identity_$traits_name ", ";";
         header_ref("Export.h");
         header_ref("DataDefs.h");
@@ -112,7 +112,7 @@ sub render_bitfield_core {
             $lines[-1] =~ s/,$//;
         } "const bitfield_item_info bitfield_${traits_name}::bits[bit_count] = ", ";";
 
-        emit "bitfield_identity identity_${traits_name}::identity(",
+        emit "const bitfield_identity identity_${traits_name}::identity(",
              "sizeof($full_name), ",
              type_identity_reference($tag,-parent => 1), ', ',
              "\"$name\", bitfield_${traits_name}::bit_count, bitfield_${traits_name}::bits);";

--- a/Enum.pm
+++ b/Enum.pm
@@ -90,8 +90,8 @@ sub render_enum_tables($$$$$$) {
 
     with_emit_traits {
         emit_block {
-            emit "static enum_identity identity;";
-            emit "static enum_identity *get() { return &identity; }";
+            emit "const static enum_identity identity;";
+            emit "const static enum_identity *get() { return &identity; }";
         } "template<> struct ${export_prefix}identity_$traits_name ", ";";
         header_ref("Export.h");
         header_ref("DataDefs.h");
@@ -175,7 +175,7 @@ sub render_enum_tables($$$$$$) {
                     for (my $i = 0; $i < @anames; $i++) {
                         emit "$atypes[$i] $anames[$i];";
                     }
-                    emit "static struct_identity _identity;";
+                    emit "const static struct_identity _identity;";
                 } "struct attr_entry_type ", ";";
                 emit "static const attr_entry_type attr_table[", $count, "+1];";
                 emit "static const attr_entry_type &attrs(enum_type value);";
@@ -296,7 +296,7 @@ sub render_enum_tables($$$$$$) {
                     @field_defs = @field_meta;
                 } $entry_type;
 
-                emit "struct_identity ${entry_type}::_identity(",
+                emit "const struct_identity ${entry_type}::_identity(",
                         "sizeof($entry_type), NULL, ",
                         type_identity_reference($tag), ', ',
                         "\"_attr_entry_type\", NULL, $ftable);";
@@ -306,7 +306,7 @@ sub render_enum_tables($$$$$$) {
             $atable_meta = "&${entry_type}::_identity";
         }
 
-        emit "enum_identity identity_${traits_name}::identity(",
+        emit "const enum_identity identity_${traits_name}::identity(",
                 "sizeof($full_name), ",
                 type_identity_reference($tag,-parent => 1), ', ',
                 "\"$name\", TID($base_type), $base, ",

--- a/StructFields.pm
+++ b/StructFields.pm
@@ -671,14 +671,14 @@ sub emit_struct_fields($$;%) {
 
         with_emit_traits {
             emit_block {
-                emit "static $identity_type identity;";
-                emit "static $identity_type *get() { return &identity; }";
+                emit "static const $identity_type identity;";
+                emit "static const $identity_type *get() { return &identity; }";
             } "template<> struct ${export_prefix}$traits_name ", ";";
         };
 
         with_emit_static {
             my $ftable = render_field_metadata $tag, $full_name, @fields, %info;
-            emit "$identity_type ${traits_name}::identity(",
+            emit "const $identity_type ${traits_name}::identity(",
                     "sizeof($full_name), &allocator_fn<${full_name}>, ",
                     type_identity_reference($tag,-parent => 1), ', ',
                     "\"$name\", NULL, $ftable);";
@@ -707,13 +707,13 @@ sub emit_struct_fields($$;%) {
     my $inherits = $flags{-inherits};
     my $original_name = $tag->getAttribute('original-name');
 
-    emit "static $identity_type _identity;";
+    emit "static const $identity_type _identity;";
 
     with_emit_static {
         local @simple_inits;
         my @ctor_lines = with_emit {
             if ($flags{-class}) {
-                $ctor_args = "virtual_identity *_id";
+                $ctor_args = "const virtual_identity *_id";
                 $ctor_arg_init = " = &".$name."::_identity";
                 push @simple_inits, "$flags{-inherits}(_id)" if $flags{-inherits};
                 emit "_identity.adjust_vtable(this, _id);";
@@ -747,14 +747,14 @@ sub emit_struct_fields($$;%) {
         my $ftable = render_field_metadata $tag, $full_name, @fields, %info;
 
         if ($flags{-class}) {
-            emit "virtual_identity ${full_name}::_identity(",
+            emit "const virtual_identity ${full_name}::_identity(",
                     "sizeof($full_name), &${alloc_fn}<${full_name}>, ",
                     "\"$name\", ",
                     ($original_name ? "\"$original_name\"" : 'NULL'), ', ',
                     ($inherits ? "&${inherits}::_identity" : 'NULL'), ', ',
                     "$ftable);";
         } else {
-            emit "$identity_type ${full_name}::_identity(",
+            emit "const $identity_type ${full_name}::_identity(",
                     "sizeof($full_name), &allocator_fn<${full_name}>, ",
                     type_identity_reference($tag,-parent => 1), ', ',
                     "\"$name\", ",


### PR DESCRIPTION
cause the `type_identity` objects created by codegen to be `const`

ref dfhack/dfhack#5597