### PR TITLE
Initialize pool_id values to -1

### DIFF
--- a/df.announcement.xml
+++ b/df.announcement.xml
@@ -66,7 +66,7 @@
         <int32_t name='activity_event_id' ref-target='activity_event' since='v0.40.01'/>
         <int32_t name='speaker_id' original-name='speaker_unid' ref-target='unit' since='v0.40.01' comment='unit speaking the conversation'/>
 
-        <size_t name='pool_id'/>
+        <size_t name='pool_id' init-value='-1'/>
     </struct-type>
 
     <struct-type type-name='popup_message' original-name='mega_announcementst'>

--- a/df.army.xml
+++ b/df.army.xml
@@ -92,7 +92,7 @@
 
         <stl-vector pointer-type='item' name='items' original-name='item' since='v0.44.07'/>
 
-        <size_t name='pool_id'/>
+        <size_t name='pool_id' init-value='-1'/>
     </struct-type>
 
     <struct-type type-name='army_handlerst'>

--- a/df.army_controller.xml
+++ b/df.army_controller.xml
@@ -484,7 +484,7 @@
         </compound>
         <enum type-name='army_controller_goal_type' name='goal'/>
 
-        <size_t name='pool_id'/>
+        <size_t name='pool_id' init-value='-1'/>
     </struct-type>
 
     <struct-type type-name='army_controller_handlerst'>

--- a/df.block.xml
+++ b/df.block.xml
@@ -249,7 +249,7 @@
         <compound type-name='coord' name='map_pos' original-name='start'/>
         <compound type-name='coord2d' name='region_pos' original-name='a'/>
 
-        <size_t name='pool_id'/>
+        <size_t name='pool_id' init-value='-1'/>
 
         <static-array name='tiletype' original-name='map_tile' count='16'>
             <static-array count='16'>

--- a/df.entity.xml
+++ b/df.entity.xml
@@ -1811,7 +1811,7 @@
 
         <int32_t name='temporary_count'/>
         -- protected --
-        <size_t name='pool_id'/>
+        <size_t name='pool_id' init-value='-1'/>
     </struct-type>
 
     <struct-type type-name='entity_handlerst'>

--- a/df.history_figure.xml
+++ b/df.history_figure.xml
@@ -1083,7 +1083,7 @@
         <int32_t name='gen_material_skill_ip_sum' init-value='-1' since='v0.40.17-19'/>
         <int32_t name='defensive_skill_ip_sum' init-value='-1'/>
         -- protected --
-        <size_t name='pool_id'/>
+        <size_t name='pool_id' init-value='-1'/>
     </struct-type>
 </data-definition>
 

--- a/df.nemesis.xml
+++ b/df.nemesis.xml
@@ -47,7 +47,7 @@
 
         <df-flagarray name='flags' original-name='flag' index-enum='nemesis_flags'/>
 
-        <size_t name='pool_id'/>
+        <size_t name='pool_id' init-value='-1'/>
     </struct-type>
 
     <struct-type type-name='nemesis_handlerst'>

--- a/df.unit.xml
+++ b/df.unit.xml
@@ -3136,7 +3136,7 @@
         <enum type-name='dungeon_control_state' name='dungeon_control'/>
 
         protected:
-        <size_t name='pool_id'/>
+        <size_t name='pool_id' init-value='-1'/>
         <stl-mutex name='mtx'/>
 
         <virtual-methods>


### PR DESCRIPTION
(to avoid potential mishaps with DF's pooled object manager)

Note that this _might_ result in compiler warnings - if it does, we might need to further tweak codegen (e.g. to add type casts around the initializers).