### PR TITLE
add missing extra-includes

### DIFF
--- a/df.block.xml
+++ b/df.block.xml
@@ -66,6 +66,7 @@
         <int32_t name='inorganic_mat' original-name='stone_index' ref-target='inorganic_raw'/>
         <compound type-name='tile_bitmask' name='tile_bitmask' original-name='mask'/>
         <bitfield base-type='uint32_t' type-name='mineral_event_flag' name='flags' original-name='flag'/>
+        <extra-include type-name='coord2d'/>
         <custom-methods>
             <cmethod name='has_assignments'/>
         </custom-methods>
@@ -218,6 +219,7 @@
 
         <pointer type-name='block_burrow_link' name="link" original-name='my_link'/>
 
+        <extra-include type-name='coord2d'/>
         <custom-methods>
             <cmethod name='has_assignments'/>
         </custom-methods>


### PR DESCRIPTION
these types have custom methods that need coord2d but don't require it to be included. this currently works but can't be guaranteed, so...