### PR TITLE
use `std::array` to implement fixed arrays

### DIFF
--- a/StructFields.pm
+++ b/StructFields.pm
@@ -340,8 +340,9 @@ sub get_struct_field_type($;%) {
         $prefix = get_container_item_type($tag, -weak => 1, -void => 'void')."*";
     } elsif ($meta eq 'static-array') {
         ($prefix, $suffix) = get_container_item_type($tag);
+        header_ref("array");
         my $count = get_container_count($tag);
-        $suffix = "[$count]".$suffix;
+        $prefix = "std::array<$prefix,$count>";
     } elsif ($meta eq 'primitive') {
         local $_ = $tag;
         my $handler = $custom_primitive_handlers{$subtype} or die "Invalid primitive: $subtype\n";

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Template for new versions:
 # Future
 
 ## Structures
+- changed codegen to use ``std::array`` for fixed-length arrays instead of C-style arrays
 
 # 53.15-r1
 

--- a/codegen.pl
+++ b/codegen.pl
@@ -154,7 +154,7 @@ with_header_file {
                 emit "INIT_GLOBAL_FUNCTION_PREFIX";
 
                 for my $item (@items) {
-                    emit "INIT_GLOBAL_FUNCTION_ITEM(", $item->[0], ', ', $item->[1], ");";
+                    emit "INIT_GLOBAL_FUNCTION_ITEM(", $item->[1], ', ', $item->[0], ");";
                 }
             } "void InitGlobals() ";
         } "namespace global ";


### PR DESCRIPTION
`std::array` is byte-equivalent to a C style array, so this will always work with DF's structures, but using `std::array` gives us a lot of coding convenience on our side as `std::array` has much more reasonable semantics than a C-style array

these changes require a coordinated change in the dfhack repository (dfhack/dfhack#5847)