### PR TITLE
Fix lengths of enum-linked arrays

### DIFF
--- a/df.abstract_building.xml
+++ b/df.abstract_building.xml
@@ -115,7 +115,7 @@
     </struct-type>
 
     <struct-type type-name='ab_reputation_infost'>
-        <static-array name='reputation' type-name='int32_t' count='8' index-enum='abstract_building_reputation_type'/>
+        <static-array name='reputation' type-name='int32_t' index-enum='abstract_building_reputation_type'/>
     </struct-type>
 
     <class-type type-name='abstract_building' original-name='abstract_buildingst' key-field='id'>

--- a/df.adventure.xml
+++ b/df.adventure.xml
@@ -752,7 +752,7 @@
 
     <struct-type type-name='adventure_rumor_infost'>
         <stl-vector name='base_data' pointer-type='adventure_rumor_datast' since='v0.44.10'/>
-        <static-array name='data' count='34' index-enum='entity_event_type'>
+        <static-array name='data' index-enum='entity_event_type'>
             <stl-vector pointer-type='adventure_rumor_datast'/>
         </static-array>
     </struct-type>

--- a/df.announcement.xml
+++ b/df.announcement.xml
@@ -136,9 +136,9 @@
 
     <struct-type type-name='combat_event_listst'>
         <static-array name='slotdata' count='100' type-name='combat_eventst'/>
-        <static-array name='slot_id_used' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
-        <static-array name='slot_id_idx1' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
-        <static-array name='slot_id_idx2' type-name='int16_t' count='38' index-enum='combat_report_event_type'/>
+        <static-array name='slot_id_used' type-name='int16_t' index-enum='combat_report_event_type'/>
+        <static-array name='slot_id_idx1' type-name='int16_t' index-enum='combat_report_event_type'/>
+        <static-array name='slot_id_idx2' type-name='int16_t' index-enum='combat_report_event_type'/>
         <int16_t name='slots_used'/>
     </struct-type>
 

--- a/df.belief_system.xml
+++ b/df.belief_system.xml
@@ -21,7 +21,7 @@
         <stl-vector name='story' pointer-type='storyst'/>
         <stl-vector name='deities' type-name='int32_t' ref-target="historical_figure" comment="historical figure ID of gods the belief system is concerned with"/>
         <stl-vector name='worship_levels' type-name='int32_t' comment="worship level for each god referenced in the deities field"/>
-        <static-array name='value' type-name='int32_t' count='64' index-enum='value_type'/>
+        <static-array name='value' type-name='int32_t' count='64' index-enum='value_type'/> SAVE_VALUENUM
     </struct-type>
 
     <struct-type type-name='belief_system_handlerst'>

--- a/df.building.xml
+++ b/df.building.xml
@@ -300,7 +300,7 @@
         <compound name='links' type-name='stockpile_links'/>
         <int32_t name='max_general_orders'/>
         <bitfield name='flags' base-type='uint32_t' type-name='workshop_profile_flag'/>
-        <static-array name='blocked_labors' type-name='bool' count='94' index-enum='unit_labor'/>
+        <static-array name='blocked_labors' type-name='bool' index-enum='unit_labor'/>
     </struct-type>
 
     <class-type type-name='building' original-name='buildingst'
@@ -1516,7 +1516,7 @@
     </bitfield-type>
 
     <class-type type-name='building_farmplotst' inherits-from='building_actual'>
-        <static-array name='plant_id' count='4'>
+        <static-array name='plant_id' index-enum='season'>
             <int16_t ref-target='plant_raw'/>
         </static-array>
         <int32_t name='material_amount'/>
@@ -1776,7 +1776,7 @@
             <!-- <item-attr name='civzone' value='ActivityZone'/> -->
         </enum-item>
 
-        -- 98 different civzone subtypes
+        -- 98 different civzone subtypes: array of length BUILDING_CIVZONENUM
         <enum-item name='ZONE_HOME'>
             <item-attr name='building' value='Civzone'/>
             <item-attr name='civzone' value='Home'/>

--- a/df.civagreement.xml
+++ b/df.civagreement.xml
@@ -23,7 +23,7 @@
     </enum-type>
 
     <struct-type type-name='entity_sell_requests' original-name='civgoods_demandst'>
-        <static-array count='107' index-enum='entity_sell_category' name='priority'>
+        <static-array index-enum='entity_sell_category' name='priority'>
             <stl-vector type-name='int8_t'/>
         </static-array>
     </struct-type>
@@ -50,7 +50,7 @@
 
     <struct-type type-name='entity_sell_prices' original-name='civ_tradeagreementst'>
         <pointer type-name='entity_sell_requests' name='items'/>
-        <static-array count='107' index-enum='entity_sell_category' name='price'>
+        <static-array index-enum='entity_sell_category' name='price'>
             <stl-vector type-name='int32_t'/>
         </static-array>
     </struct-type>

--- a/df.creature.xml
+++ b/df.creature.xml
@@ -426,6 +426,7 @@
     </struct-type>
 
     <enum-type type-name='gait_type' base-type='int32_t'> bay12: GaitType
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='WALK'/>
         <enum-item name='FLY'/>
         <enum-item name='SWIM'/>
@@ -489,7 +490,7 @@
 
         <bitfield name='flags' base-type='int32_t' type-name='body_flag' since='v0.34.01'/>
 
-        <static-array name='gait_info' count="5" index-enum='gait_type'>
+        <static-array name='gait_info' index-enum='gait_type'>
             <stl-vector pointer-type='gait_info'/>
         </static-array>
 
@@ -501,17 +502,17 @@
         <int32_t name='fraction_fat'/>
         <int32_t name='fraction_muscle'/>
 
-        <static-array name='default_gait_index' count="5" index-enum='gait_type' type-name='int32_t'/>
-        <static-array name='fastest_gait_index' count="5" index-enum='gait_type' type-name='int32_t'/>
-        <static-array name='slowest_gait_index' count="5" index-enum='gait_type' type-name='int32_t'/>
+        <static-array name='default_gait_index' index-enum='gait_type' type-name='int32_t'/>
+        <static-array name='fastest_gait_index' index-enum='gait_type' type-name='int32_t'/>
+        <static-array name='slowest_gait_index' index-enum='gait_type' type-name='int32_t'/>
 
         <pointer name='clothing_items' type-name='clothing_needsst'/>
     </struct-type>
 
     <struct-type type-name='creature_personality_profilest'>
-        <static-array type-name='int16_t' name='min' count='50' index-enum='personality_facet_type'/>
-        <static-array type-name='int16_t' name='med' count='50' index-enum='personality_facet_type'/>
-        <static-array type-name='int16_t' name='max' count='50' index-enum='personality_facet_type'/>
+        <static-array type-name='int16_t' name='min' index-enum='personality_facet_type'/>
+        <static-array type-name='int16_t' name='med' index-enum='personality_facet_type'/>
+        <static-array type-name='int16_t' name='max' index-enum='personality_facet_type'/>
     </struct-type>
 
     <enum-type type-name='secretion_condition'> bay12: SecretionCondition, no base type
@@ -536,13 +537,13 @@
         <stl-string name='token'/>
 
         <static-array name='texpos' count='2'>
-            <static-array count='7' index-enum='creature_graphics_role'>
+            <static-array index-enum='creature_graphics_role'>
                 <static-array count='3'><static-array count='2' type-name='int32_t'/></static-array>
             </static-array>
         </static-array>
-        <static-array name='texpos_add_color' count='7' index-enum='creature_graphics_role' type-name='int8_t'/>
+        <static-array name='texpos_add_color' index-enum='creature_graphics_role' type-name='int8_t'/>
         <static-array name='sheet_icon_texpos' count='2'>
-            <static-array count='7' index-enum='creature_graphics_role' type-name='int32_t'/>
+            <static-array index-enum='creature_graphics_role' type-name='int32_t'/>
         </static-array>
     </struct-type>
 
@@ -706,34 +707,34 @@
     </enum-type>
 
     <struct-type type-name='creature_raw_graphics' original-name='creature_graphicsst'>
-        <static-array name='creature_texture_texpos' count='2'><static-array count='7' index-enum='creature_graphics_role'><static-array count='3'><static-array type-name='int32_t' count='2'/></static-array></static-array></static-array>
-        <static-array name='creature_texture_add_color' type-name='bool' count='7' index-enum='creature_graphics_role'/>
-        <static-array name='creature_texture_sheet_icon_texpos' count='2'><static-array type-name='int32_t' count='7' index-enum='creature_graphics_role'/></static-array>
+        <static-array name='creature_texture_texpos' count='2'><static-array index-enum='creature_graphics_role'><static-array count='3'><static-array type-name='int32_t' count='2'/></static-array></static-array></static-array>
+        <static-array name='creature_texture_add_color' type-name='bool' index-enum='creature_graphics_role'/>
+        <static-array name='creature_texture_sheet_icon_texpos' count='2'><static-array type-name='int32_t' index-enum='creature_graphics_role'/></static-array>
 
-        <static-array name='entity_link_texpos' count='2'><static-array count='18' index-enum='histfig_entity_link_type'><static-array count='7' index-enum='creature_graphics_role'><static-array count='3'><static-array count='2' type-name='int32_t'/></static-array></static-array></static-array></static-array>
-        <static-array name='entity_link_add_color' count='18' index-enum='histfig_entity_link_type'><static-array type-name='bool' count='7' index-enum='creature_graphics_role'/></static-array>
-        <static-array name='entity_link_sheet_icon_texpos' count='2'><static-array count='18' index-enum='histfig_entity_link_type'><static-array type-name='int32_t' count='7' index-enum='creature_graphics_role'/></static-array></static-array>
+        <static-array name='entity_link_texpos' count='2'><static-array index-enum='creature_graphics_role'><static-array index-enum='histfig_entity_link_type'><static-array count='3'><static-array count='2' type-name='int32_t'/></static-array></static-array></static-array></static-array>
+        <static-array name='entity_link_add_color' index-enum='creature_graphics_role'><static-array type-name='bool' index-enum='histfig_entity_link_type'/></static-array>
+        <static-array name='entity_link_sheet_icon_texpos' count='2'><static-array index-enum='creature_graphics_role'><static-array type-name='int32_t' index-enum='histfig_entity_link_type'/></static-array></static-array>
 
-        <static-array name='site_link_texpos' count='2'><static-array count='10' index-enum='histfig_site_link_type'><static-array count='7' index-enum='creature_graphics_role'><static-array count='3'><static-array count='2' type-name='int32_t'/></static-array></static-array></static-array></static-array>
-        <static-array name='site_link_add_color' count='10' index-enum='histfig_site_link_type'><static-array type-name='bool' count='7' index-enum='creature_graphics_role'/></static-array>
-        <static-array name='site_link_sheet_icon_texpos' count='2'><static-array count='10' index-enum='histfig_site_link_type'><static-array type-name='int32_t' count='7' index-enum='creature_graphics_role'/></static-array></static-array>
+        <static-array name='site_link_texpos' count='2'><static-array index-enum='creature_graphics_role'><static-array index-enum='histfig_site_link_type'><static-array count='3'><static-array count='2' type-name='int32_t'/></static-array></static-array></static-array></static-array>
+        <static-array name='site_link_add_color' index-enum='creature_graphics_role'><static-array type-name='bool' index-enum='histfig_site_link_type'/></static-array>
+        <static-array name='site_link_sheet_icon_texpos' count='2'><static-array index-enum='creature_graphics_role'><static-array type-name='int32_t' index-enum='histfig_site_link_type'/></static-array></static-array>
 
-        <static-array name='profession_texpos' count='2'><static-array count='135' index-enum='profession'><static-array count='7' index-enum='creature_graphics_role'><static-array count='3'><static-array count='2' type-name='int32_t'/></static-array></static-array></static-array></static-array>
-        <static-array name='profession_add_color' count='135' index-enum='profession'><static-array type-name='bool' count='7' index-enum='creature_graphics_role'/></static-array>
-        <static-array name='profession_sheet_icon_texpos' count='2'><static-array count='135' index-enum='profession'><static-array type-name='int32_t' count='7' index-enum='creature_graphics_role'/></static-array></static-array>
+        <static-array name='profession_texpos' count='2'><static-array index-enum='creature_graphics_role'><static-array index-enum='profession'><static-array count='3'><static-array count='2' type-name='int32_t'/></static-array></static-array></static-array></static-array>
+        <static-array name='profession_add_color' index-enum='creature_graphics_role'><static-array type-name='bool' index-enum='profession'/></static-array>
+        <static-array name='profession_sheet_icon_texpos' count='2'><static-array index-enum='creature_graphics_role'><static-array type-name='int32_t' index-enum='profession'/></static-array></static-array>
 
         <stl-vector name='position_graphics' pointer-type='creature_position_graphicst'/>
         <stl-vector name='graphics_layer_set' pointer-type='creature_graphics_layer_setst'/>
 
-        <static-array name='creature_small_texpos' type-name='int32_t' count='12' index-enum='creature_small_texture_type'/>
+        <static-array name='creature_small_texpos' type-name='int32_t' index-enum='creature_small_texture_type'/>
 
         <int32_t name='egg_texpos'/>
         <int32_t name='list_icon_texpos'/>
         <int32_t name='skeleton_with_skull_texpos'/>
         <int32_t name='skeleton_texpos'/>
 
-        <static-array name='layer_unitless_texpos' count='135' index-enum='profession'><static-array count='3'><static-array count='2'><stl-vector type-name='int32_t'/></static-array></static-array></static-array>
-        <static-array name='layer_unitless_sheet_icon_texpos' count='135' index-enum='profession'><stl-vector type-name='int32_t'/></static-array>
+        <static-array name='layer_unitless_texpos' index-enum='profession'><static-array count='3'><static-array count='2'><stl-vector type-name='int32_t'/></static-array></static-array></static-array>
+        <static-array name='layer_unitless_sheet_icon_texpos' index-enum='profession'><stl-vector type-name='int32_t'/></static-array>
 
         <int32_t name='texpos_glow'/>
         <int32_t name='texpos_glow_left_gone'/>
