### PR TITLE
add codegen override support

### DIFF
--- a/StructType.pm
+++ b/StructType.pm
@@ -223,6 +223,8 @@ sub render_struct_type {
     my $has_methods = $is_class || is_attr_true($tag, 'has-methods');
     my $inherits = $tag->getAttribute('inherits-from');
     my $original_name = $tag->getAttribute('original-name');
+    my @codegen_override = $tag->findnodes('codegen-override');
+
     my $ispec = '';
 
     for my $extra ($tag->findnodes('extra-include')) {
@@ -252,72 +254,84 @@ sub render_struct_type {
         register_ref $list_link_type, 0;
     }
 
-    with_struct_block {
-        my $vmethod_emit = sub {
-            my %info;
+    my @struct = with_emit {
+        with_struct_block {
+            my $vmethod_emit = sub {
+                my %info;
 
-            emit_find_instance(%info, $tag);
+                emit_find_instance(%info, $tag);
 
-            if ($list_link_type) {
-                emit $list_link_type," *dfhack_get_list_link();";
-                emit "void dfhack_set_list_link(",$list_link_type," *);";
-                with_emit_static {
-                    emit_block {
-                        if ($list_link_field) {
-                            emit "return ",$list_link_field,";";
-                        } else {
-                            emit "return nullptr;";
+                if ($list_link_type) {
+                    emit $list_link_type," *dfhack_get_list_link();";
+                    emit "void dfhack_set_list_link(",$list_link_type," *);";
+                    with_emit_static {
+                        emit_block {
+                            if ($list_link_field) {
+                                emit "return ",$list_link_field,";";
+                            } else {
+                                emit "return nullptr;";
+                            }
+                        } "$list_link_type *${typename}::dfhack_get_list_link()";
+                        emit_block {
+                            if ($list_link_field) {
+                                emit "this->",$list_link_field," = l;";
+                            }
+                        } "void ${typename}::dfhack_set_list_link($list_link_type *l)";
+                    };
+                }
+
+                if ($has_methods || $custom_methods) {
+                    if ($custom_methods) {
+                        local $indentation = 0;
+                        emit '#include "custom/', $typename, '.methods.inc"';
+
+                        my %name_index;
+                        $info{cmethods} = [];
+                        for my $method ($tag->findnodes('custom-methods/cmethod')) {
+                            my $name = $method->getAttribute('name');
+                            die "Custom method has no name in ".$typename."\n"
+                                if not $name;
+                            die "Duplicate custom method: $name in ".$typename."\n"
+                                if exists $name_index{$name};
+                            $name_index{$name} = 1;
+                            push @{$info{cmethods}}, $method;
                         }
-                    } "$list_link_type *${typename}::dfhack_get_list_link()";
-                    emit_block {
-                        if ($list_link_field) {
-                            emit "this->",$list_link_field," = l;";
-                        }
-                    } "void ${typename}::dfhack_set_list_link($list_link_type *l)";
-                };
-            }
+                    }
 
-            if ($has_methods || $custom_methods) {
-                if ($custom_methods) {
-                    local $indentation = 0;
-                    emit '#include "custom/', $typename, '.methods.inc"';
-
-                    my %name_index;
-                    $info{cmethods} = [];
-                    for my $method ($tag->findnodes('custom-methods/cmethod')) {
-                        my $name = $method->getAttribute('name');
-                        die "Custom method has no name in ".$typename."\n"
-                            if not $name;
-                        die "Duplicate custom method: $name in ".$typename."\n"
-                            if exists $name_index{$name};
-                        $name_index{$name} = 1;
-                        push @{$info{cmethods}}, $method;
+                    if ($is_class) {
+                        my ($no_dtor, $vmethods) = render_virtual_methods $tag;
+                        $info{nodtor} = $no_dtor;
+                        $info{vmethods} = $vmethods;
+                    } elsif (!$custom_methods) {
+                        emit "~",$typename,"() {}";
                     }
                 }
 
-                if ($is_class) {
-                    my ($no_dtor, $vmethods) = render_virtual_methods $tag;
-                    $info{nodtor} = $no_dtor;
-                    $info{vmethods} = $vmethods;
-                } elsif (!$custom_methods) {
-                    emit "~",$typename,"() {}";
+                return %info;
+            };
+
+            emit_struct_fields($tag, $typename, -class => $is_class, -inherits => $inherits,
+                                -addmethods => $vmethod_emit);
+
+            if ($field_backrefs{$typename}) {
+                for my $backref (@{$field_backrefs{$typename}}) {
+                    register_ref $backref;
+                    emit 'friend struct ' . fully_qualified_name($types{$backref}, $backref) . ';';
                 }
             }
 
-            return %info;
-        };
+        } $tag, "$typename$ispec", -export => 1;
+    };
 
-        emit_struct_fields($tag, $typename, -class => $is_class, -inherits => $inherits,
-                            -addmethods => $vmethod_emit);
-
-        if ($field_backrefs{$typename}) {
-            for my $backref (@{$field_backrefs{$typename}}) {
-                register_ref $backref;
-                emit 'friend struct ' . fully_qualified_name($types{$backref}, $backref) . ';';
-            }
+    if (@codegen_override) {
+        my $using = $codegen_override[0]->getAttribute('using');
+        if ($using) {
+            emit "using $typename = $using;";
+            return;
         }
+    }
 
-    } $tag, "$typename$ispec", -export => 1;
+    emit $_ for @struct;
 
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Template for new versions:
 # Future
 
 ## Structures
+- added support for overriding code generation for a specific type
 
 # 53.16-r1
 

--- a/data-definition.xsd
+++ b/data-definition.xsd
@@ -13,6 +13,16 @@
                     </xs:simpleContent>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="codegen-override">
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attribute name="using" use="required">
+                            </xs:attribute>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
         </xs:choice>
     </xs:group>
 
@@ -115,6 +125,7 @@
                         <xs:group ref="CompoundField" />
                         <xs:element name="extra-include" type="ExtraInclude" />
                     </xs:choice>
+                    <xs:element name="codegen-override" minOccurs="0" maxOccurs="1" />
                     <xs:element name="custom-methods" type="CustomMethods" minOccurs="0" maxOccurs="1" />
                     <xs:group ref="SharedElements" minOccurs="0" maxOccurs="unbounded" />
                 </xs:sequence>
@@ -132,6 +143,7 @@
                         <xs:group ref="CompoundField" />
                         <xs:element name="extra-include" type="ExtraInclude" />
                     </xs:choice>
+                    <xs:element name="codegen-override" minOccurs="0" maxOccurs="1" />
                     <xs:choice minOccurs="0">
                         <xs:sequence>
                             <xs:element name="virtual-methods" type="VirtualMethods" />

--- a/lower-1.xslt
+++ b/lower-1.xslt
@@ -34,7 +34,7 @@
         </ld:data-definition>
     </xsl:template>
 
-    <xsl:template match="comment|code-helper|enum-attr|enum-item|item-attr|extra-include">
+    <xsl:template match="comment|code-helper|codegen-override|enum-attr|enum-item|item-attr|extra-include">
         <xsl:copy>
             <xsl:apply-templates select='@*|node()'/>
         </xsl:copy>


### PR DESCRIPTION
`<codegen-override using="othertype"`>` will replace the usual generated structure with `using type = othertype;` as an alias. this type must be defined elsewhere

note that this only overrides C++ generation and fields and custom methods must still be defined in the XML _and the aliased type must correspond exactly to what codegen would normally produce_

the main purpose for this is so we can add `coord` and `coord2d` as a utility template and then define `df::coord` and `df::coord2d` as instantiations of that template