### PR TITLE
Remove unit_move.action.raw_data

### DIFF
--- a/df.d_basics.xml
+++ b/df.d_basics.xml
@@ -1938,9 +1938,7 @@
         <enum-attr name='tag' comment='for unit_action.data'/>
         <enum-attr name='group' type-name='unit_action_type_group' is-list='true'/>
 
-        <enum-item name='None' original-name='NONE' value='-1'>
-            <item-attr name='tag' value='raw_data'/>
-        </enum-item>
+        <enum-item name='None' original-name='NONE' value='-1'/>
         <enum-item name='Move' original-name='MOVE'>
             <item-attr name='tag' value='move'/>
             <item-attr name='group' value='All'/>

--- a/df.unit.xml
+++ b/df.unit.xml
@@ -1173,7 +1173,6 @@
 
         <int32_t name="id" original-name='reference_id' init-value='-1'/>
         <compound name='data' is-union='true' union-tag-attr='tag'>
-            <static-array name='raw_data' count='24' type-name='int32_t'/>
             <compound type-name='unit_action_data_move' name='move'/>
             <compound type-name='unit_action_data_job' name='job'/>
             <compound type-name='unit_action_data_job_recover' name='jobrecover' original-name='recover_from_job'/>


### PR DESCRIPTION
There's no reason why anything should ever need to access this, and it could eventually result in a structure misalignment if the current largest member of that union ever becomes smaller.