@@ -1046,24 +1047,24 @@
         <stl-vector name='caste_speech_token' pointer-type='stl-string'/>
 
         <static-array name='skill_rates' count='4'> learn_ip_perc, last_used, rust, demote
-            <static-array type-name='int32_t' count='149' index-enum='job_skill'/>
+            <static-array type-name='int32_t' index-enum='job_skill'/>
         </static-array>
 
         <compound name='attributes'> not a compound
-            <static-array name='phys_att_range' count='6' index-enum='physical_attribute_type'>
+            <static-array name='phys_att_range' index-enum='physical_attribute_type'>
                 <static-array type-name='int32_t' count='7'/>
             </static-array>
-            <static-array name='ment_att_range' count='13' index-enum='mental_attribute_type'>
+            <static-array name='ment_att_range' index-enum='mental_attribute_type'>
                 <static-array type-name='int32_t' count='7'/>
             </static-array>
-            <static-array name='phys_att_rates' count='6' index-enum='physical_attribute_type'>
+            <static-array name='phys_att_rates' index-enum='physical_attribute_type'>
                 <static-array type-name='int32_t' count='4'/>
             </static-array>
-            <static-array name='ment_att_rates' count='13' index-enum='mental_attribute_type'>
+            <static-array name='ment_att_rates' index-enum='mental_attribute_type'>
                 <static-array type-name='int32_t' count='4'/>
             </static-array>
-            <static-array type-name='int32_t' name='phys_att_cap_perc' count='6' index-enum='physical_attribute_type'/>
-            <static-array type-name='int32_t' name='ment_att_cap_perc' count='13' index-enum='mental_attribute_type'/>
+            <static-array type-name='int32_t' name='phys_att_cap_perc' index-enum='physical_attribute_type'/>
+            <static-array type-name='int32_t' name='ment_att_cap_perc' index-enum='mental_attribute_type'/>
         </compound>
 
         <enum name='sex' type-name='pronoun_type'/>
@@ -1103,10 +1104,10 @@
         <stl-vector name='tissue_styles' pointer-type='tissue_style_raw'/>
         <stl-vector name='shearable_tissue_layer' pointer-type='shearable_tissue_layerst'/>
 
-        <static-array name='body_app_mode_rate_index' count='4'>
-            <stl-vector/>
+        <static-array name='body_app_mode_rate_index' index-enum='appearance_modifier_growth_interval'>
+            <stl-vector type-name='int32_t'/>
         </static-array>
-        <static-array name='bp_app_mode_rate_index' count='4'>
+        <static-array name='bp_app_mode_rate_index' index-enum='appearance_modifier_growth_interval'>
             <stl-vector type-name='int32_t'/>
         </static-array>
 
@@ -1255,9 +1256,9 @@
         </compound>
 
         <stl-vector name='sound' pointer-type='creature_soundst'/>
-        <stl-vector type-name='int32_t' name='sound_alert'/> bay12: vector[CreatureSoundType]
-        <stl-vector type-name='int32_t' name='sound_peaceful_intermittent'
-                    refers-to='$$._global.sound[$]'/>
+        <static-array name='sound_index' index-enum='creature_sound_type'>
+            <stl-vector type-name='int32_t' refers-to='$$._global.sound[$]'/>
+        </static-array>
 
         <stl-vector name='material_force_adjust' since='v0.34.01' pointer-type='material_force_adjustst'/>
 

--- a/df.cultural_identity.xml
+++ b/df.cultural_identity.xml
@@ -39,8 +39,8 @@
         <int32_t name="site_id" ref-target='world_site'/>
         <int32_t name="civ_id" ref-target='historical_entity'/>
         <stl-vector name='group_log' pointer-type='cultural_identity_entityst' comment='the circumstances of groups joining or leaving this culture'/>
-        <static-array name='ethic' count='22' type-name='ethic_response' index-enum='ethic_type'/>
-        <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/>
+        <static-array name='ethic' type-name='ethic_response' index-enum='ethic_type'/>
+        <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/> SAVE_VALUENUM
         <stl-vector name='events' pointer-type='entity_event'/>
         <int32_t name='world_general_knowledge_year' init-value='-1'/>
         <stl-vector name="known_heid" type-name='int32_t' ref-target='history_event'/>

--- a/df.d_basics.xml
+++ b/df.d_basics.xml
@@ -4458,6 +4458,49 @@
         <enum-item name='Clay'/>
         <enum-item name='Parchment'/>
         <enum-item name='CupsMugsGoblets'/>
+        <enum-item name='UNUSED18'/>
+        <enum-item name='UNUSED19'/>
+        <enum-item name='UNUSED20'/>
+        <enum-item name='UNUSED21'/>
+        <enum-item name='UNUSED22'/>
+        <enum-item name='UNUSED23'/>
+        <enum-item name='UNUSED24'/>
+        <enum-item name='UNUSED25'/>
+        <enum-item name='UNUSED26'/>
+        <enum-item name='UNUSED27'/>
+        <enum-item name='UNUSED28'/>
+        <enum-item name='UNUSED29'/>
+        <enum-item name='UNUSED30'/>
+        <enum-item name='UNUSED31'/>
+        <enum-item name='UNUSED32'/>
+        <enum-item name='UNUSED33'/>
+        <enum-item name='UNUSED34'/>
+        <enum-item name='UNUSED35'/>
+        <enum-item name='UNUSED36'/>
+        <enum-item name='UNUSED37'/>
+        <enum-item name='UNUSED38'/>
+        <enum-item name='UNUSED39'/>
+        <enum-item name='UNUSED40'/>
+        <enum-item name='UNUSED41'/>
+        <enum-item name='UNUSED42'/>
+        <enum-item name='UNUSED43'/>
+        <enum-item name='UNUSED44'/>
+        <enum-item name='UNUSED45'/>
+        <enum-item name='UNUSED46'/>
+        <enum-item name='UNUSED47'/>
+        <enum-item name='UNUSED48'/>
+        <enum-item name='UNUSED49'/>
+        <enum-item name='UNUSED50'/>
+        <enum-item name='UNUSED51'/>
+        <enum-item name='UNUSED52'/>
+        <enum-item name='UNUSED53'/>
+        <enum-item name='UNUSED54'/>
+        <enum-item name='UNUSED55'/>
+        <enum-item name='UNUSED56'/>
+        <enum-item name='UNUSED57'/>
+        <enum-item name='UNUSED58'/>
+        <enum-item name='UNUSED59'/>
+        <enum-item name='UNUSED60'/>
     </enum-type>
 
     -- Unused: ConversationTask
@@ -4636,15 +4679,15 @@
         <enum-item name='DAILY_WINDS'/>
         <enum-item name='SNOWFALL'/>
         <enum-item name='SALINITY'/>
-        <enum-item/>
-        <enum-item/>
-        <enum-item/>
-        <enum-item/>
-        <enum-item/>
-        <enum-item/>
-        <enum-item/>
-        <enum-item/>
-        <enum-item/>
+        <enum-item name='UNUSED16'/>
+        <enum-item name='UNUSED17'/>
+        <enum-item name='UNUSED18'/>
+        <enum-item name='UNUSED19'/>
+        <enum-item name='UNUSED20'/>
+        <enum-item name='UNUSED21'/>
+        <enum-item name='UNUSED22'/>
+        <enum-item name='UNUSED23'/>
+        <enum-item name='UNUSED24'/>
     </enum-type>
 
     <enum-type type-name='biome_type'> bay12: Biome, no base type
@@ -4857,7 +4900,72 @@
         </enum-item>
     </enum-type>
 
-    -- Unused: TextSetType
+    <enum-type type-name='text_set_type' base-type='int32_t'> bay12: TextSetType
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='BOOK_INSTRUCTION'/>
+        <enum-item name='BOOK_ART'/>
+        <enum-item name='SECRET_DEATH'/>
+        <enum-item name='SPEECH_GENERAL'/>
+        <enum-item name='SPEECH_SLAYER'/>
+        <enum-item name='SPEECH_THREAT'/>
+        <enum-item name='SPEECH_GREET'/>
+        <enum-item name='SPEECH_GREET_REPLY'/>
+        <enum-item name='SPEECH_GREET_REPLY_DIFF_LANGUAGE'/>
+        <enum-item name='SPEECH_GREET_REPLY_UNUSUAL_FIRST'/>
+        <enum-item name='SPEECH_GREET_WORSHIP'/>
+        <enum-item name='SPEECH_GREET_BABY'/>
+        <enum-item name='SPEECH_GOODBYE_WORSHIP_1'/>
+        <enum-item name='SPEECH_GOODBYE_WORSHIP_2'/>
+        <enum-item name='SPEECH_GOODBYE_WORSHIP_3'/>
+        <enum-item name='SPEECH_TEMPLE_ALREADY_MEMBER'/>
+        <enum-item name='SPEECH_TEMPLE_BECOME_MEMBER'/>
+        <enum-item name='SPEECH_POSITIVE'/>
+        <enum-item name='SPEECH_TASK_RECOMMENDATION'/>
+        <enum-item name='SPEECH_UNKNOWN_HF_SEEKER'/>
+        <enum-item name='SPEECH_AB_SPECIFIC_HF_SEEKER'/>
+        <enum-item name='SPEECH_SITE_SPECIFIC_HF_SEEKER'/>
+        <enum-item name='SPEECH_SAME_SITE_AB_SPECIFIC_HF_SEEKER'/>
+        <enum-item name='SPEECH_SAME_SITE_SPECIFIC_HF_SEEKER'/>
+        <enum-item name='SPEECH_ARCH_INFO_JUSTIFICATION'/>
+        <enum-item name='SPEECH_JUSTIFICATION_REPRESENTATION'/>
+        <enum-item name='SPEECH_JUSTIFICATION_PROXIMITY'/>
+        <enum-item name='SPEECH_JUSTIFICATION_EXPERIENCE'/>
+        <enum-item name='SPEECH_JUSTIFICATION_REMINDER'/>
+        <enum-item name='SPEECH_JUSTIFICATION_ANTITHETICAL'/>
+        <enum-item name='SPEECH_NO_FAMILY'/>
+        <enum-item name='SPEECH_FAMILY_RELATIONSHIP_SPEC'/>
+        <enum-item name='SPEECH_FAMILY_RELATIONSHIP_NO_SPEC'/>
+        <enum-item name='SPEECH_FAMILY_RELATIONSHIP_ADDITIONAL'/>
+        <enum-item name='SPEECH_FAMILY_RELATIONSHIP_SPEC_DEAD'/>
+        <enum-item name='SPEECH_FAMILY_RELATIONSHIP_NO_SPEC_DEAD'/>
+        <enum-item name='SPEECH_FAMILY_RELATIONSHIP_ADDITIONAL_DEAD'/>
+        <enum-item name='SPEECH_CHILD_AGE_PROCLAMATION'/>
+        <enum-item name='SPEECH_WANDERING_PROFESSION'/>
+        <enum-item name='SPEECH_HUNTING_PROFESSION'/>
+        <enum-item name='SPEECH_THIEF_PROFESSION'/>
+        <enum-item name='SPEECH_SNATCHER_PROFESSION'/>
+        <enum-item name='SPEECH_GUARD_PROFESSION'/>
+        <enum-item name='SPEECH_GUARD_WARNING'/>
+        <enum-item name='SPEECH_SOLDIER_PROFESSION'/>
+        <enum-item name='SPEECH_PAST_PROFESSION_NO_YEAR'/>
+        <enum-item name='SPEECH_PAST_PROFESSION_YEAR'/>
+        <enum-item name='SPEECH_CURRENT_PROFESSION_NO_YEAR'/>
+        <enum-item name='SPEECH_CURRENT_PROFESSION_YEAR'/>
+        <enum-item name='SPEECH_HIST_FIG_SLAYER'/>
+        <enum-item name='SPEECH_ANIMAL_SLAYER'/>
+        <enum-item name='SPEECH_WANDERING_PROFESSION_YEAR'/>
+        <enum-item name='SPEECH_HUNTING_PROFESSION_YEAR'/>
+        <enum-item name='SPEECH_SNATCHER_PROFESSION_YEAR'/>
+        <enum-item name='SPEECH_THIEF_PROFESSION_YEAR'/>
+        <enum-item name='SPEECH_PAST_WANDERING_PROFESSION'/>
+        <enum-item name='SPEECH_PAST_HUNTING_PROFESSION'/>
+        <enum-item name='SPEECH_PAST_SNATCHER_PROFESSION'/>
+        <enum-item name='SPEECH_PAST_THIEF_PROFESSION'/>
+        <enum-item name='SPEECH_GREET_REPLY_AFTER_HERO'/>
+        <enum-item name='SPEECH_MERCENARY_PROFESSION'/>
+        <enum-item name='SPEECH_MERCENARY_PROFESSION_YEAR'/>
+        <enum-item name='SPEECH_PAST_MERCENARY_PROFESSION'/>
+    </enum-type>
 
     <enum-type type-name='schedule_type'> bay12: Schedule, no base type
         <enum-item name='Eat'/>

--- a/df.d_init.xml
+++ b/df.d_init.xml
@@ -33,7 +33,7 @@
     <struct-type type-name='d_init_displayst'>
         <df-flagarray name='flags' index-enum='d_init_flags1'/>
 
-        <static-array name='nickname' count='11' index-enum='game_type'><enum type-name='d_init_nickname'/></static-array>
+        <static-array name='nickname' count='11' index-enum='game_type'><enum type-name='d_init_nickname'/></static-array> must specify count 10 because game_type.NONE is not -1
 
         <uint8_t name='sky_tile'/>
         <static-array name='sky_color' type-name='int16_t' count='3'/>
@@ -46,7 +46,7 @@
         <static-array name='track_ramp_tiles' type-name='uint8_t' count='15' since='v0.34.08'/>
         <static-array name='track_ramp_invert' type-name='uint8_t' count='15' since='v0.34.08'/>
 
-        <static-array name='tree_tiles' type-name='uint8_t' count='104' since='v0.40.01'/>
+        <static-array name='tree_tiles' type-name='uint8_t' count='104' since='v0.40.01'/> TREE_PART_TILENUM
 
         <static-array name='chasm_color' type-name='int16_t' count='3'/>
 
