### PR TITLE
add codegen support for `stl-fs-filetime`

### DIFF
--- a/SYNTAX.rst
+++ b/SYNTAX.rst
@@ -248,7 +248,14 @@ Primitive fields can be classified as following:
     abstractly represent a path to a filesystem object in an
     architecture-independent manner.
 
-6)  File Stream::
+6)  Filesystem Time::
+
+        <stl-fs-filetime name='id'/>
+
+    This tag correspond to ``std::filesystem::file_time_type`` and is used to represent
+    a filesystem time value in an architecture-independent manner.
+
+7)  File Stream::
 
         <stl-fstream name='id'/>
 

--- a/StructFields.pm
+++ b/StructFields.pm
@@ -128,6 +128,7 @@ my %custom_primitive_handlers = (
     'stl-condition-variable' => sub { header_ref("condition_variable"); return "std::condition_variable"; },
     'stl-future' => sub { header_ref("future"); return "std::future<void>"; },
     'stl-fs-path' => sub { header_ref("filesystem"); return "std::filesystem::path"; },
+    'stl-fs-filetime' => sub { header_ref("filesystem"); return "std::filesystem::file_time_type"; },
 );
 
 my %custom_primitive_inits = (

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Template for new versions:
 # Future
 
 ## Structures
+- added support for ``stl-fs-filetime`` representing ``std::filesystem::file_time_type``
 
 # 53.15-r3
 

--- a/data-definition.xsd
+++ b/data-definition.xsd
@@ -229,6 +229,7 @@
             <xs:element name="stl-function" type="StlFunctionField" />
             <xs:element name="stl-variant" type="StlVariantField" />
             <xs:element name="stl-fs-path" type="StlPathField" />
+            <xs:element name="stl-fs-filetime" type="StlFileTimeField" />
             <xs:element name="df-linked-list" type="DfLinkedListField" />
             <xs:element name="df-array" type="DfArrayField" />
             <xs:element name="df-flagarray" type="DfFlagArrayField" />
@@ -382,6 +383,12 @@
         </xs:complexContent>
     </xs:complexType>
     <xs:complexType name="StlPathField">
+        <xs:complexContent>
+            <xs:extension base="SimpleFieldType">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="StlFileTimeField">
         <xs:complexContent>
             <xs:extension base="SimpleFieldType">
             </xs:extension>

--- a/lower-1.xslt
+++ b/lower-1.xslt
@@ -224,6 +224,7 @@ Error: field <xsl:value-of select='$enum-key'/> corresponds to an enum value of 
         <prim-type ld:meta='primitive' ld:subtype='stl-condition-variable'/>
         <prim-type ld:meta='primitive' ld:subtype='stl-future'/>
         <prim-type ld:meta='primitive' ld:subtype='stl-fs-path'/>
+        <prim-type ld:meta='primitive' ld:subtype='stl-fs-filetime'/>
     </ld:primitive-types>
 
     <xsl:template match='int8_t|uint8_t|int16_t|uint16_t|int32_t|uint32_t|int64_t|uint64_t|size_t|ssize_t|long|ulong|bool|flag-bit|s-float|d-float|padding|static-string|ptr-string|stl-string|stl-fstream|stl-mutex|stl-condition-variable|stl-future|stl-fs-path'>


### PR DESCRIPTION
This adds codegen support for `stl-fs-filetime`, representing `std::filesystem::file_time_type`