### PR TITLE
add missing extra includes

### DIFF
--- a/df.dfhack.xml
+++ b/df.dfhack.xml
@@ -588,6 +588,7 @@
     </struct-type>
 
     <struct-type type-name='coord2d_path' custom-methods='true' comment='not a real structure'>
+        <extra-include type-name='coord2d'/>
         <stl-vector type-name='int16_t' name='x'/>
         <stl-vector type-name='int16_t' name='y'/>
 
@@ -618,6 +619,7 @@
     </struct-type>
 
     <struct-type type-name='coord_path' custom-methods='true' comment='not a real structure'>
+        <extra-include type-name='coord'/>
         <stl-vector type-name='int16_t' name='x'/>
         <stl-vector type-name='int16_t' name='y'/>
         <stl-vector type-name='int16_t' name='z'/>


### PR DESCRIPTION
This PR adds extra includes to `coord_path` and `coord2d_path` that are by chance not currently required but should be there; currently the code only works by chance because `coord` and `coord2d` are being included ubiquitiously elsewhere in DFHack

No changelog: this is inside baseball