@@ -176,8 +176,7 @@
     </bitfield-type>
 
     <struct-type type-name='announcements' original-name='d_init_announcementst'>
-        <static-array name='flags' type-name='announcement_flags'
-                      count='356' index-enum='announcement_type'/>
+        <static-array name='flags' type-name='announcement_flags' index-enum='announcement_type'/>
     </struct-type>
 
     <struct-type type-name='d_init' original-name='d_initst'>

--- a/df.d_interface.xml
+++ b/df.d_interface.xml
@@ -1670,27 +1670,27 @@
         <int32_t name='trait_num'/>
 
         <ulong name='last_tick_update'/>
-        <static-array type-name='int32_t' count='4' name='reqroom' comment='demands'/>
-        <static-array type-name='int32_t' count='4' name='curroom' comment='demands'/>
-        <static-array type-name='int32_t' count='149' index-enum='job_skill' name='labor_skill_ind'/>
-        <static-array type-name='int32_t' count='149' index-enum='job_skill' name='labor_skill_val'/>
-        <static-array type-name='int32_t' count='149' index-enum='job_skill' name='labor_skill_w_rust'/>
+        <static-array type-name='int32_t' index-enum='demand_room' name='reqroom' comment='demands'/>
+        <static-array type-name='int32_t' index-enum='demand_room' name='curroom' comment='demands'/>
+        <static-array type-name='int32_t' index-enum='job_skill' name='labor_skill_ind'/>
+        <static-array type-name='int32_t' index-enum='job_skill' name='labor_skill_val'/>
+        <static-array type-name='int32_t' index-enum='job_skill' name='labor_skill_w_rust'/>
         <int32_t name='labor_skill_num'/>
-        <static-array type-name='int32_t' count='149' index-enum='job_skill' name='combat_skill_ind'/>
-        <static-array type-name='int32_t' count='149' index-enum='job_skill' name='combat_skill_val'/>
-        <static-array type-name='int32_t' count='149' index-enum='job_skill' name='combat_skill_w_rust'/>
+        <static-array type-name='int32_t' index-enum='job_skill' name='combat_skill_ind'/>
+        <static-array type-name='int32_t' index-enum='job_skill' name='combat_skill_val'/>
+        <static-array type-name='int32_t' index-enum='job_skill' name='combat_skill_w_rust'/>
         <int32_t name='combat_skill_num'/>
-        <static-array type-name='int32_t' count='149' index-enum='job_skill' name='other_skill_ind'/>
-        <static-array type-name='int32_t' count='149' index-enum='job_skill' name='other_skill_val'/>
-        <static-array type-name='int32_t' count='149' index-enum='job_skill' name='other_skill_w_rust'/>
+        <static-array type-name='int32_t' index-enum='job_skill' name='other_skill_ind'/>
+        <static-array type-name='int32_t' index-enum='job_skill' name='other_skill_val'/>
+        <static-array type-name='int32_t' index-enum='job_skill' name='other_skill_w_rust'/>
         <int32_t name='other_skill_num'/>
         <stl-vector pointer-type='historical_entity' name='ent_vect'/>
         <stl-vector pointer-type='entity_position' name='ep_vect'/>
         <stl-bit-vector name='ep_vect_spouse'/>
 
-        <static-array type-name='int32_t' count='30' index-enum='need_type' name='unmet_need_type'/>
-        <static-array type-name='int32_t' count='30' index-enum='need_type' name='unmet_need_spec_id'/>
-        <static-array type-name='int32_t' count='30' index-enum='need_type' name='unmet_need_se'/>
+        <static-array type-name='int32_t' index-enum='need_type' name='unmet_need_type'/>
+        <static-array type-name='int32_t' index-enum='need_type' name='unmet_need_spec_id'/>
+        <static-array type-name='int32_t' index-enum='need_type' name='unmet_need_se'/>
         <int32_t name='unmet_need_num'/>
 
         <stl-vector pointer-type='stl-string' name='raw_thought_str'/>
@@ -1959,9 +1959,9 @@
 
     <struct-type type-name='buildings_interfacest'>
         <enum name='mode' type-name='buildings_mode_type'/>
-        <static-array count='5' index-enum='buildings_mode_type' name='list'><stl-vector pointer-type='building'/></static-array>
-        <static-array count='5' index-enum='buildings_mode_type' name='scrolling_position' type-name='int32_t'/>
-        <static-array count='5' index-enum='buildings_mode_type' name='scrolling' type-name='bool'/>
+        <static-array index-enum='buildings_mode_type' name='list'><stl-vector pointer-type='building'/></static-array>
+        <static-array index-enum='buildings_mode_type' name='scrolling_position' type-name='int32_t'/>
+        <static-array index-enum='buildings_mode_type' name='scrolling' type-name='bool'/>
     </struct-type>
 
     <class-type type-name='labor_work_details_interfacest' inherits-from='widget_container'/>
@@ -2046,13 +2046,13 @@
     <class-type type-name='labor_stone_use_interfacest' inherits-from='widget'>
         <enum name='current_category' type-name='stone_use_category_type'/>
 
-        <static-array count='2' index-enum='stone_use_category_type' name='stone_mg_index'><stl-vector type-name='int32_t'/></static-array>
-        <static-array count='2' index-enum='stone_use_category_type' name='stone_restriction_p'><stl-vector pointer-type='int8_t'/></static-array>
+        <static-array index-enum='stone_use_category_type' name='stone_mg_index'><stl-vector type-name='int32_t'/></static-array>
+        <static-array index-enum='stone_use_category_type' name='stone_restriction_p'><stl-vector pointer-type='int8_t'/></static-array>
 
         <stl-vector pointer-type='stl-string' name='stone_item_use_str'/>
 
-        <static-array count='2' index-enum='stone_use_category_type' type-name='int32_t' name='scroll_position'/>
-        <static-array count='2' index-enum='stone_use_category_type' type-name='bool' name='scrolling'/>
+        <static-array index-enum='stone_use_category_type' type-name='int32_t' name='scroll_position'/>
+        <static-array index-enum='stone_use_category_type' type-name='bool' name='scrolling'/>
     </class-type>
 
     <enum-type type-name='labor_mode_type' base-type='int32_t'> bay12: LaborModeType
@@ -2221,9 +2221,9 @@
     <struct-type type-name='artifacts_interfacest'>
         <enum name='mode' type-name='artifacts_mode_type'/>
 
-        <static-array count='4' index-enum='artifacts_mode_type' name='list'><stl-vector pointer-type='artifact_record'/></static-array>
-        <static-array count='4' index-enum='artifacts_mode_type' name='scroll_position' type-name='int32_t'/>
-        <static-array count='4' index-enum='artifacts_mode_type' name='scrolling' type-name='bool'/>
+        <static-array index-enum='artifacts_mode_type' name='list'><stl-vector pointer-type='artifact_record'/></static-array>
+        <static-array index-enum='artifacts_mode_type' name='scroll_position' type-name='int32_t'/>
+        <static-array index-enum='artifacts_mode_type' name='scrolling' type-name='bool'/>
     </struct-type>
 
     <bitfield-type type-name='actor_entry_flag' base-type='uint32_t'> bay12: ACTOR_ENTRY_FLAG_*
@@ -2726,7 +2726,7 @@
         <enum-item name='ADVENTURE_MODE'/>
     </enum-type>
 
-    <enum-type type-name='keybinding_category' base-type='int32_t'> bay12: KeybindingCategory
+    <enum-type type-name='keybinding_category_type' base-type='int32_t'> bay12: KeybindingCategory
         <enum-item name='NONE' value='-1'/>
         <enum-item name='GENERAL'/>
         <enum-item name='FORTRESS_MODE'/>
@@ -2764,16 +2764,16 @@
         <int32_t name='scroll_position_permitted_fullscreen'/>
         <bool name='scrolling_permitted_fullscreen'/>
 
-        <stl-vector type-name='keybinding_category' name='keybinding_category'/>
+        <stl-vector type-name='keybinding_category_type' name='keybinding_category'/>
         <int32_t name='keybinding_selected_category'/>
         <int32_t name='keybinding_scroll_position_cat'/>
         <bool name='keybinding_scrolling_cat'/>
 
-        <static-array count='4' name='keybinding_name'><stl-vector pointer-type='stl-string'/></static-array>
-        <static-array count='4' name='keybinding_key'><stl-vector type-name='interface_key'/></static-array>
-        <static-array count='4' name='keybinding_binding'><stl-vector type-name='pointer' comment='EventMatch from g_src'/></static-array>
-        <static-array count='4' name='keybinding_binding_name'><stl-vector pointer-type='stl-string'/></static-array>
-        <static-array count='4' name='keybinding_flag'><stl-vector type-name='settings_keybinding_flag'/></static-array>
+        <static-array index-enum='keybinding_category_type' name='keybinding_name'><stl-vector pointer-type='stl-string'/></static-array>
+        <static-array index-enum='keybinding_category_type' name='keybinding_key'><stl-vector type-name='interface_key'/></static-array>
+        <static-array index-enum='keybinding_category_type' name='keybinding_binding'><stl-vector type-name='pointer' comment='EventMatch from g_src'/></static-array>
+        <static-array index-enum='keybinding_category_type' name='keybinding_binding_name'><stl-vector pointer-type='stl-string'/></static-array>
+        <static-array index-enum='keybinding_category_type' name='keybinding_flag'><stl-vector type-name='settings_keybinding_flag'/></static-array>
         <int32_t name='keybinding_scroll_position_key'/>
         <bool name='keybinding_scrolling_key'/>
         <int32_t name='keybinding_registering_index'/>
@@ -5010,7 +5010,7 @@
         <bool name='started_from_main'/>
 
         <stl-vector name='option_current' pointer-type='adventure_optionst'/>
-        <static-array name='option' count='9' index-enum='adventure_inventory_option_list_type'><stl-vector pointer-type='adventure_optionst'/></static-array>
+        <static-array name='option' index-enum='adventure_inventory_option_list_type'><stl-vector pointer-type='adventure_optionst'/></static-array>
 
         <bool name='scrolling'/>
         <int32_t name='scroll_position'/>
@@ -5502,7 +5502,7 @@
         <int32_t name='current_hover_left_x'/>
         <int32_t name='current_hover_bot_y'/>
 
-        <static-array count='621' name='hover_instruction' type-name='curses_text_boxst' index-enum='main_hover_instruction'/>
+        <static-array name='hover_instruction' type-name='curses_text_boxst' index-enum='main_hover_instruction'/>
         <int32_t name='last_displayed_hover_inst'/>
         <int32_t name='last_displayed_hover_id1'/>
         <int32_t name='last_displayed_hover_id2'/>
@@ -5615,14 +5615,14 @@
         <stl-vector name='primary_skill' type-name='int16_t'/>
         <stl-vector name='secondary_skill' type-name='int16_t'/>
         <stl-vector name='tertiary_skill' type-name='int16_t'/>
-        <static-array count='6' name='phys_att_range_val' index-enum='physical_attribute_type'>
+        <static-array name='phys_att_range_val' index-enum='physical_attribute_type'>
             <enum type-name='adventurer_attribute_level' base-type='int32_t'/>
         </static-array>
-        <static-array count='13' name='ment_att_range_val' index-enum='mental_attribute_type'>
+        <static-array name='ment_att_range_val' index-enum='mental_attribute_type'>
             <enum type-name='adventurer_attribute_level' base-type='int32_t'/>
         </static-array>
         <int32_t name='att_points'/>
-        <static-array name='skilllevel' count='149' index-enum='job_skill'>
+        <static-array name='skilllevel' index-enum='job_skill'>
             <enum type-name='skill_rating'/>
         </static-array>
         <int32_t name='ip'/>
@@ -5632,7 +5632,7 @@
         <compound type-name='language_name' name='name'/>
         <int16_t name='race' ref-target='creature_raw'/>
         <int16_t name='caste' ref-target='caste_raw' aux-value='$$.race'/>
-        <static-array name='skilllevel' count='149' index-enum='job_skill'>
+        <static-array name='skilllevel' index-enum='job_skill'>
             <enum type-name='skill_rating'/>
         </static-array>
         <int32_t name='quick_entity_id' ref-target='historical_entity'/>
@@ -5644,10 +5644,10 @@
         <enum name='start_civ_type' type-name='profession' base-type='int32_t'/> rather than the matching typedef
         <int16_t name='skill_picks_left'/>
 
-        <static-array count='6' name='phys_att_range_val' index-enum='physical_attribute_type'>
+        <static-array name='phys_att_range_val' index-enum='physical_attribute_type'>
             <enum type-name='adventurer_attribute_level' base-type='int32_t'/>
         </static-array>
-        <static-array count='13' name='ment_att_range_val' index-enum='mental_attribute_type'>
+        <static-array name='ment_att_range_val' index-enum='mental_attribute_type'>
             <enum type-name='adventurer_attribute_level' base-type='int32_t'/>
         </static-array>
 
@@ -5660,7 +5660,7 @@
         <int32_t name='start_site_id' ref-target='world_site' since='v0.47.01'/>
         <int32_t name='background_start_squad_epp_id' since='v0.47.01'/>
         <enum type-name='profession' name='background_unit' since='v0.47.01'/>
-        <static-array name='background_skill_bonus' type-name='int32_t' count='149' index-enum='job_skill' since='v0.47.01'/>
+        <static-array name='background_skill_bonus' type-name='int32_t' index-enum='job_skill' since='v0.47.01'/>
 
         <int32_t name='worship_hfid' ref-target='historical_figure'/>
         <int32_t name='worship_enid' ref-target='historical_entity' since='v0.40.01'/>
@@ -5676,7 +5676,7 @@
 
         <uint32_t name='flag' comment='none used'/>
         <enum type-name='setup_adventure_type' name='sub_mode'/>
-        <static-array name='visited_mode' type-name='bool' count='12' index-enum='setup_adventure_type'/>
+        <static-array name='visited_mode' type-name='bool' index-enum='setup_adventure_type'/>
 
         <bool name='customizing_skills'/>
         <int32_t name='selected_att'/>
@@ -5734,12 +5734,12 @@
         <int32_t name='scroll_position_specific_personality'/>
         <bool name='scrolling_specific_personality'/>
         <int32_t name='selected_specific_pers_item'/>
-        <static-array name='min_pers' type-name='int16_t' index-enum='personality_facet_type' count='50'/>
-        <static-array name='max_pers' type-name='int16_t' index-enum='personality_facet_type' count='50'/>
-        <static-array name='civ_value_level' type-name='int32_t' index-enum='value_type' count='33'/>
+        <static-array name='min_pers' type-name='int16_t' index-enum='personality_facet_type'/>
+        <static-array name='max_pers' type-name='int16_t' index-enum='personality_facet_type'/>
+        <static-array name='civ_value_level' type-name='int32_t' index-enum='value_type'/>
 
         <int32_t name='eqpet_points'/>
-        <static-array name='s_item' index-enum='entity_sell_category' count='107'><stl-vector pointer-type='item_actual'/></static-array>
+        <static-array name='s_item' index-enum='entity_sell_category'><stl-vector pointer-type='item_actual'/></static-array>
 
         <compound type-name='embark_item_choice' name='etl'/>
         <int32_t name='itype'/>
@@ -5747,7 +5747,7 @@
         <int32_t name='imat'/>
         <int32_t name='imatg'/>
 
-        <static-array name='item_expander_on' index-enum='entity_sell_category' count='107' type-name='bool'/>
+        <static-array name='item_expander_on' index-enum='entity_sell_category' type-name='bool'/>
         <int32_t name='scroll_position_item'/>
         <enum name='current_category' type-name='entity_sell_category'/>
         <int32_t name='scroll_position_category'/>
@@ -6530,7 +6530,7 @@
 
     <class-type type-name='viewscreen_choose_game_typest' inherits-from='viewscreen'>
         <stl-vector type-name="game_type" name="gametypes"/>
-        <static-array name='game_type_box' index-enum='game_type' count='11' type-name='curses_text_boxst'/>
+        <static-array name='game_type_box' index-enum='game_type' count='11' type-name='curses_text_boxst'/> must specify count 10 because game_type.NONE is not -1
     </class-type>
 
     <enum-type type-name='choose_start_site_view_mode'> bay12: ChooseStartSiteViewMode, no base type!
@@ -6643,10 +6643,8 @@
         <int32_t name="find_block_dx" init-value='-1' comment='to world width / 16'/>
         <int32_t name="find_block_dy" comment='to world height / 16'/>
         <int32_t name="find_select" refers-to='$$._parent.enabled_options[$]'/>
-        <static-array type-name='int32_t' name="find_param"
-                      count="22" index-enum='embark_finder_option'/>
-        <static-array type-name='bool' name="find_missed_param"
-                      count="22" index-enum='embark_finder_option'/>
+        <static-array type-name='int32_t' name="find_param" index-enum='embark_finder_option'/>
+        <static-array type-name='bool' name="find_missed_param" index-enum='embark_finder_option'/>
 
         <stl-vector type-name='int16_t' name='find_missed_metal_ore'/>
         <stl-vector type-name='int32_t' name='find_param_list'/>
@@ -6693,7 +6691,7 @@
     <class-type type-name='viewscreen_setupdwarfgamest' inherits-from='viewscreen'>
         <static-string size='768' name='title'/>
         <stl-vector name='dwarf_info' pointer-type='setup_character_info'/>
-        <static-array count='4' name='embark_skills' index-enum='embark_skill_tab_type'>
+        <static-array name='embark_skills' index-enum='embark_skill_tab_type'>
             <stl-vector><enum type-name='job_skill' base-type='int16_t'/></stl-vector>
         </static-array>
         <stl-vector name='reclaim_professions'><enum type-name='profession' base-type='int16_t'/></stl-vector>
@@ -6744,8 +6742,8 @@
         <int8_t name='saving_profile_warning'/>
 
         <compound type-name='embark_item_choice' name='etl'/>
-        <static-array name='s_item' index-enum='entity_sell_category' count='107'><stl-vector pointer-type='item_actual'/></static-array>
-        <static-array name='item_expander_on' index-enum='entity_sell_category' count='107' type-name='bool'/>
+        <static-array name='s_item' index-enum='entity_sell_category'><stl-vector pointer-type='item_actual'/></static-array>
+        <static-array name='item_expander_on' index-enum='entity_sell_category' type-name='bool'/>
         <int32_t name='scroll_position_item'/>
         <enum name='current_category' type-name='entity_sell_category'/>
         <int32_t name='scroll_position_category'/>
@@ -7180,15 +7178,15 @@
             <enum-item name='ItemTypes'/>
             <enum-item name='Items'/>
         </enum>
-        <stl-vector name='item_type'>
+        <stl-vector name='item_types'>
             <enum base-type='int16_t' type-name='item_type'/>
         </stl-vector>
         <compound name='artifact_list' type-name='itemlistst'/>
         <bool name='build_artifact_list'/>
-        <static-array name='i_list' count='93' index-enum='item_type'>
+        <static-array name='i_list' index-enum='item_type'>
             <compound name='artifact_list' type-name='itemlistst'/>
         </static-array>
-        <static-array name='build_item_list' count='93' index-enum='item_type' type-name='bool'/>
+        <static-array name='build_item_list' index-enum='item_type' type-name='bool'/>
         <compound name='item_desc' type-name='curses_text_boxst'/>
     </class-type>
 </data-definition>

--- a/df.entity.xml
+++ b/df.entity.xml
@@ -428,7 +428,7 @@
     <struct-type type-name='resource_allotment_data' original-name='production_zonest'
                  instance-vector='$global.world.world_data.resource_allotments'>
         <int32_t name='index'/>
-        <static-array name='resource_allotments' count='100'>
+        <static-array name='resource_allotments' index-enum='resource_allotment_specifier_type'>
             <stl-vector pointer-type='resource_allotment_specifier'/>
         </static-array>
         <int32_t name='center_x'/>
@@ -512,7 +512,7 @@
         <stl-vector name='succession_by_position_str' pointer-type='stl-string'/>
         <stl-vector name='succession_by_position' type-name='int32_t'/>
 
-        <static-array type-name='bool' name='responsibilities' count='43' index-enum='entity_position_responsibility'/>
+        <static-array type-name='bool' name='responsibilities' index-enum='entity_position_responsibility'/>
         <static-array type-name='int16_t' name='color' count='3'/>
 
         <int32_t name='required_boxes'/>
@@ -616,36 +616,35 @@
         <stl-string name='translation'/>
 
         <compound name='symbols'> not an actual compound
-            <static-array name='symbols_major' type-name='language_word_table' index-enum='entity_name_type' count='19'/>
-            <static-array name='symbols_minor' type-name='language_word_table' index-enum='entity_name_type' count='19'/>
-            <static-array name='select_symbol' index-enum='entity_name_type' count='19'>
+            <static-array name='symbols_major' type-name='language_word_table' index-enum='entity_name_type'/>
+            <static-array name='symbols_minor' type-name='language_word_table' index-enum='entity_name_type'/>
+            <static-array name='select_symbol' index-enum='entity_name_type'>
                 <stl-vector pointer-type='stl-string'/>
             </static-array>
-            <static-array name='subselect_symbol' index-enum='entity_name_type' count='19'>
+            <static-array name='subselect_symbol' index-enum='entity_name_type'>
                 <stl-vector pointer-type='stl-string'/>
             </static-array>
-            <static-array name='cull_symbol' index-enum='entity_name_type' count='19'>
+            <static-array name='cull_symbol' index-enum='entity_name_type'>
                 <stl-vector pointer-type='stl-string'/>
             </static-array>
         </compound>
 
-        <static-array name='sphere_alignment' type-name='int32_t' count='130' index-enum='sphere_type'/>
-        <static-array name='art_facet_modifier' type-name='int32_t' count='4' index-enum='art_facet_type'/>
-        <static-array name='art_image_element_modifier' type-name='int32_t' count='5' index-enum='art_image_element_type'/>
-        <static-array name='item_improvement_modifier' type-name='int32_t'
-                      count='15' index-enum='improvement_type'/>
+        <static-array name='sphere_alignment' type-name='int32_t' index-enum='sphere_type'/>
+        <static-array name='art_facet_modifier' type-name='int32_t' index-enum='art_facet_type'/>
+        <static-array name='art_image_element_modifier' type-name='int32_t' index-enum='art_image_element_type'/>
+        <static-array name='item_improvement_modifier' type-name='int32_t' index-enum='improvement_type'/>
 
         <static-array name='friendly_color' type-name='int16_t' count='3'/>
 
         <enum base-type='int32_t' name='default_site_type' type-name='world_site_type'/>
-        <static-array name='likes_site' type-name='int8_t' count='11' index-enum='world_site_type'/>
-        <static-array name='tolerates_site' type-name='int8_t' count='11' index-enum='world_site_type'/>
+        <static-array name='likes_site' type-name='int8_t' index-enum='world_site_type'/>
+        <static-array name='tolerates_site' type-name='int8_t' index-enum='world_site_type'/>
 
-        <static-array name='biome_support' type-name='int32_t' count='51' index-enum='biome_type'/>
-        <static-array name='start_biome' type-name='int8_t' count='51' index-enum='biome_type'/>
-        <static-array name='settlement_biome' type-name='int8_t' count='51' index-enum='biome_type'/>
+        <static-array name='biome_support' type-name='int32_t' index-enum='biome_type'/>
+        <static-array name='start_biome' type-name='int8_t' index-enum='biome_type'/>
+        <static-array name='settlement_biome' type-name='int8_t' index-enum='biome_type'/>
 
-        <static-array name='active_season' type-name='int8_t' count='4' index-enum='season'/>
+        <static-array name='active_season' type-name='int8_t' index-enum='season'/>
 
         <compound name='progress_trigger'>  not an actual compound
             <int16_t name='population'/>
@@ -656,13 +655,13 @@
             <int16_t name='trade_siege'/>
         </compound>
 
-        <static-array name='ethic' count='22' index-enum='ethic_type'>
+        <static-array name='ethic' index-enum='ethic_type'>
             <enum base-type='int16_t' type-name='ethic_response'/>
         </static-array>
 
-        <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/>
-        <static-array name='variable_value_min' type-name='int32_t' count='64' index-enum='value_type' since='v0.42.01'/>
-        <static-array name='variable_value_max' type-name='int32_t' count='64' index-enum='value_type' since='v0.42.01'/>
+        <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/> SAVE_VALUENUM
+        <static-array name='variable_value_min' type-name='int32_t' count='64' index-enum='value_type' since='v0.42.01'/> SAVE_VALUENUM
+        <static-array name='variable_value_max' type-name='int32_t' count='64' index-enum='value_type' since='v0.42.01'/> SAVE_VALUENUM
         <bitfield name='scholar' base-type='uint32_t' type-name='entity_scholar_flag'/>
         <int32_t name='max_site_pop_number'/>
         <int32_t name='max_pop_number'/>
@@ -674,22 +673,16 @@
         </stl-vector>
 
         <compound name='jobs'> not an actual compound
-            <static-array name='permitted_job' type-name='bool'
-                          index-enum='profession'/>
-            <static-array name='permitted_labor' type-name='bool'
-                          index-enum='unit_labor' count='94'/>
-
-            <static-array name='world_construction' type-name='bool'
-                          index-enum='world_construction_type' count='4'/>
+            <static-array name='permitted_job' type-name='bool' index-enum='profession'/>
+            <static-array name='permitted_labor' type-name='bool' index-enum='unit_labor'/>
+            <static-array name='world_construction' type-name='bool' index-enum='world_construction_type'/>
         </compound>
 
         <stl-vector name='positions' pointer-type='entity_position_raw'/>
 
-        <static-array name='variable_positions' type-name='int8_t'
-                      index-enum='entity_position_responsibility' count='43'/>
+        <static-array name='variable_positions' type-name='int8_t' index-enum='entity_position_responsibility'/>
 
-        <static-array name='site_variable_positions' type-name='int8_t'
-                      index-enum='entity_position_responsibility' count='43'/>
+        <static-array name='site_variable_positions' type-name='int8_t' index-enum='entity_position_responsibility'/>
 
         <stl-vector name='tissue_styles' pointer-type='entity_def_tissue_stylest'/>
 
@@ -869,19 +862,19 @@
             (describe-obj $.name)
         </code-helper>
 
-        <static-array name='uniform_item_types' count='7' index-enum='uniform_category'>
+        <static-array name='uniform_item_types' index-enum='uniform_category'>
             <stl-vector>
                 <enum base-type='int16_t' type-name='item_type'/>
             </stl-vector>
         </static-array>
 
-        <static-array name='uniform_item_subtypes' count='7' index-enum='uniform_category'>
+        <static-array name='uniform_item_subtypes' index-enum='uniform_category'>
             <stl-vector>
                 <int16_t refers-to='(item-subtype-target $$._parent._parent._parent.uniform_item_types[$$._parent._key][$$._key] $)'/>
             </stl-vector>
         </static-array>
 
-        <static-array name='uniform_item_info' count='7' index-enum='uniform_category'>
+        <static-array name='uniform_item_info' index-enum='uniform_category'>
             <stl-vector pointer-type='entity_uniform_item'/>
         </static-array>
 
@@ -891,7 +884,7 @@
     </struct-type>
 
     <struct-type type-name='embark_item_choice' original-name='entity_trade_listst'>
-        <static-array name='list' count='107' index-enum='entity_sell_category'>
+        <static-array name='list' index-enum='entity_sell_category'>
             <stl-vector pointer-type='itinfost'/>
         </static-array>
         <stl-vector name='race' type-name='int32_t' ref-target='creature_raw'
@@ -960,7 +953,7 @@
         <stl-vector name='appointed_by_civ' type-name='int32_t' ref-target='historical_entity'/>
         <stl-vector name='succession_by_position' type-name='int32_t'/>
 
-        <static-array type-name='bool' name='responsibilities' count='43' index-enum='entity_position_responsibility'/>
+        <static-array type-name='bool' name='responsibilities' index-enum='entity_position_responsibility'/>
         <stl-string name='description'/>
         <static-array type-name='int16_t' name='color' count='3'/>
 
@@ -1031,7 +1024,47 @@
         <int32_t name='id'/>
     </struct-type>
 
-    -- Unused: TradeCategoryType
+    <enum-type type-name='trade_category_type' base-type='int32_t'> bay12: TradeCategoryType
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='FOOD_CARN'/>
+        <enum-item name='FOOD_OMNI'/>
+        <enum-item name='WEARABLE_CLOTHING_HELM'/>
+        <enum-item name='WEARABLE_CLOTHING_BODY'/>
+        <enum-item name='WEARABLE_CLOTHING_PANTS'/>
+        <enum-item name='WEARABLE_CLOTHING_GLOVES'/>
+        <enum-item name='WEARABLE_CLOTHING_BOOTS'/>
+        <enum-item name='CRAFTS'/>
+        <enum-item name='THREAD'/>
+        <enum-item name='CLOTH'/>
+        <enum-item name='SKIN'/>
+        <enum-item name='LEATHER'/>
+        <enum-item name='BONE_CARVABLE'/>
+        <enum-item name='METAL_WEAPON'/>
+        <enum-item name='METAL_WEAPON_RANGED'/>
+        <enum-item name='METAL_ANVIL'/>
+        <enum-item name='METAL_AMMO'/>
+        <enum-item name='METAL_DIGGER'/>
+        <enum-item name='METAL_ARMOR'/>
+        <enum-item name='METAL_HARD'/>
+        <enum-item name='STONE'/>
+        <enum-item name='ROUGH_GEMS'/>
+        <enum-item name='LEATHER_ACCESSORIES'/>
+        <enum-item name='TABLE'/>
+        <enum-item name='CHAIR'/>
+        <enum-item name='BOX'/>
+        <enum-item name='BED'/>
+        <enum-item name='CABINET'/>
+        <enum-item name='WOOD'/>
+        <enum-item name='GEMS'/>
+        <enum-item name='WEAPON_MELEE'/>
+        <enum-item name='WEAPON_RANGED'/>
+        <enum-item name='WEARABLE_ARMOR_HELM'/>
+        <enum-item name='WEARABLE_ARMOR_BODY'/>
+        <enum-item name='WEARABLE_ARMOR_PANTS'/>
+        <enum-item name='WEARABLE_ARMOR_GLOVES'/>
+        <enum-item name='WEARABLE_ARMOR_BOOTS'/>
+        <enum-item name='AMMO'/>
+    </enum-type>
 
     <struct-type type-name='world_gen_entity_debtst'>
         <int32_t name='civ' ref-target='historical_entity'/>
@@ -1481,14 +1514,14 @@
             <int16_t name='min_temperature'/>
             <int16_t name='max_temperature'/>
 
-            <static-array name='ethic' count='22' index-enum='ethic_type'>
+            <static-array name='ethic' index-enum='ethic_type'>
                 <enum base-type='int16_t' type-name='ethic_response'/>
             </static-array>
 
-            <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/>
+            <static-array name='values' type-name='int32_t' count='64' index-enum='value_type'/> SAVE_VALUENUM
 
             <uint32_t name='scholar_flag' since='v0.42.01'/> likely ENTITY_SCHOLAR_FLAG_*
-            <static-array name='permitted_skill' type-name='bool' index-enum='job_skill' count='149'/>
+            <static-array name='permitted_skill' type-name='bool' index-enum='job_skill'/>
 
             <stl-vector type-name='int16_t' name='art_image_types' comment='0 = civilization symbol, 1 = commissioned'/>
             <stl-vector type-name='int32_t' name='art_image_ids'/>
@@ -1554,7 +1587,7 @@
         <stl-vector name='local_known_events' comment='since the above year' type-name='int32_t' ref-target='history_event'/>
         <int32_t name='production_zone_id' comment='not sure what this refers to'/>
         <compound name='law' type-name='entity_lawst'/>
-        <static-array name='worldgen_can_make_guildhall' count='15' index-enum='town_labor_type' type-name='int32_t' since='v0.34.01' comment='specialization_hours'/>
+        <static-array name='worldgen_can_make_guildhall' index-enum='town_labor_type' type-name='int32_t' since='v0.34.01' comment='specialization_hours'/>
 
         <pointer name='training_knowledge' type-name='entity_animal_training_knowledgest' since='v0.34.06'/>
 
@@ -1652,8 +1685,7 @@
             <stl-vector name='gloves_over' type-name='int16_t' ref-target='itemdef_glovesst'/>
             <stl-vector name='gloves_cover' type-name='int16_t' ref-target='itemdef_glovesst'/>
         </compound>
-        <static-array name='assignments_by_type' count='43'
-                      index-enum='entity_position_responsibility'>
+        <static-array name='assignments_by_type' index-enum='entity_position_responsibility'>
             <stl-vector pointer-type='entity_position_assignment'/>
         </static-array>
 
@@ -1715,11 +1747,11 @@
         <int32_t name='total_food_veg' since='v0.47.01'/>?
         <int32_t name='total_food_carn' since='v0.47.01'/>?
 
-        <static-array name='trade_current_amount' count='38' type-name='int32_t'/>
-        <static-array name='trade_needed_amount' count='38' type-name='int32_t'/>
-        <static-array name='trade_wanted_amount' count='38' type-name='int32_t'/>
-        <static-array name='trade_maximum_buy_price' count='38' type-name='int32_t'/>
-        <static-array name='town_labor_hours' count='15' type-name='int32_t'/>
+        <static-array name='trade_current_amount' type-name='int32_t' index-enum='trade_category_type'/>
+        <static-array name='trade_needed_amount' type-name='int32_t' index-enum='trade_category_type'/>
+        <static-array name='trade_wanted_amount' type-name='int32_t' index-enum='trade_category_type'/>
+        <static-array name='trade_maximum_buy_price' type-name='int32_t' index-enum='trade_category_type'/>
+        <static-array name='town_labor_hours' type-name='int32_t' index-enum='town_labor_type'/>
 
         <stl-vector name='world_gen_entity_debt' pointer-type='world_gen_entity_debtst'/>
         <int32_t name='account' since='v0.47.01'/>

--- a/df.g_src.graphics.xml
+++ b/df.g_src.graphics.xml
@@ -217,7 +217,23 @@
     -- Unused: UnitStatusType
     -- Unused: SideIndicatorType
     -- Unused: TreeWoodTileType
-    -- Unused: Texture
+
+    <enum-type type-name='texture_type'> bay12: Texture, no base type
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='MOUSE'/>
+        <enum-item name='PUBLISHER'/>
+        <enum-item name='PUBLISHER_SMALL'/>
+        <enum-item name='PUBLISHER_TINY'/>
+        <enum-item name='TITLE'/>
+        <enum-item name='TITLE_BACKGROUND'/>
+        <enum-item name='TITLE_ADV'/>
+        <enum-item name='DEVELOPER'/>
+        <enum-item name='DEVELOPER_SMALL'/>
+        <enum-item name='DEVELOPER_TINY'/>
+        <enum-item name='SOUND_SYSTEM'/>
+        <enum-item name='TITLE_SIEGE'/>
+    </enum-type>
+
     -- Unused: SCREENTEXPOS_FLAG_*
     -- Unused: RectangleCursorType
     -- Unused: MAP_PORT_CLOUD_BITS_*
@@ -491,8 +507,8 @@
         <static-array count='5' name='texpos_short_subsubtab'><static-array type-name='int32_t' count='2'/></static-array>
         <static-array count='5' name='texpos_short_subsubtab_selected'><static-array type-name='int32_t' count='2'/></static-array>
         <int32_t name='texpos_interface_background'/>
-        <static-array count='715' name='texpos_button_main'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array>
-        <static-array count='13' name='texpos_button_small'><static-array count='2'><static-array type-name='int32_t' count='2'/></static-array></static-array>
+        <static-array count='715' name='texpos_button_main'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array> INTERFACE_BUTTON_MAINNUM
+        <static-array count='13' name='texpos_button_small'><static-array count='2'><static-array type-name='int32_t' count='2'/></static-array></static-array> INTERFACE_BUTTON_SMALLNUM
         <static-array count='4' name='texpos_button_horizontal_option_left_ornament'><static-array type-name='int32_t' count='3'/></static-array>
         <static-array count='3' name='texpos_button_horizontal_option_active'><static-array type-name='int32_t' count='3'/></static-array>
         <static-array count='3' name='texpos_button_horizontal_option_inactive'><static-array type-name='int32_t' count='3'/></static-array>
@@ -584,15 +600,15 @@
         <static-array count='3' name='texpos_building_jobs_quota'><static-array type-name='int32_t' count='3'/></static-array>
         <static-array count='3' name='texpos_building_jobs_remove_worker'><static-array type-name='int32_t' count='3'/></static-array>
 
-        <static-array count='5' name='texpos_button_assign_trade'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array>
-        <static-array count='24' name='texpos_button_building_info'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array>
-        <static-array count='3' name='texpos_button_building_sheet'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array>
-        <static-array count='4' name='texpos_button_unit_sheet'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array>
-        <static-array count='5' name='texpos_button_large_unit_sheet'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array>
-        <static-array count='12' name='texpos_button_pets_livestock'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array>
-        <static-array count='7' name='texpos_button_inventory_item'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array>
+        <static-array count='5' name='texpos_button_assign_trade'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array> INTERFACE_BUTTON_ASSIGN_TRADENUM
+        <static-array count='24' name='texpos_button_building_info'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array> INTERFACE_BUTTON_BUILDING_INFONUM
+        <static-array count='3' name='texpos_button_building_sheet'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array> INTERFACE_BUTTON_BUILDING_SHEETNUM
+        <static-array count='4' name='texpos_button_unit_sheet'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array> INTERFACE_BUTTON_UNIT_SHEETNUM
+        <static-array count='5' name='texpos_button_large_unit_sheet'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array> INTERFACE_BUTTON_LARGE_UNIT_SHEETNUM
+        <static-array count='12' name='texpos_button_pets_livestock'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array> INTERFACE_BUTTON_PETS_LIVESTOCKNUM
+        <static-array count='7' name='texpos_button_inventory_item'><static-array count='3'><static-array type-name='int32_t' count='3'/></static-array></static-array> INTERFACE_BUTTON_INVENTORY_ITEMNUM
 
-        <static-array count='21' name='texpos_adventure_travel_dir' type-name='int32_t'/>
+        <static-array count='21' name='texpos_adventure_travel_dir' type-name='int32_t'/> INTERFACE_ADVENTURE_TRAVEL_DIRNUM
 
         <int32_t name='texpos_skill_progress_bar_left_full'/>
         <int32_t name='texpos_skill_progress_bar_mid_full'/>
@@ -626,7 +642,7 @@
         <static-array count='2' name='texpos_adv_tracks_on'><static-array type-name='int32_t' count='2'/></static-array>
         <static-array count='2' name='texpos_adv_tracks_off'><static-array type-name='int32_t' count='2'/></static-array>
 
-        <static-array count='76' name='texpos_adv_env'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array>
+        <static-array count='76' name='texpos_adv_env'><static-array count='4'><static-array type-name='int32_t' count='3'/></static-array></static-array> INTERFACE_ADV_ENV_TEXTURENUM
 
         <static-array count='3' name='texpos_legends_tab_page_left'><static-array type-name='int32_t' count='2'/></static-array>
         <static-array count='3' name='texpos_legends_tab_page_right'><static-array type-name='int32_t' count='2'/></static-array>
@@ -753,7 +769,7 @@
 
         <static-array type-name='long' name='clipx' count='2'/>
         <static-array type-name='long' name='clipy' count='2'/>
-        <static-array type-name='cached_texturest' name='tex' count='12'/>
+        <static-array type-name='cached_texturest' name='tex' index-enum='texture_type'/>
         <stl-vector name='texblits' type-name='texblitst'/>
 
         <long name='rect_id'/>
@@ -796,7 +812,7 @@
         <static-array type-name='int32_t' count='101' name='texture_indices9'/>
         <static-array name='texpos_site_map_hillock' count='4'><stl-vector type-name='int32_t'/></static-array>
         <static-array type-name='int32_t' count='276' name='texture_indices10'/>
-        <static-array name='texpos_map_drawn' count='73'><stl-vector type-name='int32_t'/></static-array>
+        <static-array name='texpos_map_drawn' count='73'><stl-vector type-name='int32_t'/></static-array> TEXTURE_MAP_DRAWNNUM
         <static-array type-name='int32_t' count='6845' name='texture_indices11'/>
     </struct-type>
 

--- a/df.g_src.init.xml
+++ b/df.g_src.init.xml
@@ -119,7 +119,15 @@
         <df-flagarray name='flag' index-enum='init_window_flags'/>
     </struct-type>
 
-    -- Unused: InitLoadBarTextureType
+    <enum-type type-name='init_load_bar_texture_type' base-type='int32_t'> bay12: InitLoadBarTextureType
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='LEFT_FULL'/>
+        <enum-item name='MID_FULL'/>
+        <enum-item name='RIGHT_FULL'/>
+        <enum-item name='LEFT_EMPTY'/>
+        <enum-item name='MID_EMPTY'/>
+        <enum-item name='RIGHT_EMPTY'/>
+    </enum-type>
 
     <struct-type type-name='init' original-name='initst'>
         <compound name='display' type-name='init_display'/>
@@ -131,7 +139,7 @@
         <int32_t name='fps_cap'/>
         <int32_t name='gfps_cap'/>
 
-        <static-array name='load_bar_texpos' type-name='long' count='6'/>
+        <static-array name='load_bar_texpos' type-name='long' index-enum='init_load_bar_texture_type'/>
 
         <static-array name='intro_button_texpos' type-name='long' count='117'/>
         <static-array name='texpos_neutral_intro_button' type-name='int32_t' count='9'/>
@@ -205,7 +213,7 @@
         <static-array name='texpos_sort_text_active' type-name='int32_t' count='3'/>
         <static-array name='texpos_sort_text_inactive' type-name='int32_t' count='3'/>
 
-        <static-array name='classic_load_bar_texpos' type-name='long' count='6'/>
+        <static-array name='classic_load_bar_texpos' type-name='long' index-enum='init_load_bar_texture_type'/>
         <static-array name='classic_texpos_neutral_intro_button' type-name='int32_t' count='9'/>
         <static-array name='classic_texpos_confirm_intro_button' type-name='int32_t' count='9'/>
         <static-array name='classic_texpos_cancel_intro_button' type-name='int32_t' count='9'/>

--- a/df.game_v.xml
+++ b/df.game_v.xml
@@ -25,10 +25,10 @@
         <stl-vector pointer-type='timed_event'/>
     </global-object>
     <global-object name='jobvalue'>
-        <static-array count='258' type-name='int32_t'/>
+        <static-array type-name='int32_t' index-enum='job_type'/>
     </global-object>
     <global-object name='jobvalue_setter'>
-        <static-array count='258' pointer-type='unit'/>
+        <static-array pointer-type='unit' index-enum='job_type'/>
     </global-object>
     <global-object name='buildreq' type-name='buildreq'/>
 

--- a/df.history.xml
+++ b/df.history.xml
@@ -233,7 +233,7 @@
         <stl-vector name='hf_plotters' pointer-type='historical_figure'/>
 
         11 - necromancers
-        <static-array name='hf_teachers' since='v0.40.01' count='15' index-enum='goal_type'>
+        <static-array name='hf_teachers' since='v0.40.01' index-enum='goal_type'>
             <stl-vector pointer-type='historical_figure'/>
         </static-array>
 

--- a/df.history_figure.xml
+++ b/df.history_figure.xml
@@ -319,7 +319,7 @@
         <int32_t name='y'/>
         <int32_t name='year'/>
         <int32_t name='season_tick'/>
-        <static-array name='reputation' type-name='int32_t' count='8' index-enum='abstract_building_reputation_type'/>
+        <static-array name='reputation' type-name='int32_t' index-enum='abstract_building_reputation_type'/>
     </struct-type>
 
     <struct-type type-name='site_reputation_info' original-name='ab_review_infost'>
@@ -435,8 +435,8 @@
         <int32_t name='army_strength_material_bonus' since='v0.44.01'/>
         <int32_t name='average_equipment_quality' since='v0.47.01'/>
         <int32_t name='equip_add'/>
-        <static-array name='invp_skill_ip' type-name='int32_t' count='13' index-enum='inventory_profile_skill_type' since='v0.44.06' comment="only when specific_items flag set"/>
-        <static-array name='invp_mat_strength' type-name='int32_t' count='13' index-enum='inventory_profile_skill_type' since='v0.44.06' comment="only when specific_items flag set"/>
+        <static-array name='invp_skill_ip' type-name='int32_t' index-enum='inventory_profile_skill_type' since='v0.44.06' comment="only when specific_items flag set"/>
+        <static-array name='invp_mat_strength' type-name='int32_t' index-enum='inventory_profile_skill_type' since='v0.44.06' comment="only when specific_items flag set"/>
         <bitfield name='flags' base-type='uint32_t' since='v0.44.06' type-name='inventory_profile_flag'/>
         <enum name='using_weapon_skill' type-name='job_skill' since='v0.44.06' comment='not saved'/>
         <pointer name='building_usage_profile' type-name='hf_building_usage_profilest' since='v0.47.01'/>

--- a/df.interaction.xml
+++ b/df.interaction.xml
@@ -60,7 +60,7 @@
 
     <class-type type-name='interaction_source_regionst' inherits-from='interaction_source'>
         <bitfield name='region_flags' base-type='uint32_t' type-name='interaction_source_region_flag'/>
-        <static-array name='regions' type-name='int8_t' count='10' index-enum='world_region_type'/>
+        <static-array name='regions' type-name='int8_t' index-enum='world_region_type'/>
     </class-type>
 
     <class-type type-name='interaction_source_underground_specialst' inherits-from='interaction_source'/>

--- a/df.item.xml
+++ b/df.item.xml
@@ -1146,15 +1146,20 @@
         <enum-item name='Leather'/>
         <enum-item name='Bone'/>
         <enum-item name='Shell'/>
-
         <enum-item name='Wood'/>
         <enum-item name='Soap'/>
         <enum-item name='Tooth'/>
         <enum-item name='Horn'/>
         <enum-item name='Pearl'/>
-
         <enum-item name='HairWool'/>
         <enum-item name='Yarn'/>
+        <enum-item name='UNUSED_02'/>
+        <enum-item name='UNUSED_03'/>
+        <enum-item name='UNUSED_04'/>
+        <enum-item name='UNUSED_05'/>
+        <enum-item name='UNUSED_06'/>
+        <enum-item name='UNUSED_07'/>
+        <enum-item name='UNUSED_08'/>
     </enum-type>
 
     <class-type type-name='item_body_component' inherits-from='item_actual'
@@ -1174,7 +1179,7 @@
         <compound name='body'> not a compound
             <stl-vector name='wounds' pointer-type='unit_wound'/>
 
-            <static-array name='systemic_wound_id' type-name='int32_t' count='10' index-enum='wound_effect_type'/>
+            <static-array name='systemic_wound_id' type-name='int32_t' index-enum='wound_effect_type'/>
             <int32_t name='wound_next_id'/>
 
             <compound name='components'> not a compound
@@ -1201,10 +1206,8 @@
                             index-refers-to='$$._global._upglobal.caste.ref-target.body_info.layer_idx[$].refers-to'/>
             </compound>
 
-            <static-array type-name='int32_t' name='physical_attr_value'
-                          count='6' index-enum='physical_attribute_type'/>
-            <static-array type-name='int32_t' name='physical_attr_soft_demotion'
-                          count='6' index-enum='physical_attribute_type'/>
+            <static-array type-name='int32_t' name='physical_attr_value' index-enum='physical_attribute_type'/>
+            <static-array type-name='int32_t' name='physical_attr_soft_demotion' index-enum='physical_attribute_type'/>
 
             <compound name='size_info'> not a compound
                 <int32_t name='size_cur'/>
@@ -1251,8 +1254,7 @@
 
         <bitfield name='corpse_flags' base-type='uint32_t' type-name='item_body_component_flag'/>
 
-        <static-array name='material_amount' type-name='int32_t'
-                      count='19' index-enum='corpse_material_type'/>
+        <static-array name='material_amount' type-name='int32_t' index-enum='corpse_material_type'/>
 
         <compound name='largest_tissue'>
             <int16_t name='mat_type' ref-target='material' aux-value='$$.mat_index'/>

--- a/df.itemdef.xml
+++ b/df.itemdef.xml
@@ -1531,7 +1531,7 @@
         <stl-vector name='trapcomps' pointer-type='itemdef_trapcompst'/>
         <stl-vector name='toys' pointer-type='itemdef_toyst'/>
         <stl-vector name='tools' pointer-type='itemdef_toolst'/>
-        <static-array name='tools_by_type' count='26' index-enum='tool_uses'>
+        <static-array name='tools_by_type' index-enum='tool_uses'>
             <stl-vector pointer-type='itemdef_toolst'/>
         </static-array>
         <stl-vector name='instruments' pointer-type='itemdef_instrumentst'/>
@@ -1601,8 +1601,8 @@
         <stl-vector name='powder_graphics_info' pointer-type='item_powder_graphics_infost'/>
         <stl-vector name='pipe_section_graphics_info' pointer-type='item_pipe_section_graphics_infost'/>
         <stl-vector name='rock_graphics_info' pointer-type='item_rock_graphics_infost'/>
-        <static-array name='statue_texpos_top' count='93' type-name='int32_t'/>
-        <static-array name='statue_texpos_bottom' count='93' type-name='int32_t'/>
+        <static-array name='statue_texpos_top' index-enum='item_type' type-name='int32_t'/>
+        <static-array name='statue_texpos_bottom' index-enum='item_type' type-name='int32_t'/>
     </struct-type>
 </data-definition>
 

--- a/df.job.xml
+++ b/df.job.xml
@@ -1445,6 +1445,17 @@
             <item-attr name='type' value='SiegeWeapon'/>
             <item-attr name='skill' value='SIEGEOPERATE'/>
         </enum-item>
+
+        <enum-item name='UNUSED_31'/>
+        <enum-item name='UNUSED_32'/>
+        <enum-item name='UNUSED_33'/>
+        <enum-item name='UNUSED_34'/>
+        <enum-item name='UNUSED_35'/>
+        <enum-item name='UNUSED_36'/>
+        <enum-item name='UNUSED_37'/>
+        <enum-item name='UNUSED_38'/>
+        <enum-item name='UNUSED_39'/>
+        <enum-item name='UNUSED_40'/>
     </enum-type>
 
     <bitfield-type type-name='job_flags' base-type='uint32_t'> bay12: JOBFLAG_*

--- a/df.language.xml
+++ b/df.language.xml
@@ -195,10 +195,10 @@
         <stl-string name='first_name'/>
         <stl-string name='nickname'/>
 
-        <static-array name='words' count='7' index-enum='language_name_component'>
+        <static-array name='words' index-enum='language_name_component'>
             <int32_t ref-target='language_word'/>
         </static-array>
-        <static-array name='parts_of_speech' count='7' index-enum='language_name_component'>
+        <static-array name='parts_of_speech' index-enum='language_name_component'>
             <enum base-type='int16_t' type-name='part_of_speech'/>
         </static-array>
 
@@ -240,12 +240,12 @@
     </struct-type>
 
     <struct-type type-name='language_word_table' comment='word_selectorst'>
-        <static-array name='words' index-enum='language_word_table_index' count='6'>
+        <static-array name='words' index-enum='language_word_table_index'>
             <stl-vector index-refers-to='$$._parent._parent.parts[$$._key][$]'>
                 <int32_t ref-target='language_word'/>
             </stl-vector>
         </static-array>
-        <static-array name='parts' index-enum='language_word_table_index' count='6'>
+        <static-array name='parts' index-enum='language_word_table_index'>
             <stl-vector>
                 <enum base-type='int32_t' type-name='part_of_speech'/>
             </stl-vector>
@@ -337,7 +337,7 @@
         <stl-vector name='translations' pointer-type='language_translation'/>
 
         <static-array name='word_table' count='2'> default_major_selector + default_minor_selector
-            <static-array type-name='language_word_table' index-enum='language_name_category' count='68'/>
+            <static-array type-name='language_word_table' index-enum='language_name_category'/>
         </static-array>
     </struct-type>
 </data-definition>

--- a/df.material.xml
+++ b/df.material.xml
@@ -554,18 +554,14 @@
 
     <class-type type-name='creature_interaction_effect_phys_att_changest'
                 inherits-from='creature_interaction_effect'>
-        <static-array name='phys_att_perc' type-name='int32_t'
-                      count='6' index-enum='physical_attribute_type'/>
-        <static-array name='phys_att_add' type-name='int32_t'
-                      count='6' index-enum='physical_attribute_type'/>
+        <static-array name='phys_att_perc' type-name='int32_t' index-enum='physical_attribute_type'/>
+        <static-array name='phys_att_add' type-name='int32_t' index-enum='physical_attribute_type'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_ment_att_changest'
                 inherits-from='creature_interaction_effect'>
-        <static-array name='ment_att_perc' type-name='int32_t'
-                      count='13' index-enum='mental_attribute_type'/>
-        <static-array name='ment_att_add' type-name='int32_t'
-                      count='13' index-enum='mental_attribute_type'/>
+        <static-array name='ment_att_perc' type-name='int32_t' index-enum='mental_attribute_type'/>
+        <static-array name='ment_att_add' type-name='int32_t' index-enum='mental_attribute_type'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_material_force_adjustst'
@@ -587,7 +583,7 @@
 
     <class-type type-name='creature_interaction_effect_change_personalityst'
                 inherits-from='creature_interaction_effect'>
-        <static-array type-name='int16_t' name='facets' count='50' index-enum='personality_facet_type'/>
+        <static-array type-name='int16_t' name='facets' index-enum='personality_facet_type'/>
     </class-type>
 
     <class-type type-name='creature_interaction_effect_erratic_behaviorst'
@@ -685,22 +681,16 @@
         <int32_t name='liquid_density'/>
         <int32_t name='molar_mass'/>
 
-        <static-array name='state_color' type-name='int32_t'
-                      count='6' index-enum='matter_state'/>
-        <static-array name='state_name' type-name='stl-string'
-                      count='6' index-enum='matter_state'/>
-        <static-array name='state_adj' type-name='stl-string'
-                      count='6' index-enum='matter_state'/>
+        <static-array name='state_color' type-name='int32_t' index-enum='matter_state'/>
+        <static-array name='state_name' type-name='stl-string' index-enum='matter_state'/>
+        <static-array name='state_adj' type-name='stl-string' index-enum='matter_state'/>
 
         <compound name='strength'> not a compound
             <int32_t name='absorption'/>
 
-            <static-array name='yield' type-name='int32_t'
-                          count='6' index-enum='strain_type'/>
-            <static-array name='fracture' type-name='int32_t'
-                          count='6' index-enum='strain_type'/>
-            <static-array name='strain_at_yield' type-name='int32_t'
-                          count='6' index-enum='strain_type'/>
+            <static-array name='yield' type-name='int32_t' index-enum='strain_type'/>
+            <static-array name='fracture' type-name='int32_t' index-enum='strain_type'/>
+            <static-array name='strain_at_yield' type-name='int32_t' index-enum='strain_type'/>
 
             <int32_t name='max_edge'/>
         </compound>
@@ -755,7 +745,7 @@
         <stl-vector name='sphere' type-name='sphere_type' since='v0.40.01'/>
 
         <stl-string name='powder_dye_str' comment='temporary'/>
-        <static-array name='state_color_str' type-name='stl-string' count='6' index-enum='matter_state'/>
+        <static-array name='state_color_str' type-name='stl-string' index-enum='matter_state'/>
     </struct-type>
 
     <struct-type type-name='material_template_handlerst'>
@@ -782,22 +772,16 @@
         <int32_t name='liquid_density'/>
         <int32_t name='molar_mass'/>
 
-        <static-array name='state_color' type-name='int32_t'
-                      count='6' index-enum='matter_state'/>
-        <static-array name='state_name' type-name='stl-string'
-                      count='6' index-enum='matter_state'/>
-        <static-array name='state_adj' type-name='stl-string'
-                      count='6' index-enum='matter_state'/>
+        <static-array name='state_color' type-name='int32_t' index-enum='matter_state'/>
+        <static-array name='state_name' type-name='stl-string' index-enum='matter_state'/>
+        <static-array name='state_adj' type-name='stl-string' index-enum='matter_state'/>
 
         <compound name='strength'> not a compound
             <int32_t name='absorption'/>
 
-            <static-array name='yield' type-name='int32_t'
-                          count='6' index-enum='strain_type'/>
-            <static-array name='fracture' type-name='int32_t'
-                          count='6' index-enum='strain_type'/>
-            <static-array name='strain_at_yield' type-name='int32_t'
-                          count='6' index-enum='strain_type'/>
+            <static-array name='yield' type-name='int32_t' index-enum='strain_type'/>
+            <static-array name='fracture' type-name='int32_t' index-enum='strain_type'/>
+            <static-array name='strain_at_yield' type-name='int32_t' index-enum='strain_type'/>
 
             <int32_t name='max_edge'/>
         </compound>
@@ -858,13 +842,13 @@
 
         <stl-string name='prefix'/>
 
-        <static-array name='food_mat_index' count='39' index-enum='organic_mat_category'>
+        <static-array name='food_mat_index' index-enum='organic_mat_category'>
             <int32_t refers-to='(food-mat-by-idx $$._key $)'
                      comment='When valid, refers to itself.'/>
         </static-array>
 
         <stl-string name='powder_dye_str' comment='temporary'/>
-        <static-array name='state_color_str' type-name='stl-string' count='6' index-enum='matter_state'/>
+        <static-array name='state_color_str' type-name='stl-string' index-enum='matter_state'/>
 
         <int32_t name='wood_texpos'/>
         <int32_t name='boulder_texpos1'/>
@@ -883,18 +867,18 @@
     </struct-type>
 
     <struct-type type-name='special_mat_table' original-name='material_infost'>
-        <static-array name='organic_types' count='39' index-enum='organic_mat_category'>
+        <static-array name='organic_types' index-enum='organic_mat_category'>
             <stl-vector type-name='int16_t' index-refers-to='(food-mat-by-idx $$._key $)'/>
         </static-array>
-        <static-array name='organic_indexes' count='39' index-enum='organic_mat_category'>
+        <static-array name='organic_indexes' index-enum='organic_mat_category'>
             <stl-vector type-name='int32_t'/>
         </static-array>
-        <static-array name='organic_temp' count='39' comment='everything 0'
+        <static-array name='organic_temp' comment='everything 0'
                       index-enum='organic_mat_category'>
             <stl-vector type-name='int32_t'/>
         </static-array>
 
-        <static-array name='builtin' count='659' index-enum='builtin_mats'>
+        <static-array name='builtin' count='659' index-enum='builtin_mats'> MATERIALNUM
             <pointer type-name='material'/>
         </static-array>
 

--- a/df.matgloss.xml
+++ b/df.matgloss.xml
@@ -287,7 +287,7 @@
 
     -- Simplified: pmd_tree_texture_infost
     <struct-type type-name='pmd_tree_texture_infost'>
-        <static-array name='texpos_tree_wood_tile' type-name='int32_t' count='104'/> index-enum TreePartTileType
+        <static-array name='texpos_tree_wood_tile' type-name='int32_t' count='104'/> TREE_PART_TILENUM
         <static-array name='texpos_tree_twigs_full' type-name='int32_t' count='12'/>
         <static-array name='texpos_tree_twigs' type-name='int32_t' count='16'/>
         <static-array name='texpos_overleaves' type-name='int32_t' count='15'/>
@@ -342,7 +342,7 @@
             <uint8_t name='dead_sapling_tile'/>
             <static-array type-name='uint8_t' name='grass_tiles' count='16'/>
             <static-array type-name='uint8_t' name='alt_grass_tiles' count='12'/>
-            <static-array type-name='uint8_t' name='tree_tiles' count='104'/>
+            <static-array type-name='uint8_t' name='tree_tiles' count='104'/> TREE_PART_TILENUM
         </compound>
 
         <static-array type-name='int32_t' name='texpos' count='18'/>

--- a/df.nemesis.xml
+++ b/df.nemesis.xml
@@ -49,10 +49,24 @@
 
     <struct-type type-name='nemesis_handlerst'>
         <stl-vector name='all' pointer-type='nemesis_record'/>
-        <static-array name='other' count='28'>
-            <stl-vector pointer-type='nemesis_record'/>
-        </static-array>
+
+        <stl-vector name='independent_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='civilized_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='plotter_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='new_plotter_actor' pointer-type='nemesis_record'/>
+        <static-array name='teacher_actor' index-enum='goal_type'><stl-vector pointer-type='nemesis_record'/></static-array>
+        <stl-vector name='artist_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='poet_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='bard_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='dancer_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='scholar_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='hero_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='underbelly_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='religious_actor' pointer-type='nemesis_record'/>
+        <stl-vector name='merchant_actor' pointer-type='nemesis_record'/>
+
         <stl-vector name='order_load' has-bad-pointers='true' pointer-type='nemesis_record'/>
+
         <bool name='do_not_remove_from_vector'/>
     </struct-type>
 </data-definition>

--- a/df.personality.xml
+++ b/df.personality.xml
@@ -1367,6 +1367,7 @@
     </struct-type>
 
     <enum-type type-name='need_type' base-type='int32_t'> bay12: PersonalityNeedType
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='Socialize'/>
         <enum-item name='DrinkAlcohol'/>
         <enum-item name='PrayOrMeditate'/>
@@ -1410,7 +1411,7 @@
     -- Unused: circumstancest
 
     <struct-type type-name='soul_personality_changest'>
-        <static-array type-name='int16_t' name='traits' count='50' index-enum='personality_facet_type'/>
+        <static-array type-name='int16_t' name='traits' index-enum='personality_facet_type'/>
     </struct-type>
 
     <bitfield-type type-name='personality_memory_flag' base-type='uint32_t'> bay12: PERSONALITY_MEMORY_FLAG_*
@@ -1452,8 +1453,8 @@
     </bitfield-type>
 
     <struct-type type-name='personality_debugst'>
-        <static-array name='total_circ_stress' type-name='int32_t' count='280' index-enum='unit_thought_type'/>
-        <static-array name='total_circ_memory_stress' type-name='int32_t' count='280' index-enum='unit_thought_type'/>
+        <static-array name='total_circ_stress' type-name='int32_t' index-enum='unit_thought_type'/>
+        <static-array name='total_circ_memory_stress' type-name='int32_t' index-enum='unit_thought_type'/>
         <int32_t name='total_eustress_gain'/>
         <int32_t name='total_distress_gain'/>
         <int32_t name='total_eustress_loss'/>
@@ -1474,7 +1475,7 @@
         <int32_t name='next_dream_id' since='v0.40.01'/>
         <stl-vector name='preferences' pointer-type='personality_preferencest' since='v0.40.01'/>
 
-        <static-array type-name='uint16_t' name='traits' count='50' index-enum='personality_facet_type'/>
+        <static-array type-name='uint16_t' name='traits' index-enum='personality_facet_type'/>
 
         <int32_t name='civ_id' ref-target='historical_entity' since='v0.40.01'/>
         <int32_t name='cultural_identity' ref-target='cultural_identity' since='v0.40.01'/>

--- a/df.plotinfo.xml
+++ b/df.plotinfo.xml
@@ -531,15 +531,15 @@
     </struct-type>
 
     <struct-type type-name='equip_infost'>
-        <static-array name='items_unmanifested' count='113' index-enum='item_type'>
+        <static-array name='items_unmanifested' count='113' index-enum='item_type'> SAVEITEMNUM
             <stl-vector type-name='int32_t' ref-target='item'/>
         </static-array>
 
-        <static-array name='items_unassigned' count='113' index-enum='item_type'>
+        <static-array name='items_unassigned' count='113' index-enum='item_type'> SAVEITEMNUM
             <stl-vector type-name='int32_t' ref-target='item'/>
         </static-array>
 
-        <static-array name='items_assigned' count='113' index-enum='item_type'>
+        <static-array name='items_assigned' count='113' index-enum='item_type'> SAVEITEMNUM
             <stl-vector type-name='int32_t' ref-target='item'/>
         </static-array>
 
@@ -604,7 +604,7 @@
     <struct-type type-name='labor_infost' since='v0.50.01'>
         <bitfield name="flags" base-type='uint32_t' type-name='labor_info_flag'/>
         <stl-vector name='work_details' pointer-type='work_detail'/>
-        <static-array type-name='bool' name='chores' index-enum='unit_labor' count='94'/>
+        <static-array type-name='bool' name='chores' index-enum='unit_labor'/>
         <stl-vector name='chores_exempted_children' type-name='int32_t' ref-target='unit'/> sorted
     </struct-type>
 
@@ -813,7 +813,7 @@
 
         <int16_t name='manager_timer' comment='bay12: quota_checktime'/>
 
-        <static-array name='units_killed' type-name='int16_t' count='152' index-enum='profession'/>
+        <static-array name='units_killed' type-name='int16_t' count='152' index-enum='profession'/> SAVEUNITNUM
 
         <stl-vector name='currency_value' type-name='int32_t'
                     index-refers-to='(material-by-id 0 $)'/>

--- a/df.region.xml
+++ b/df.region.xml
@@ -36,7 +36,7 @@
     <struct-type type-name='worldgen_parms_ps' original-name='world_gen_param_presetst'>
         <int32_t name='width'/>
         <int32_t name='height'/>
-        <static-array count='24' name='data' index-enum='worldgen_range_type'>
+        <static-array name='data' index-enum='worldgen_range_type'>
             <pointer is-array='true'><pointer is-array='true' type-name='int16_t'/></pointer>
         </static-array>
     </struct-type>
@@ -59,8 +59,8 @@
         <int32_t name='partial_ocean_edge_min'/>
         <int32_t name='complete_ocean_edge_min'/>
         <int32_t name='volcano_min'/>
-        <static-array name='region_counts' count='3'>
-            <static-array type-name='int32_t' count='10' index-enum='world_region_type'/>
+        <static-array name='region_counts' count='3'> initial, pre, post
+            <static-array type-name='int32_t' index-enum='world_region_type'/>
         </static-array>
         <static-array type-name='int32_t' name='river_mins' count='2'/>
         <int32_t name='subregion_max'/>
@@ -98,8 +98,8 @@
         <int32_t name='volcanism_ranges_1'/>
         <int32_t name='volcanism_ranges_0'/>
         <int32_t name='volcanism_ranges_2'/>
-        <static-array count='4' name='ranges'>
-            <static-array type-name='int32_t' count='24' index-enum='worldgen_range_type'/>
+        <static-array count='4' name='ranges'> min, max, var_x, var_y
+            <static-array type-name='int32_t' index-enum='worldgen_range_type'/>
         </static-array>
         <int32_t name='beast_end_year'/>
         <int32_t name='end_year'/>
@@ -330,7 +330,7 @@
 
         <stl-vector name="population" pointer-type='world_population'/>
 
-        <static-array name="biome_tile_counts" count="51" type-name='int32_t' index-enum='biome_type'/>
+        <static-array name="biome_tile_counts" type-name='int32_t' index-enum='biome_type'/>
         <stl-vector name="tree_biomes">
             <enum base-type='int16_t' type-name='biome_type'/>
         </stl-vector>
@@ -467,7 +467,7 @@
     <struct-type type-name='region_headerst'>
         <compound type-name='language_name' name='name'/>
         <stl-string name='display_name'/>
-        <static-array name='permission' count='15' type-name='int8_t' index-enum='region_permission_type'/>
+        <static-array name='permission' type-name='int8_t' index-enum='region_permission_type'/>
         <compound name='last_id' comment='when loading, DF sets *_next_id to these fields plus 1'> not a compound
             <int32_t name='unit'/>
             <int32_t name='soul'/>
@@ -624,7 +624,7 @@
         <int32_t name='embark_rectangle_ex'/>
         <int32_t name='embark_rectangle_sy'/>
         <int32_t name='embark_rectangle_ey'/>
-        <static-array type-name='int32_t' count='22' index-enum='embark_finder_option'/>
+        <static-array name='find_param' type-name='int32_t' index-enum='embark_finder_option'/>
         <pointer name='find_metal_ore'><stl-vector type-name='int16_t' ref-target='inorganic_raw'/></pointer>
         <pointer name='skip_metal_ore'><stl-vector type-name='int16_t' ref-target='inorganic_raw'/></pointer>
         <int32_t name='highlight_site_id' ref-target='world_site'/>
@@ -733,7 +733,7 @@
     <struct-type type-name='world_data' original-name='regionst'>
         <compound name='name' type-name='language_name' comment='name of the world'/>
 
-        <static-array name='permission' count='15' type-name='int8_t' index-enum='region_permission_type'/>
+        <static-array name='permission' type-name='int8_t' index-enum='region_permission_type'/>
 
         <int32_t name='next_site_id'/>
         <int32_t name='next_resource_pile_id'/>
@@ -856,8 +856,8 @@
             <enum-item name='Done'/>
         </enum>
         <int32_t name='num_rejects'/>
-        <static-array name='skip_reject' count='53' type-name='int32_t'/>
-        <static-array name='reject_type' count='53' type-name='int32_t'/>
+        <static-array name='skip_reject' index-enum='map_reject_type' type-name='int32_t'/>
+        <static-array name='reject_type' index-enum='map_reject_type' type-name='int32_t'/>
         <int16_t name='rejection_reason'/>
         <int32_t name='new_dimx'/>
         <int32_t name='new_dimy'/>
@@ -906,13 +906,13 @@
         <stl-vector name='entity_race' type-name='int16_t'/>
         <int32_t name='civ_count'/>  --  Only valid during civ placement phase
         <int32_t name='civs_left_to_place'/>  --  Ditto
-        <static-array name='normal_regions' count='10'>
+        <static-array name='normal_regions' index-enum='world_region_type'>
             <stl-vector pointer-type='world_region'/>
         </static-array>
-        <static-array name='good_regions' count='10'>
+        <static-array name='good_regions' index-enum='world_region_type'>
             <stl-vector pointer-type='world_region'/>
         </static-array>
-        <static-array name='evil_regions' count='10'>
+        <static-array name='evil_regions' index-enum='world_region_type'>
             <stl-vector pointer-type='world_region'/>
         </static-array>
         <stl-vector name='cave_choice_x' type-name='int32_t'/>

--- a/df.report.xml
+++ b/df.report.xml
@@ -15,7 +15,7 @@
             <int32_t name='plant'/>
             <int32_t name='drink'/>
         </compound>
-        <static-array name='unit_counts' type-name='int16_t' count='152' index-enum='profession'/>
+        <static-array name='unit_counts' type-name='int16_t' count='152' index-enum='profession'/> SAVEUNITNUM
         <int16_t name='population'/>
         <int16_t name='menial_exempt'/>
         <int16_t name='omnivores'/>
@@ -24,7 +24,7 @@
         <int16_t name='other_animals'/>
         <int16_t name='potential_soldiers'/>
         <int32_t name='combat_aptitude'/>
-        <static-array name='item_counts' type-name='int32_t' count='113' index-enum='item_type'/>
+        <static-array name='item_counts' type-name='int32_t' count='113' index-enum='item_type'/> SAVEITEMNUM
         <stl-vector name='created_weapons' type-name='int32_t' index-refers-to='$global.world.raws.itemdefs.weapons[$]'/>
         <compound name='wealth'> not a compound
             <int32_t name='total'/>
@@ -40,7 +40,7 @@
             <int32_t name='exported'/>
         </compound>
         <static-array name='recent_jobs' count='7'> creature, all, glass, stone, metal, tree, shrub
-            <static-array count='258' type-name='int32_t' index-enum='job_type'/>
+            <static-array type-name='int32_t' index-enum='job_type'/>
         </static-array>
         <int32_t name='excavated_tiles' comment='unhidden, subterranean, and excluding map features'/>
         <static-array count='5' type-name='int32_t' name='death_history'/>

--- a/df.site.xml
+++ b/df.site.xml
@@ -110,7 +110,17 @@
         <compound name='practice_data' type-name='religious_practice_data'/>
     </struct-type>
 
-    -- Unused: InfrastructureType
+    <enum-type type-name='infrastructure_type' base-type='int32_t'>
+        <enum-item name='NONE' value='-1'/>
+        <enum-item name='VILLAGE'/>
+        <enum-item name='PASTURE'/>
+        <enum-item name='MEADOW'/>
+        <enum-item name='SMALL_CROPS'/>
+        <enum-item name='ORCHARD'/>
+        <enum-item name='WOODLAND'/>
+        <enum-item name='WASTE'/>
+        <enum-item name='TOWN'/>
+    </enum-type>
 
     <bitfield-type type-name='site_crop_flag' base-type='uint32_t'> bay12: SITE_CROP_FLAG_*
         <flag-bit name='has_growths'/>
@@ -338,7 +348,7 @@
         <int32_t name="added_size" comment='Subset of caves can have non zero.'/>
         <int32_t name="infrastructure_pop_level" comment='Monument 0, LairShrine 5, Camp 20, others varying'/>
         <int32_t name="base_infrastructure_pop_level" comment=' "site_level" is in here somewhere. Same as for unk_124, but varying ones always less/equal'/>
-        <static-array name='infrastructure' type-name='int32_t' count='8' comment="Has all zero for Fortress, Camp, PlayerFortress, Monument, and LairShrine. Cave can have value, while DarkFortress, MountainHalls, ForestRetreat and Town all have at least one non zero value"/>
+        <static-array name='infrastructure' type-name='int32_t' index-enum='infrastructure_type' comment="Has all zero for Fortress, Camp, PlayerFortress, Monument, and LairShrine. Cave can have value, while DarkFortress, MountainHalls, ForestRetreat and Town all have at least one non zero value"/>
 
         <stl-vector name='small_crop' pointer-type='site_cropst' comment='MountainHall, Town, DarkFortress, but not all'/>
         <stl-vector name='orchard' pointer-type='site_cropst'  comment='forest retreat'/>

--- a/df.soul.xml
+++ b/df.soul.xml
@@ -61,7 +61,7 @@
         <int32_t name='old_year' init-value='-1' comment='bay12: age_death_year'/>
         <int32_t name='old_time' init-value='-1' comment='bay12: age_death_season_count'/>
 
-        <static-array type-name='unit_attribute' name='mental_attrs' count='13' index-enum='mental_attribute_type'/>
+        <static-array type-name='unit_attribute' name='mental_attrs' index-enum='mental_attribute_type'/>
 
         <stl-vector name='skills' pointer-type='unit_skill'/>
         <stl-vector name='preferences' pointer-type='unit_preference'/>

--- a/df.squad.xml
+++ b/df.squad.xml
@@ -134,7 +134,8 @@
         <stl-string name='override_name'/>
     </class-type>
 
-    <enum-type type-name='barrack_preference_category'> bay12: SquadPositionBuildingType
+    <enum-type type-name='barrack_preference_category' base-type='int16_t'> bay12: SquadPositionBuildingType
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='Bed'/>
         <enum-item name='Armorstand'/>
         <enum-item name='Box'/>
@@ -158,7 +159,7 @@
     </struct-type>
 
     <struct-type type-name='squad_position_equipmentst'>
-        <static-array name='uniform' count='7' index-enum='uniform_category'>
+        <static-array name='uniform' index-enum='uniform_category'>
             <stl-vector pointer-type='squad_uniform_spec'/>
         </static-array>
 
@@ -180,15 +181,15 @@
 
         <stl-vector name="orders" pointer-type='squad_order'/>
 
-        <static-array name='preferences' count='4' index-enum='barrack_preference_category'>
+        <static-array name='preferences' index-enum='barrack_preference_category'>
             <stl-vector type-name='int32_t' ref-target='building'/>
         </static-array>
 
         <compound name='equipment' type-name='squad_position_equipmentst'/>
 
-        <static-array name='activities' count='3' index-enum='squad_event_type'
+        <static-array name='activities' index-enum='squad_event_type'
                       type-name='int32_t' ref-target='activity_entry'/>
-        <static-array name='events' count='3' index-enum='squad_event_type'
+        <static-array name='events' index-enum='squad_event_type'
                       type-name='int32_t' ref-target='activity_event'
                       aux-value='$._global.activities[$._key]'/>
 

--- a/df.text_set.xml
+++ b/df.text_set.xml
@@ -12,7 +12,7 @@
 
     <struct-type type-name='text_set_handlerst'>
         <stl-vector name='text_sets' pointer-type='text_setst'/>
-        <static-array name='hardcoded_set_index' count='63' type-name='int32_t'/>
+        <static-array name='hardcoded_set_index' index-enum='text_set_type' type-name='int32_t'/>
     </struct-type>
 </data-definition>
 

--- a/df.unit.xml
+++ b/df.unit.xml
@@ -1243,14 +1243,10 @@
     -- Unused: SKILL_ROLL_FLAG_*
 
     <struct-type type-name='curse_attr_change' original-name='unit_att_changest'>
-        <static-array name='phys_att_perc' type-name='int32_t'
-                      count='6' index-enum='physical_attribute_type'/>
-        <static-array name='phys_att_add' type-name='int32_t'
-                      count='6' index-enum='physical_attribute_type'/>
-        <static-array name='ment_att_perc' type-name='int32_t'
-                      count='13' index-enum='mental_attribute_type'/>
-        <static-array name='ment_att_add' type-name='int32_t'
-                      count='13' index-enum='mental_attribute_type'/>
+        <static-array name='phys_att_perc' type-name='int32_t' index-enum='physical_attribute_type'/>
+        <static-array name='phys_att_add' type-name='int32_t' index-enum='physical_attribute_type'/>
+        <static-array name='ment_att_perc' type-name='int32_t' index-enum='mental_attribute_type'/>
+        <static-array name='ment_att_add' type-name='int32_t' index-enum='mental_attribute_type'/>
     </struct-type>
 
     -- Unused: unit_training_assessmentst
@@ -1512,6 +1508,7 @@
     </enum-type>
 
     <enum-type type-name='demand_room'> bay12: DemandRooms
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='Office'/>
         <enum-item name='Bedroom'/>
         <enum-item name='DiningRoom'/>
@@ -2107,6 +2104,7 @@
     </struct-type>
 
     <enum-type type-name='unit_report_type' base-type='int16_t'> bay12: UnitAnnouncementCategoryType
+        <enum-item name='NONE' value='-1'/>
         <enum-item name='Combat'/>
         <enum-item name='Sparring'/>
         <enum-item name='Hunting'/>
@@ -2228,7 +2226,7 @@
         <stl-vector name='clothing_item_id' type-name='int32_t'
                     ref-target='item' since='v0.34.06'/>
 
-        <static-array name='uniforms' count='4' index-enum='unit_uniform_mode_type'>
+        <static-array name='uniforms' index-enum='unit_uniform_mode_type'>
             <stl-vector type-name='int32_t' ref-target='item'/>
         </static-array>
 
@@ -2421,7 +2419,7 @@
         <int32_t name='local_id'/>
         <int32_t name='caste_index' refers-to='$global.world.raws.creatures.list_creature[$]' comment='also refers to $global.world.raws.creatures.list_caste[$]'/>
         <int16_t name='favoredgrasp_bp'/>
-        <static-array name='physical_attributes' count='6' type-name='unit_attribute' index-enum='physical_attribute_type'/>
+        <static-array name='physical_attributes' type-name='unit_attribute' index-enum='physical_attribute_type'/>
         <int32_t name='energy_storage'/>
         <stl-vector name='body_modifiers' type-name='int32_t' index-refers-to='(find-creature $$._parent.race).caste[$$._parent.caste].body_appearance_modifiers[$]'/>
         <stl-vector name='bp_modifiers' type-name='int32_t' index-refers-to='(find-creature $$._parent.race).caste[$$._parent.caste].bp_appearance.modifiers[$]'/>
@@ -2667,7 +2665,7 @@
         <pointer name='following' type-name='unit'/>
         <enum name='owner_type' type-name='unit_owner_type' base-type='int16_t' comment='invalid unless following'/>
 
-        <static-array name='relationship_ids' type-name='int32_t' count='9' index-enum='unit_relationship_type'/>
+        <static-array name='relationship_ids' type-name='int32_t' count='9' index-enum='unit_relationship_type'/>  unit_relationship_type.NUM
 
         <enum name='mount_type' type-name='rider_positions_type' base-type='int16_t' comment='bay12: riderposition'/>
 
@@ -2751,14 +2749,13 @@
             <stl-vector name='wounds' pointer-type='unit_wound'/>
             <int32_t name='wound_next_id' init-value='1'/>
 
-            <static-array name='systemic_wound_id' count='10' type-name='int32_t' index-enum='wound_effect_type'/>
+            <static-array name='systemic_wound_id' type-name='int32_t' index-enum='wound_effect_type'/>
 
             <pointer name='body_plan' type-name='caste_body_info'/>
 
             <int16_t name='weapon_bp' refers-to='$$._parent.body_plan.body_parts[$]' init-value='-1'/>
 
-            <static-array type-name='unit_attribute' name='physical_attrs'
-                          count='6' index-enum='physical_attribute_type'/>
+            <static-array type-name='unit_attribute' name='physical_attrs' index-enum='physical_attribute_type'/>
 
             <compound name='size_info'> not a compound
                 <int32_t name='size_cur'/>
@@ -2909,7 +2906,7 @@
 
             <stl-vector name='demands' pointer-type='unit_demand'/>
 
-            <static-array type-name='bool' name='labors' index-enum='unit_labor' count='94'/>
+            <static-array type-name='bool' name='labors' index-enum='unit_labor'/>
 
             <stl-vector name='wrestle_items'><stl-shared-ptr type-name='unit_item_wrestle'/></stl-vector>
             <stl-vector name='observed_traps' type-name='int32_t' ref-target='building'/>
@@ -2921,7 +2918,7 @@
             <stl-vector name='commands' pointer-type='command' since='v0.47.01'/>
             <int32_t name='last_command_received_year' since='v0.47.01'/>
             <int32_t name='last_command_received_season_count' since='v0.47.01'/>
-            <static-array name='command_gait_index' type-name='int32_t' count='5' index-enum='gait_type' since='v0.47.01' comment='initialized together with enemy.gait_index'/>
+            <static-array name='command_gait_index' type-name='int32_t' index-enum='gait_type' since='v0.47.01' comment='initialized together with enemy.gait_index'/>
             <bitfield name='unit_command_flag' type-name='unit_command_flags' since='v0.47.01'/>
 
             <int16_t name='adv_sleep_timer' comment='bay12: dungeonlag'/>
@@ -2970,13 +2967,13 @@
         </compound>
 
         <compound name='reports'> not a compound
-            <static-array name='log' count='3' index-enum='unit_report_type'>
+            <static-array name='log' index-enum='unit_report_type'>
                 <stl-vector type-name='int32_t' ref-target='report'/>
             </static-array>
 
             -- Garbage when the matching vector is empty:
-            <static-array type-name='int32_t' name='last_year' count='3' index-enum='unit_report_type'/>
-            <static-array type-name='int32_t' name='last_year_tick' count='3' index-enum='unit_report_type'/>
+            <static-array type-name='int32_t' name='last_year' index-enum='unit_report_type'/>
+            <static-array type-name='int32_t' name='last_year_tick' index-enum='unit_report_type'/>
         </compound>
 
         <pointer name='health' type-name='unit_health_info'/>
@@ -3000,7 +2997,7 @@
 
             <stl-vector name='rumor' pointer-type='entity_event'/>
 
-            <static-array name='gait_index' type-name='int32_t' count='5' index-enum='gait_type'/>
+            <static-array name='gait_index' type-name='int32_t' index-enum='gait_type'/>
 
             <compound name='attack_awareness' type-name='attack_awarenessst'/>
 


### PR DESCRIPTION
to automatically infer the length based on the values in the enum, so that when Toady adds new enum entries we don't end up missing them.

No structures should report any size differences (aside from enum types being created or renamed) - if they do, it means I made a mistake somewhere.